### PR TITLE
build: remove Dockerfile used during early development.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM alpine:3.9
-MAINTAINER Nomad Team <nomad@hashicorp.com>
-
-COPY ./bin/nomad-autoscaler-linux-amd64 /bin/nomad-autoscaler
-
-ENTRYPOINT ["nomad-autoscaler"]
-
-CMD ["run"]


### PR DESCRIPTION
Now that the Nomad Autoscaler Docker image is being built in an
offical and correct manner, the Dockerfile from the repo root
can be removed.