### PR TITLE
target: add example dry-run option Nomad target plugin.

### DIFF
--- a/example/webapp-dry-run.nomad
+++ b/example/webapp-dry-run.nomad
@@ -1,0 +1,73 @@
+job "webapp" {
+  datacenters = ["dc1"]
+
+  group "demo" {
+    count = 1
+
+    scaling {
+      enabled = true
+
+      policy {
+        source = "prometheus"
+        query  = "scalar(avg((haproxy_server_current_sessions{backend=\"http_back\"}) and (haproxy_server_up{backend=\"http_back\"} == 1)))"
+
+        strategy = {
+          name = "target-value"
+          min  = 1
+          max  = 10
+
+          config = {
+            target = 20
+          }
+        }
+
+        target = {
+          name   = "local-nomad"
+          driver = "nomad"
+          config = {
+            dry-run = true
+          }
+        }
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image          = "hashicorp/demo-webapp-lb-guide"
+        cpu_hard_limit = true
+
+        ulimit {
+          nofile = "512:512"
+        }
+      }
+
+      env {
+        PORT    = "${NOMAD_PORT_http}"
+        NODE_IP = "${NOMAD_IP_http}"
+      }
+
+      resources {
+        cpu = 50
+
+        network {
+          mbits = 10
+          port  "http"{}
+        }
+      }
+
+      service {
+        name = "webapp"
+        port = "http"
+
+        check {
+          type     = "http"
+          path     = "/"
+          interval = "2s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/policystorage/nomad.go
+++ b/policystorage/nomad.go
@@ -59,11 +59,14 @@ func canonicalize(from *api.ScalingPolicy, to *Policy) {
 
 	if to.Target.Name == "" {
 		to.Target.Name = "local-nomad"
-		to.Target.Config = map[string]string{
-			"job_id": from.JobID,
-			"group":  group,
-		}
 	}
+
+	if to.Target.Config == nil {
+		to.Target.Config = make(map[string]string)
+	}
+
+	to.Target.Config["job_id"] = from.JobID
+	to.Target.Config["group"] = group
 
 	if to.Source == "" {
 		to.Source = "local-nomad"


### PR DESCRIPTION
This commit adds functionality which allows operators to specify a dry-run config option on the Nomad target within the scaling jobspec block. The dry-run option instructs the autoscaler to submit a no-op scaling action, not changing the state of the job, but allowing operators to inspect potential behaviours prior to full enforcement.

A new example job has been added which includes the dry-run config option allowing for ad-hoc testing and demoing.