### PR TITLE
Allow `nil` value for Count

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -452,22 +452,15 @@ func (a *Agent) handlePolicy(p *policystorage.Policy) {
 
 		// Check if this action will not violate the min and max limits set by
 		// the policy.
-		withinLimts, err := action.IsWithinLimits(p.Min, p.Max)
-		if err != nil {
-			logger.Error(fmt.Sprintf("failed to execute action: %s", err))
-			continue
-		}
-
+		// We can ignore the returned error becase we check for nil Count above.
+		withinLimts, _ := action.IsWithinLimits(p.Min, p.Max)
 		if !withinLimts {
 			logger.Info("next count outside limits",
 				"from", currentCount, "to", *action.Count, "min", p.Min, "max", p.Max)
 
 			// Make sure new count value is within [min, max] limits
-			err := action.CapCount(p.Min, p.Max)
-			if err != nil {
-				logger.Error(fmt.Sprintf("failed to execute action: %s", err))
-				continue
-			}
+			// We can ignore the returned error becase we check for nil Count above.
+			action.CapCount(p.Min, p.Max)
 
 			logger.Info("updated count to be within limits",
 				"from", currentCount, "to", *action.Count, "min", p.Min, "max", p.Max)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -434,6 +434,8 @@ func (a *Agent) handlePolicy(p *policystorage.Policy) {
 		if val, ok := p.Target.Config["dry-run"]; ok && val == "true" {
 			logger.Info("scaling dry-run is enabled, using no-op task group count",
 				"target_config", p.Target.Config)
+			action.Meta["nomad_autoscaler.dry_run"] = "true"
+			action.Meta["nomad_autoscaler.dry_run_count"] = action.Count
 			action.Count = nil
 		}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -458,7 +458,7 @@ func (a *Agent) handlePolicy(p *policystorage.Policy) {
 
 		if !withinLimts {
 			logger.Info("next count outside limits",
-				"from", currentCount, "to", action.Count, "min", p.Min, "max", p.Max)
+				"from", currentCount, "to", *action.Count, "min", p.Min, "max", p.Max)
 
 			// Make sure new count value is within [min, max] limits
 			err := action.CapCount(p.Min, p.Max)
@@ -468,19 +468,19 @@ func (a *Agent) handlePolicy(p *policystorage.Policy) {
 			}
 
 			logger.Info("updated count to be within limits",
-				"from", currentCount, "to", action.Count, "min", p.Min, "max", p.Max)
+				"from", currentCount, "to", *action.Count, "min", p.Min, "max", p.Max)
 		}
 
 		// If count is not nil, but its value doesn't change, assume that
 		// no action should happen, not even an empty scale event.
 		if *action.Count == currentCount {
 			logger.Info("nothing to do: intended count equals current count",
-				"from", currentCount, "to", action.Count)
+				"from", currentCount, "to", *action.Count)
 			continue
 		}
 
 		logger.Info("scaling target",
-			"target_config", p.Target.Config, "from", currentCount, "to", action.Count, "reason", action.Reason)
+			"target_config", p.Target.Config, "from", currentCount, "to", *action.Count, "reason", action.Reason)
 
 		if err = (*targetPlugin).Scale(action, p.Target.Config); err != nil {
 			logger.Error("failed to scale target", "error", err)

--- a/plugins/nomad/target/tgcount.go
+++ b/plugins/nomad/target/tgcount.go
@@ -43,8 +43,12 @@ func (t *NomadGroupCount) Count(config map[string]string) (int64, error) {
 }
 
 func (t *NomadGroupCount) Scale(action strategy.Action, config map[string]string) error {
-	countInt := int(action.Count)
-	_, _, err := t.client.Jobs().Scale(config["job_id"], config["group"], &countInt, &action.Reason, nil, nil, nil)
+	var countIntPtr *int
+	if action.Count != nil {
+		countInt := int(*action.Count)
+		countIntPtr = &countInt
+	}
+	_, _, err := t.client.Jobs().Scale(config["job_id"], config["group"], countIntPtr, &action.Reason, nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to scale group %s/%s: %v", config["job_id"], config["group"], err)
 	}

--- a/plugins/target-value/strategy/targetvalue.go
+++ b/plugins/target-value/strategy/targetvalue.go
@@ -51,7 +51,7 @@ func (s *Strategy) Run(req strategy.RunRequest) (strategy.RunResponse, error) {
 	}
 
 	action := strategy.Action{
-		Count:  newCount,
+		Count:  &newCount,
 		Reason: reason,
 	}
 	resp.Actions = append(resp.Actions, action)

--- a/strategy/action.go
+++ b/strategy/action.go
@@ -8,7 +8,6 @@ const (
 	metaKeyDryRunCount   = "nomad_autoscaler.dry_run.count"
 	metaKeyCountCapped   = "nomad_autoscaler.count.capped"
 	metaKeyCountOriginal = "nomad_autoscaler.count.original"
-	metaKeyCountNil      = "nomad_autoscaler.count.nil"
 	metaKeyReasonHistory = "nomad_autoscaler.reason_history"
 )
 
@@ -23,10 +22,6 @@ type Action struct {
 func (a *Action) Canonicalize() {
 	if a.Meta == nil {
 		a.Meta = make(map[string]interface{})
-	}
-
-	if a.Count == nil {
-		a.Meta[metaKeyCountNil] = true
 	}
 }
 

--- a/strategy/action.go
+++ b/strategy/action.go
@@ -58,7 +58,7 @@ func (a *Action) CapCount(min, max int64) {
 	if newCount != oldCount {
 		a.Meta[metaKeyCountCapped] = true
 		a.Meta[metaKeyCountOriginal] = oldCount
-		a.PushReason(fmt.Sprintf("capped count from %d to %d to stay withing limits", oldCount, newCount))
+		a.PushReason(fmt.Sprintf("capped count from %d to %d to stay within limits", oldCount, newCount))
 		a.Count = &newCount
 	}
 }

--- a/strategy/action.go
+++ b/strategy/action.go
@@ -1,0 +1,71 @@
+package strategy
+
+import "fmt"
+
+const (
+	metaKeyDryRun        = "nomad_autoscaler.dry_run"
+	metaKeyDryRunCount   = "nomad_autoscaler.dry_run.count"
+	metaKeyCountCapped   = "nomad_autoscaler.count.capped"
+	metaKeyCountOriginal = "nomad_autoscaler.count.original"
+	metaKeyCountNil      = "nomad_autoscaler.count.nil"
+	metaKeyReasonHistory = "nomad_autoscaler.reason_history"
+)
+
+type Action struct {
+	Count  *int64
+	Reason string
+	Meta   map[string]interface{}
+}
+
+func (a *Action) Canonicalize() {
+	if a.Meta == nil {
+		a.Meta = make(map[string]interface{})
+	}
+
+	if a.Count == nil {
+		a.Meta[metaKeyCountNil] = true
+	}
+}
+
+func (a *Action) SetDryRun(dryRun bool) {
+	a.Meta[metaKeyDryRun] = true
+	if a.Count != nil {
+		a.Meta[metaKeyDryRunCount] = *a.Count
+	}
+	a.Count = nil
+}
+
+func (a *Action) CapCount(min, max int64) {
+	if a.Count == nil {
+		return
+	}
+
+	oldCount, newCount := *a.Count, *a.Count
+	if newCount < min {
+		newCount = min
+	} else if newCount > max {
+		newCount = max
+	}
+
+	if newCount != oldCount {
+		a.Meta[metaKeyCountCapped] = true
+		a.Meta[metaKeyCountOriginal] = oldCount
+		a.PushReason(fmt.Sprintf("capped count from %d to %d to stay withing limits", oldCount, newCount))
+		a.Count = &newCount
+	}
+}
+
+func (a *Action) PushReason(r string) {
+	history := []string{}
+
+	// Check if we already have a reason stack in Meta
+	if historyInterface, ok := a.Meta[metaKeyReasonHistory]; ok {
+		if historySlice, ok := historyInterface.([]string); ok {
+			history = historySlice
+		}
+	}
+
+	// Append current reason to history and update action
+	a.Meta[metaKeyReasonHistory] = append(history, a.Reason)
+	a.Reason = r
+}

--- a/strategy/action.go
+++ b/strategy/action.go
@@ -3,6 +3,7 @@ package strategy
 import "fmt"
 
 const (
+	// Standarized Meta keys used by the Autoscaler.
 	metaKeyDryRun        = "nomad_autoscaler.dry_run"
 	metaKeyDryRunCount   = "nomad_autoscaler.dry_run.count"
 	metaKeyCountCapped   = "nomad_autoscaler.count.capped"
@@ -11,12 +12,14 @@ const (
 	metaKeyReasonHistory = "nomad_autoscaler.reason_history"
 )
 
+// Action represents a Strategy's intention to modify.
 type Action struct {
 	Count  *int64
 	Reason string
 	Meta   map[string]interface{}
 }
 
+// Canonicalize ensures Action has proper default values.
 func (a *Action) Canonicalize() {
 	if a.Meta == nil {
 		a.Meta = make(map[string]interface{})
@@ -27,6 +30,9 @@ func (a *Action) Canonicalize() {
 	}
 }
 
+// SetDryRun marks the Action to be executed in dry-run mode.
+// Dry-run mode is indicated using Meta tags.
+// A dry-run action doesn't modify the Target's count value.
 func (a *Action) SetDryRun(dryRun bool) {
 	a.Meta[metaKeyDryRun] = true
 	if a.Count != nil {
@@ -35,6 +41,8 @@ func (a *Action) SetDryRun(dryRun bool) {
 	a.Count = nil
 }
 
+// CapCount caps the value of Count so it remains within the specified limits.
+// If Count is nil this method has no effect.
 func (a *Action) CapCount(min, max int64) {
 	if a.Count == nil {
 		return
@@ -55,6 +63,7 @@ func (a *Action) CapCount(min, max int64) {
 	}
 }
 
+// PushReason updates the Reason value and stores previous Reason into Meta.
 func (a *Action) PushReason(r string) {
 	history := []string{}
 

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -13,7 +13,7 @@ type Strategy interface {
 }
 
 type Action struct {
-	Count  int64
+	Count  *int64
 	Reason string
 	Meta   map[string]interface{}
 }
@@ -24,18 +24,28 @@ func (a *Action) Canonicalize() {
 	}
 }
 
-func (a *Action) IsWithinLimits(min, max int64) bool {
-	return a.Count >= min && a.Count <= max
+func (a *Action) IsWithinLimits(min, max int64) (bool, error) {
+	if a.Count == nil {
+		return false, fmt.Errorf("count is nil")
+	}
+
+	return (*a.Count >= min && *a.Count <= max), nil
 }
 
-func (a *Action) CapCount(min, max int64) {
-	if a.Count < min {
-		a.Count = min
+func (a *Action) CapCount(min, max int64) error {
+	if a.Count == nil {
+		return fmt.Errorf("count is nil")
+	}
+
+	if *a.Count < min {
+		a.Count = &min
 		a.PushReason(fmt.Sprintf("capping count to min value of %d", min))
-	} else if a.Count > max {
-		a.Count = max
+	} else if *a.Count > max {
+		a.Count = &max
 		a.PushReason(fmt.Sprintf("capping count to max value of %d", max))
 	}
+
+	return nil
 }
 
 func (a *Action) PushReason(r string) {

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -12,58 +12,6 @@ type Strategy interface {
 	Run(req RunRequest) (RunResponse, error)
 }
 
-type Action struct {
-	Count  *int64
-	Reason string
-	Meta   map[string]interface{}
-}
-
-func (a *Action) Canonicalize() {
-	if a.Meta == nil {
-		a.Meta = make(map[string]interface{})
-	}
-}
-
-func (a *Action) IsWithinLimits(min, max int64) (bool, error) {
-	if a.Count == nil {
-		return false, fmt.Errorf("count is nil")
-	}
-
-	return (*a.Count >= min && *a.Count <= max), nil
-}
-
-func (a *Action) CapCount(min, max int64) error {
-	if a.Count == nil {
-		return fmt.Errorf("count is nil")
-	}
-
-	if *a.Count < min {
-		a.Count = &min
-		a.PushReason(fmt.Sprintf("capping count to min value of %d", min))
-	} else if *a.Count > max {
-		a.Count = &max
-		a.PushReason(fmt.Sprintf("capping count to max value of %d", max))
-	}
-
-	return nil
-}
-
-func (a *Action) PushReason(r string) {
-	metaKey := "nomad_autoscaler.reason_history"
-	history := []string{}
-
-	// Check if we already have a reason stack in Meta
-	if historyInterface, ok := a.Meta[metaKey]; ok {
-		if historySlice, ok := historyInterface.([]string); ok {
-			history = historySlice
-		}
-	}
-
-	// Append current reason to history and update action
-	a.Meta[metaKey] = append(history, a.Reason)
-	a.Reason = r
-}
-
 type Manager struct {
 	lock            sync.RWMutex
 	lockInternal    sync.RWMutex


### PR DESCRIPTION
If a Strategy passes a `nil` value in an Action, this indicates to the Autoscaler and Targets that the current count value shouldn't change.

This can be used to register events against the Target without executing any action.

Closes #41.