### PR TITLE
agent: add basic HTTP health server to allow aliveness checks.

### DIFF
--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -20,14 +20,20 @@ func Test_Default(t *testing.T) {
 	assert.True(t, strings.HasSuffix(def.PluginDir, "/plugins"))
 	assert.Equal(t, def.ScanInterval, time.Duration(10000000000))
 	assert.Equal(t, def.Nomad.Address, "http://127.0.0.1:4646")
+	assert.Equal(t, "127.0.0.1", def.HTTP.BindAddress)
+	assert.Equal(t, 8080, def.HTTP.BindPort)
 }
 
 func TestAgent_Merge(t *testing.T) {
-	baseCfg := &Agent{}
+	baseCfg, err := Default()
+	assert.Nil(t, err)
 
 	cfg1 := &Agent{
 		PluginDir:    "/opt/nomad-autoscaler/plugins",
 		ScanInterval: 5000000000,
+		HTTP: &HTTP{
+			BindAddress: "scaler.nomad",
+		},
 		Nomad: &Nomad{
 			Address: "http://nomad.systems:4646",
 		},
@@ -45,6 +51,9 @@ func TestAgent_Merge(t *testing.T) {
 		LogJson:      true,
 		PluginDir:    "/var/lib/nomad-autoscaler/plugins",
 		ScanInterval: 10000000000,
+		HTTP: &HTTP{
+			BindPort: 4646,
+		},
 		Nomad: &Nomad{
 			Address:       "https://nomad-new.systems:4646",
 			Region:        "moon-base-1",
@@ -83,6 +92,10 @@ func TestAgent_Merge(t *testing.T) {
 		LogJson:      true,
 		PluginDir:    "/var/lib/nomad-autoscaler/plugins",
 		ScanInterval: 10000000000,
+		HTTP: &HTTP{
+			BindAddress: "scaler.nomad",
+			BindPort:    4646,
+		},
 		Nomad: &Nomad{
 			Address:       "https://nomad-new.systems:4646",
 			Region:        "moon-base-1",
@@ -116,7 +129,7 @@ func TestAgent_Merge(t *testing.T) {
 		},
 	}
 
-	actualResult := cfg1.Merge(baseCfg)
+	actualResult := baseCfg.Merge(cfg1)
 	actualResult = actualResult.Merge(cfg2)
 	assert.Equal(t, expectedResult, actualResult)
 }

--- a/agent/health.go
+++ b/agent/health.go
@@ -1,0 +1,132 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/agent/config"
+)
+
+const (
+	// healthRoutePattern is the Autoscaler HTTP router pattern which is used
+	// to register the health server endpoint.
+	healthRoutePattern = "/v1/health"
+
+	// healthAliveness is used to define the health of the Autoscaler agent. It
+	// currently can only be in two states; ready or unavailable and depends
+	// entirely on whether the server is serving or not.
+	healthAlivenessReady = iota
+	healthAlivenessUnavailable
+)
+
+type healthServer struct {
+
+	// aliveness is used to describe the health response and should be set
+	// atomically using healthAliveness* const declarations.
+	aliveness int32
+
+	log hclog.Logger
+	srv *http.Server
+	ln  net.Listener
+}
+
+// newHealthServer creates a new basic HTTP health server with a single route
+// for responding to requests.
+//
+// TODO(jrasell) enhance this endpoint to provide more than just aliveness
+//  checks.
+func newHealthServer(cfg *config.HTTP, log hclog.Logger) (*healthServer, error) {
+
+	srv := &healthServer{
+		log: log.Named("health-server"),
+	}
+
+	// Setup our router and single health check route.
+	router := http.NewServeMux()
+	router.Handle(healthRoutePattern, srv.getHealth())
+
+	// Configure the HTTP server to the most basic level.
+	srv.srv = &http.Server{
+		Addr:         fmt.Sprintf("%s:%v", cfg.BindAddress, cfg.BindPort),
+		Handler:      router,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  15 * time.Second,
+	}
+
+	// Announce on the configured network address. If there is an error in the
+	// configured HTTP bind parameters, it will be caught here and the error
+	// passed up to the agent.
+	ln, err := net.Listen("tcp", srv.srv.Addr)
+	if err != nil {
+		return nil, fmt.Errorf("could not setup HTTP listener: %v", err)
+	}
+	srv.ln = ln
+
+	return srv, nil
+}
+
+// run is used to serve the HTTP server. The function will block and should be
+// run via a go-routine. Unless http.Server.Serve panics/fails, the server can
+// be stopped by calling the stop() function.
+func (hs *healthServer) run() {
+	hs.log.Info("server now listening for connections", "address", hs.srv.Addr)
+
+	// Set our aliveness to ready.
+	atomic.StoreInt32(&hs.aliveness, healthAlivenessReady)
+
+	// Call serve, checking whether the error return is the one we expect. If
+	// we do get an unexpected error, set our aliveness as unavailable.
+	if err := hs.srv.Serve(hs.ln); err != nil && err != http.ErrServerClosed {
+		atomic.StoreInt32(&hs.aliveness, healthAlivenessUnavailable)
+		hs.log.Error("failed to serve HTTP", "addr", hs.srv.Addr, "error", err)
+	}
+}
+
+// stop attempts to gracefully stop the HTTP server used to serve the getHealth
+// endpoint. If the server does not stop before the timeout is reached, it will
+// be ungracefully stopped.
+func (hs *healthServer) stop() {
+
+	// Set the health as unavailable.
+	atomic.StoreInt32(&hs.aliveness, healthAlivenessUnavailable)
+
+	// Setup a context to use when calling server shutdown. 5 second timeout
+	// should be plenty here, but it would be worth revisiting once we enhance
+	// the health route.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// The server is shutting down, disable keepalive.
+	hs.srv.SetKeepAlivesEnabled(false)
+
+	// Shut it down.
+	if err := hs.srv.Shutdown(ctx); err != nil {
+		hs.log.Error("could not gracefully shutdown HTTP server", "error", err)
+	}
+}
+
+// getHealth is the HTTP handler used to respond when a request is made to the
+// health endpoint. The response is based on the aliveness parameter within the
+// healthServer struct.
+func (hs *healthServer) getHealth() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Only allow GET requests on this endpoint.
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		if atomic.LoadInt32(&hs.aliveness) == healthAlivenessReady {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+}

--- a/agent/health_test.go
+++ b/agent/health_test.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/agent/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_healthServer_health(t *testing.T) {
+	testCases := []struct {
+		inputReq          *http.Request
+		inputWriter       *httptest.ResponseRecorder
+		inputSetAliveness int32
+		expectedRespCode  int
+	}{
+		{
+			inputReq:          httptest.NewRequest("GET", "http://localhost:8080/v1/getHealth", nil),
+			inputWriter:       httptest.NewRecorder(),
+			inputSetAliveness: healthAlivenessReady,
+			expectedRespCode:  200,
+		},
+		{
+			inputReq:          httptest.NewRequest("GET", "http://localhost:8080/v1/getHealth", nil),
+			inputWriter:       httptest.NewRecorder(),
+			inputSetAliveness: healthAlivenessUnavailable,
+			expectedRespCode:  503,
+		},
+		{
+			inputReq:          httptest.NewRequest("PUT", "http://localhost:8080/v1/getHealth", nil),
+			inputWriter:       httptest.NewRecorder(),
+			inputSetAliveness: healthAlivenessReady,
+			expectedRespCode:  405,
+		},
+	}
+
+	svr, err := newHealthServer(&config.HTTP{BindAddress: "localhost", BindPort: 8080}, hclog.NewNullLogger())
+	assert.Nil(t, err)
+
+	for _, tc := range testCases {
+		atomic.StoreInt32(&svr.aliveness, tc.inputSetAliveness)
+		svr.getHealth().ServeHTTP(tc.inputWriter, tc.inputReq)
+		assert.Equal(t, tc.expectedRespCode, tc.inputWriter.Code)
+	}
+}

--- a/command/agent.go
+++ b/command/agent.go
@@ -54,6 +54,15 @@ Options:
   -scan-interval=<dur>
     The time to wait between Nomad Autoscaler evaluations.
 
+HTTP Options:
+
+  -http-bind-address=<addr>
+    The HTTP address that the health server will bind to. The default is
+    127.0.0.1.
+
+  -http-bind-port=<port>
+    The port that the health server will bind to. The default is 8080.
+
 Nomad Options:
 
   -nomad-address=<addr>
@@ -144,6 +153,7 @@ func (c *AgentCommand) readConfig() (*config.Agent, error) {
 
 	// cmdConfig is used to store any passed CLI flags.
 	cmdConfig := &config.Agent{
+		HTTP:  &config.HTTP{},
 		Nomad: &config.Nomad{},
 	}
 
@@ -159,6 +169,10 @@ func (c *AgentCommand) readConfig() (*config.Agent, error) {
 		cmdConfig.ScanInterval = d
 		return nil
 	}), "scan-interval", "")
+
+	// Specify our HTTP bind flags.
+	flags.StringVar(&cmdConfig.HTTP.BindAddress, "http-bind-address", "", "")
+	flags.IntVar(&cmdConfig.HTTP.BindPort, "http-bind-port", 0, "")
 
 	// Specify our Nomad client CLI flags.
 	flags.StringVar(&cmdConfig.Nomad.Address, "nomad-address", "", "")


### PR DESCRIPTION
In order to give confidence when running the autoscaler as a
Nomad job, having a basic endpoint to perform aliveness checks
is required. This commit therefore adds a simple, configurable
HTTP health server endpoint to satisfy this requirement.

closes #26 (i'll open a new issue to track enhancements)