### PR TITLE
Add reference to nightly builds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The compability requirements are as follows:
 |:-----------------------------------------------------------------------------------------:|:-------------:|
 | [0.0.1-techpreview1](https://releases.hashicorp.com/nomad-autoscaler/0.0.1-techpreview1/) | 0.11.0-beta1  |
 | [0.0.1-techpreview2](https://releases.hashicorp.com/nomad-autoscaler/0.0.1-techpreview2/) |    0.11.0     |
+| [nightly](https://github.com/hashicorp/nomad-autoscaler/releases/tag/nightly)             |    0.11.0     |
 
 ## Documentation
 Documentation is available within this repository [here](./docs/README.md).

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The Nomad Autoscaler currently supports:
 ## Requirements
 
 The autoscaler relies on Nomad APIs that were introduced in Nomad 0.11-beta1, some of which have been changed during the beta.
-The compability requirements are as follows: 
+The compability requirements are as follows:
 
-| Autoscaler Version                                                            | Nomad Version |
-|:-----------------------------------------------------------------------------:|:-------------:|
-| 0.0.1-techpreview1                                                            | 0.11-beta1    |
-| [nightly](https://github.com/hashicorp/nomad-autoscaler/releases/tag/nightly) | 0.11-beta2 +  |
+|                                     Autoscaler Version                                    | Nomad Version |
+|:-----------------------------------------------------------------------------------------:|:-------------:|
+| [0.0.1-techpreview1](https://releases.hashicorp.com/nomad-autoscaler/0.0.1-techpreview1/) | 0.11.0-beta1  |
+| [0.0.1-techpreview2](https://releases.hashicorp.com/nomad-autoscaler/0.0.1-techpreview2/) |    0.11.0     |
 
 ## Documentation
 Documentation is available within this repository [here](./docs/README.md).
@@ -30,3 +30,7 @@ The [Vagrant based demo](./demo/vagrant/README.md) provides a guided example of 
 
 ## Building
 The Nomad Autoscaler can be easily built for local testing or development using the `make build` command. This will output the compiled binary to `./bin/nomad-autoscaler`.
+
+## Nightly Builds
+
+As a tech preview, this project is under constant updates, so every day the [`nightly` release](https://github.com/hashicorp/nomad-autoscaler/releases/tag/nightly) is updated with binaries built off the latest code in the `master` branch. This should make it easier for you to try new features and bug fixes.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The Nomad Autoscaler currently supports:
 The autoscaler relies on Nomad APIs that were introduced in Nomad 0.11-beta1, some of which have been changed during the beta.
 The compability requirements are as follows: 
 
-| Autoscaler Version  | Nomad Version |
-|:-------------------:|:-------------:|
-| 0.0.1-techpreview1  |  0.11-beta1   |
-| wip                 |  0.11-beta2   |
+| Autoscaler Version                                                            | Nomad Version |
+|:-----------------------------------------------------------------------------:|:-------------:|
+| 0.0.1-techpreview1                                                            | 0.11-beta1    |
+| [nightly](https://github.com/hashicorp/nomad-autoscaler/releases/tag/nightly) | 0.11-beta2 +  |
 
 ## Documentation
 Documentation is available within this repository [here](./docs/README.md).


### PR DESCRIPTION
I was wondering if I should add more details about the nightly builds, but I thought it was not necessary. Any thoughts?