### PR TITLE
Add golangci for basic linting with makefile automation.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+run:
+  deadline: 10m
+  tests: false
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+
+linters:
+  disable-all: true
+  enable:
+    - goimports
+    - misspell
+    - govet
+    - deadcode
+    - varcheck
+    - ineffassign
+    - structcheck
+    - unconvert
+    - gofmt
+    - maligned
+  fast: false

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,28 +1,39 @@
 SHELL = bash
-default: build
+default: lint build
+
+tools: ## Install the tools used to test and build
+	@echo "==> Installing tools"
+	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	@echo "==> Done"
 
 .PHONY: build
 build:
-	@echo "Building autoscaler..."
+	@echo "==> Building autoscaler..."
 	@GOPRIVATE=$$GOPRIVATE,github.com/hashicorp/nomad-private go build -o ./bin/nomad-autoscaler
-	@echo "Done"
+	@echo "==> Done"
+
+.PHONY: lint
+lint: ## Lint the source code
+	@echo "==> Linting source code..."
+	@golangci-lint run -j 1
+	@echo "==> Done"
 
 .PHONY: plugins
 plugins:
 	@for d in apm/plugins target/plugins strategy/plugins; do \
 	   for p in $${d}/*; do \
 		   plugin=$$(basename $$p); \
-			 echo "Building $${plugin}..."; \
+			 echo "==> Building $${plugin}..."; \
 			 pushd $$p > /dev/null; \
 			 go build -o ../../../plugins/$$plugin; \
 			 popd > /dev/null;  \
      done; \
    done
-	@echo "Done"
+	@echo "==> Done"
 
 .PHONY: build-docker
 build-docker:
-	@echo "Building autoscaler docker container..."
+	@echo "==> Building autoscaler docker container..."
 	@env GOOS=linux GOARCH=amd64 go build -v -o ./bin/nomad-autoscaler-linux-amd64
 	@docker build .
-	@echo "Done"
+	@echo "==> Done"

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -38,10 +38,7 @@ type Agent struct {
 	strategyManager *strategypkg.Manager
 }
 
-type Plugin struct {
-	client   *plugin.Client
-	instance interface{}
-}
+type Plugin struct{}
 
 func NewAgent(c *Config, logger hclog.Logger) *Agent {
 	return &Agent{

--- a/main.go
+++ b/main.go
@@ -41,7 +41,3 @@ func main() {
 	}
 	os.Exit(exitCode)
 }
-
-func handleSignals() {
-
-}


### PR DESCRIPTION
As work starts to move this project towards tech-preview, having
linting available is helpful in identifying errors and code to
tidy. The rules have been copied from the Nomad project as a base
with some modifications based on codebase differences.

The makefile also now includes both a lint target, and a tools
target that can be used to install the lint tool used.