### PR TITLE
build: add makefie target to check go.mod status.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,35 @@ jobs:
     - GO_TAGS: ''
     - GO_VERSION: 1.14
     - GO111MODULE: 'on'
+  check-deps-go:
+    machine: true
+    shell: /usr/bin/env bash -euo pipefail -c
+    working_directory: /go/src/github.com/hashicorp/nomad-autoscaler
+    steps:
+    - run:
+        command: |
+          [ -n "$GO_VERSION" ] || { echo "You must set GO_VERSION"; exit 1; }
+          # Install Go
+          curl -sSLO "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
+          rm -f "go${GO_VERSION}.linux-amd64.tar.gz"
+          GOPATH="/go"
+          mkdir $GOPATH 2>/dev/null || { sudo mkdir $GOPATH && sudo chmod 777 $GOPATH; }
+          echo "export GOPATH='$GOPATH'" >> "$BASH_ENV"
+          echo "export PATH='$PATH:$GOPATH/bin:/usr/local/go/bin'" >> "$BASH_ENV"
+          echo "$ go version"
+          go version
+        name: Setup Go
+        working_directory: ~/
+    - checkout
+    - run:
+        command: make check-mod
+    environment:
+    - CIRCLECI_CLI_VERSION: 0.1.6772
+    - GO_TAGS: ''
+    - GO_VERSION: 1.14
+    - GO111MODULE: 'on'
   test-go:
     machine: true
     shell: /usr/bin/env bash -euo pipefail -c
@@ -97,6 +126,7 @@ workflows:
   ci:
     jobs:
     - lint-go
+    - check-deps-go
     - test-go
     - build-go
   version: 2
@@ -140,6 +170,12 @@ workflows:
 #     - install-go
 #     - checkout
 #     - run: make build
+#   check-deps-go:
+#     executor: go
+#     steps:
+#     - install-go
+#     - checkout
+#     - run: make check-mod
 #   lint-go:
 #     executor: go
 #     steps:
@@ -158,5 +194,6 @@ workflows:
 #   ci:
 #     jobs:
 #     - lint-go
+#     - check-deps-go
 #     - test-go
 #     - build-go

--- a/.circleci/config/jobs/check-deps-go.yml
+++ b/.circleci/config/jobs/check-deps-go.yml
@@ -1,0 +1,5 @@
+executor: go
+steps:
+  - install-go
+  - checkout
+  - run: make check-mod

--- a/.circleci/config/workflows/ci.yml
+++ b/.circleci/config/workflows/ci.yml
@@ -1,4 +1,5 @@
 jobs:
   - lint-go
+  - check-deps-go
   - test-go
   - build-go

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 SHELL = bash
-default: lint test build
+default: lint test build check-mod
 
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 GIT_DIRTY := $(if $(shell git status --porcelain),+CHANGES)
@@ -25,6 +25,16 @@ build:
 lint: ## Lint the source code
 	@echo "==> Linting source code..."
 	@golangci-lint run -j 1
+	@echo "==> Done"
+
+.PHONEY: check-mod
+check-mod: ## Checks the Go mod is tidy
+	@echo "==> Checking Go mod.."
+	@GO111MODULE=on go mod tidy
+	@if (git status --porcelain | grep -q go.mod); then \
+		echo go.mod needs updating; \
+		git --no-pager diff go.mod; \
+		exit 1; fi
 	@echo "==> Done"
 
 .PHONY: test


### PR DESCRIPTION
It is fairly easy for the go.mod file to become cluttered with
unrequired dependancies. This makefile addition therefore runs the
go mod command and checks if the go.mod file has changed as a
result to ensure this is caught during CI.

The target runs after the build phase as this also allows us to
catch dependancies that have not been added to the go.mod file
which are needed. This likely wont be hit during CircleCI runs,
but could be helpful for the development cycle.