### PR TITLE
docs: update demo to use 0.0.1-techpreview1 docker build.

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -70,15 +70,6 @@ Vagrant.configure("2") do |config|
     ln -s /opt/hashicorp/bin/{nomad,consul} /usr/local/bin
     popd
 
-    # Download and install Nomad Autoscaler.
-    # The Autoscaler will run in an exec job, so it can't be symlinked
-    pushd /tmp/downloads
-    curl --silent --show-error --remote-name-all \
-      https://releases.hashicorp.com/nomad-autoscaler/0.0.1-techpreview1/nomad-autoscaler_0.0.1-techpreview1_linux_amd64.zip
-    unzip nomad-autoscaler_0.0.1-techpreview1_linux_amd64.zip
-    mv nomad-autoscaler /usr/local/bin
-    popd
-
     rm -fr /tmp/downloads
   SHELL
 

--- a/demo/vagrant/jobs/autoscaler.nomad
+++ b/demo/vagrant/jobs/autoscaler.nomad
@@ -24,6 +24,19 @@ job "autoscaler" {
         }
       }
 
+      ## Alternatively, you could also run the Autoscaler using the exec driver
+      # driver = "exec"
+      #
+      # config {
+      #   command = "/usr/local/bin/nomad-autoscaler"
+      #   args    = ["agent", "-config", "${NOMAD_TASK_DIR}/config.hcl"]
+      # }
+      #
+      # artifact {
+      #   source      = "https://releases.hashicorp.com/nomad-autoscaler/0.0.1-techpreview1/nomad-autoscaler_0.0.1-techpreview1_linux_amd64.zip"
+      #   destination = "/usr/local/bin"
+      # }
+
       template {
         data = <<EOF
 nomad {


### PR DESCRIPTION
Now that the HashiCorp docker build has been pushed to docker hub
the demo can be updated to use this source when running. In
addition the job has had a couple of unsed config items removed
and also now sets up a service, so that the autoscaler health
endpoint can be used and seen from Consul as a health check.