### PR TITLE
handle missing apm client (instead of panicking)

### DIFF
--- a/apm/apm.go
+++ b/apm/apm.go
@@ -45,10 +45,14 @@ func (m *Manager) Dispense(key string) (*APM, error) {
 		return &apm, nil
 	}
 
-	// otherwhise dispense a plugin
+	// otherwise dispense a plugin
 	m.lock.RLock()
 	client := m.pluginClients[key]
 	m.lock.RUnlock()
+
+	if client == nil {
+		return nil, fmt.Errorf("missing client %s", key)
+	}
 
 	rpcClient, err := client.Client()
 	if err != nil {


### PR DESCRIPTION
currently, if a plugin is missing (because, for example, the autoscaler was run without config), the apm plugin dispenser will panic.