### PR TITLE
policy validation: don't try so hard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ pkg/
 # ignore Vagrant related files
 *.log
 .vagrant
+
+# ignore GoLand IDE
+.idea

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.4.0

--- a/policystorage/nomad.go
+++ b/policystorage/nomad.go
@@ -98,6 +98,7 @@ func validate(policy *api.ScalingPolicy) []error {
 	strategyList, ok := policy.Policy["strategy"].([]interface{})
 	if !ok {
 		errs = append(errs, fmt.Errorf("Policy.strategy (%T) is not a []interface{}", policy.Policy["strategy"]))
+		return errs
 	}
 
 	_, ok = strategyList[0].(map[string]interface{})

--- a/policystorage/nomad_test.go
+++ b/policystorage/nomad_test.go
@@ -1,0 +1,32 @@
+package policystorage
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+func Test_storagNomad_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy *api.ScalingPolicy
+		want   []error
+	}{
+		{
+			name:   "validate missing",
+			policy: &api.ScalingPolicy{
+				Policy: map[string]interface{}{},
+			},
+			want:   []error{fmt.Errorf("Policy.strategy (<nil>) is not a []interface{}")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validate(tt.policy); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("validate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
resolves #94 

policy was nobly trying to validate additional errors after discovery that "strategy" was of the wrong type (or, in the case of #94, did not exist). early return from this case.