### PR TITLE
plugins: allow target-value to handle zero count and target params

### DIFF
--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	// pluginName is the name of the plugin
+	// pluginName is the unique name of the this plugin amongst strategy
+	// plugins.
 	pluginName = "target-value"
 )
 
@@ -31,26 +32,36 @@ var (
 	}
 )
 
+// Assert that StrategyPlugin meets the strategy.Strategy interface.
+var _ strategy.Strategy = (*StrategyPlugin)(nil)
+
+// StrategyPlugin is the TargetValue implementation of the strategy.Strategy
+// interface.
 type StrategyPlugin struct {
 	config map[string]string
 	logger hclog.Logger
 }
 
+// NewTargetValuePlugin returns the TargetValue implementation of the
+// strategy.Strategy interface.
 func NewTargetValuePlugin(log hclog.Logger) strategy.Strategy {
 	return &StrategyPlugin{
 		logger: log,
 	}
 }
 
+// SetConfig satisfies the SetConfig function on the base.Plugin interface.
 func (s *StrategyPlugin) SetConfig(config map[string]string) error {
 	s.config = config
 	return nil
 }
 
+// PluginInfo satisfies the PluginInfo function on the base.Plugin interface.
 func (s *StrategyPlugin) PluginInfo() (*plugins.PluginInfo, error) {
 	return pluginInfo, nil
 }
 
+// Run satisfies the Run function on the strategy.Strategy interface.
 func (s *StrategyPlugin) Run(req strategy.RunRequest) (strategy.RunResponse, error) {
 	resp := strategy.RunResponse{Actions: []strategy.Action{}}
 
@@ -64,30 +75,78 @@ func (s *StrategyPlugin) Run(req strategy.RunRequest) (strategy.RunResponse, err
 		return resp, fmt.Errorf("invalid value for `target`: %v (%T)", t, t)
 	}
 
-	var reason, direction string
-	factor := req.Metric / target
+	var factor float64
 
-	if factor < 1 {
-		direction = "down"
-	} else if factor > 1 {
-		direction = "up"
-	} else {
-		// factor is 1, no need to scale
+	// Handle cases where the specified target is 0. A potential use case here
+	// is targeting a CI build queue to be 0. Adding in build agents when the
+	// queue has greater than 0 items in it.
+	switch target {
+	case 0:
+		factor = req.Metric
+	default:
+		factor = req.Metric / target
+	}
+
+	// Identify the direction of scaling, if any.
+	direction := s.calculateDirection(req.Count, factor)
+	if direction == "" {
 		return resp, nil
 	}
 
-	reason = fmt.Sprintf("scaling %s because factor is %f", direction, factor)
-	newCount := int64(math.Ceil(float64(req.Count) * factor))
+	var newCount int64
 
+	// Handle cases were users wish to scale from 0. If the current count is 0,
+	// then just use the factor as the new count to target. Otherwise use our
+	// standard calculation.
+	switch req.Count {
+	case 0:
+		newCount = int64(math.Ceil(factor))
+	default:
+		newCount = int64(math.Ceil(float64(req.Count) * factor))
+	}
+
+	// Log at trace level the details of the strategy calculation. This is
+	// helpful in ultra-debugging situations when there is a need to understand
+	// all the calculations made.
+	s.logger.Trace("calculated scaling strategy results",
+		"policy_id", req.PolicyID, "current_count", req.Count, "new_count", newCount,
+		"metric_value", req.Metric, "factor", factor, "direction", direction)
+
+	// If the calculated newCount is the same as the current count, we do not
+	// need to scale so return an empty response.
 	if newCount == req.Count {
-		// count didn't change, no need to scale
 		return resp, nil
 	}
 
 	action := strategy.Action{
 		Count:  &newCount,
-		Reason: reason,
+		Reason: fmt.Sprintf("scaling %s because factor is %f", direction, factor),
 	}
 	resp.Actions = append(resp.Actions, action)
 	return resp, nil
+}
+
+// calculateDirection is used to calculate the direction of scaling that should
+// occur, if any at all. It takes into account the current task group count in
+// order to correctly account for 0 counts.
+//
+// TODO(jrasell) the direction should probably be a type, rather than a plain
+// 	string so we don't have to return an empty string for no direction.
+func (s *StrategyPlugin) calculateDirection(count int64, factor float64) string {
+	switch count {
+	case 0:
+		if factor > 0 {
+			return "up"
+		} else {
+			return "down"
+		}
+	default:
+		if factor < 1 {
+			return "down"
+		} else if factor > 1 {
+			return "up"
+		} else {
+			return ""
+		}
+	}
 }

--- a/plugins/builtin/strategy/target-value/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin_test.go
@@ -1,0 +1,170 @@
+package plugin
+
+import (
+	"fmt"
+	"testing"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/plugins"
+	"github.com/hashicorp/nomad-autoscaler/plugins/strategy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStrategyPlugin_SetConfig(t *testing.T) {
+	s := &StrategyPlugin{}
+	expectedOutput := map[string]string{"example-item": "example-value"}
+	err := s.SetConfig(expectedOutput)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedOutput, s.config)
+}
+
+func TestStrategyPlugin_PluginInfo(t *testing.T) {
+	s := &StrategyPlugin{}
+	expectedOutput := &plugins.PluginInfo{Name: "target-value", PluginType: "strategy"}
+	actualOutput, err := s.PluginInfo()
+	assert.Nil(t, err)
+	assert.Equal(t, expectedOutput, actualOutput)
+}
+
+func TestStrategyPlugin_Run(t *testing.T) {
+	testCases := []struct {
+		inputReq      strategy.RunRequest
+		expectedResp  strategy.RunResponse
+		expectedError error
+		name          string
+	}{
+		{
+			inputReq: strategy.RunRequest{
+				PolicyID: "test-policy",
+				Config:   nil,
+			},
+			expectedResp:  strategy.RunResponse{Actions: []strategy.Action{}},
+			expectedError: fmt.Errorf("missing required field `target`"),
+			name:          "incorrect input config",
+		},
+		{
+			inputReq: strategy.RunRequest{
+				PolicyID: "test-policy",
+				Config:   map[string]string{"target": "not-the-float-you're-looking-for"},
+			},
+			expectedResp:  strategy.RunResponse{Actions: []strategy.Action{}},
+			expectedError: fmt.Errorf("invalid value for `target`: not-the-float-you're-looking-for (string)"),
+			name:          "incorrect input config target value",
+		},
+		{
+			inputReq: strategy.RunRequest{
+				PolicyID: "test-policy",
+				Config:   map[string]string{"target": "13"},
+				Metric:   13,
+				Count:    2,
+			},
+			expectedResp:  strategy.RunResponse{Actions: []strategy.Action{}},
+			expectedError: nil,
+			name:          "factor equals 1 with non-zero count",
+		},
+		{
+			inputReq: strategy.RunRequest{
+				PolicyID: "test-policy",
+				Config:   map[string]string{"target": "13"},
+				Metric:   26,
+				Count:    2,
+			},
+			expectedResp: strategy.RunResponse{Actions: []strategy.Action{
+				{
+					Count:  intToPointer(4),
+					Reason: "scaling up because factor is 2.000000",
+				},
+			}},
+			expectedError: nil,
+			name:          "factor greater than 1 with non-zero count",
+		},
+		{
+			inputReq: strategy.RunRequest{
+				PolicyID: "test-policy",
+				Config:   map[string]string{"target": "10"},
+				Metric:   20,
+				Count:    0,
+			},
+			expectedResp: strategy.RunResponse{Actions: []strategy.Action{
+				{
+					Count:  intToPointer(2),
+					Reason: "scaling up because factor is 2.000000",
+				},
+			}},
+			expectedError: nil,
+			name:          "scale from 0 with non-zero target",
+		},
+		{
+			inputReq: strategy.RunRequest{
+				PolicyID: "test-policy",
+				Config:   map[string]string{"target": "10"},
+				Metric:   9,
+				Count:    1,
+			},
+			expectedResp:  strategy.RunResponse{Actions: []strategy.Action{}},
+			expectedError: nil,
+			name:          "no scaling based on small target/metric difference",
+		},
+		{
+			inputReq: strategy.RunRequest{
+				PolicyID: "test-policy",
+				Config:   map[string]string{"target": "0"},
+				Metric:   1,
+				Count:    0,
+			},
+			expectedResp: strategy.RunResponse{Actions: []strategy.Action{
+				{
+					Count:  intToPointer(1),
+					Reason: "scaling up because factor is 1.000000",
+				},
+			}},
+			expectedError: nil,
+			name:          "scale from 0 with 0 target eg. build queue with 0 running build agents",
+		},
+		{
+			inputReq: strategy.RunRequest{
+				PolicyID: "test-policy",
+				Config:   map[string]string{"target": "0"},
+				Metric:   0,
+				Count:    5,
+			},
+			expectedResp: strategy.RunResponse{Actions: []strategy.Action{
+				{
+					Count:  intToPointer(0),
+					Reason: "scaling down because factor is 0.000000",
+				},
+			}},
+			expectedError: nil,
+			name:          "scale to 0 with 0 target eg. idle build agents",
+		},
+	}
+
+	s := &StrategyPlugin{logger: hclog.NewNullLogger()}
+
+	for _, tc := range testCases {
+		actualResp, actualError := s.Run(tc.inputReq)
+		assert.Equal(t, tc.expectedResp, actualResp)
+		assert.Equal(t, tc.expectedError, actualError)
+	}
+}
+
+func TestStrategyPlugin_calculateDirection(t *testing.T) {
+	testCases := []struct {
+		inputCount     int64
+		inputFactor    float64
+		expectedOutput string
+	}{
+		{inputCount: 0, inputFactor: 1, expectedOutput: "up"},
+		{inputCount: 5, inputFactor: 1, expectedOutput: ""},
+		{inputCount: 4, inputFactor: 0.5, expectedOutput: "down"},
+		{inputCount: 5, inputFactor: 2, expectedOutput: "up"},
+	}
+
+	s := &StrategyPlugin{}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, s.calculateDirection(tc.inputCount, tc.inputFactor))
+	}
+}
+
+func intToPointer(i int64) *int64 { return &i }


### PR DESCRIPTION
It is possible that the count of a task group we wish to scale is
0. It is also possible that the target the operator wishes the
metric maintain is zero. An example here would be a build system
queue, where the number of agents can scale to 0 if there is no
work to process. If work is added to the queue, the strategy is
to scale the build agents so that the queue metric is reduced to
the target of 0 items.

closes #76 