### PR TITLE
Rename the top-level run command to agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can import the sample dashboard to track connections to the web application.
 ### Start autoscaler
 
 ```sh
-./bin/nomad-autoscaler run -config ./example/config.hcl
+./bin/nomad-autoscaler agent -config ./example/config.hcl
 ```
 
 ### Generate load
@@ -65,7 +65,7 @@ hey -z 5m -c 30 http://127.0.0.1:8080
 This will run the load for 5 minutes with 30 connections in parallel. You should see the autoscaler output printing scaling intents:
 
 ```sh
-❯ ./nomad-autoscaler run -config ./example/config.hcl
+❯ ./nomad-autoscaler agent -config ./example/config.hcl
 ...
 2020-01-29T21:16:24.813-0500 [INFO]  agent: reading policies: policy_storage=policystorage.Nomad
 2020-01-29T21:16:24.816-0500 [INFO]  agent: found 1 policies: policy_storage=policystorage.Nomad

--- a/command/agent.go
+++ b/command/agent.go
@@ -12,23 +12,23 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/agent"
 )
 
-type RunCommand struct {
+type AgentCommand struct {
 	Ctx    context.Context
 	Logger hclog.Logger
 }
 
-type RunCommandArgs struct {
+type AgentCommandArgs struct {
 	ConfigPath string
 }
 
 // Help should return long-form help text that includes the command-line
 // usage, a brief few sentences explaining the function of the command,
 // and the complete list of flags the command accepts.
-func (c *RunCommand) Help() string {
+func (c *AgentCommand) Help() string {
 	helpText := `
-Usage: nomad-autoscaler run [options] [args]
+Usage: nomad-autoscaler agent [options] [args]
 
-  This command starts a Nomad autoscaler instance.
+  Starts the autoscaler agent and runs until an interrupt is received.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -39,7 +39,7 @@ Usage: nomad-autoscaler run [options] [args]
 //
 // There are a handful of special exit codes this can return documented
 // above that change behavior.
-func (c *RunCommand) Run(args []string) int {
+func (c *AgentCommand) Run(args []string) int {
 	// parse CLI args
 	cArgs, err := c.parseFlags(args)
 	if err != nil {
@@ -79,14 +79,14 @@ func (c *RunCommand) Run(args []string) int {
 
 // Synopsis should return a one-line, short synopsis of the command.
 // This should be less than 50 characters ideally.
-func (c *RunCommand) Synopsis() string {
-	return "Run agent."
+func (c *AgentCommand) Synopsis() string {
+	return "Runs a Nomad autoscaler agent"
 }
 
-func (c *RunCommand) parseFlags(args []string) (*RunCommandArgs, error) {
-	cArgs := &RunCommandArgs{}
+func (c *AgentCommand) parseFlags(args []string) (*AgentCommandArgs, error) {
+	cArgs := &AgentCommandArgs{}
 
-	flags := flag.NewFlagSet("run", flag.ContinueOnError)
+	flags := flag.NewFlagSet("agent", flag.ContinueOnError)
 	flags.StringVar(&cArgs.ConfigPath, "config", "", "")
 
 	err := flags.Parse(args)

--- a/main.go
+++ b/main.go
@@ -29,8 +29,8 @@ func main() {
 	c := cli.NewCLI("nomad-autoscaler", "0.1.0")
 	c.Args = os.Args[1:]
 	c.Commands = map[string]cli.CommandFactory{
-		"run": func() (cli.Command, error) {
-			return &command.RunCommand{Ctx: ctx, Logger: logger}, nil
+		"agent": func() (cli.Command, error) {
+			return &command.AgentCommand{Ctx: ctx, Logger: logger}, nil
 		},
 	}
 


### PR DESCRIPTION
Change the top-level run command to agent, inline with the
current RFC details. This also makes the autoscaler consistent
with Consul and Nomad providing an easier user experience and
better consistency.