### PR TITLE
prometheus: set config should error if address is not set.

### DIFF
--- a/plugins/builtin/apm/prometheus/plugin/plugin.go
+++ b/plugins/builtin/apm/prometheus/plugin/plugin.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/plugins"
 	"github.com/hashicorp/nomad-autoscaler/plugins/apm"
 	"github.com/hashicorp/nomad-autoscaler/plugins/base"
@@ -18,6 +18,10 @@ import (
 const (
 	// pluginName is the name of the plugin
 	pluginName = "prometheus"
+
+	// configKeyAddress is the accepted configuration key which holds the
+	// address param.
+	configKeyAddress = "address"
 )
 
 var (
@@ -52,8 +56,15 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 
 	a.config = config
 
+	// If the address is not set, or is empty within the config, any client
+	// calls will fail. It seems logical to catch this here rather than just
+	// let queries fail.
+	if a.config[configKeyAddress] == "" {
+		return fmt.Errorf("%q config value cannot be empty", configKeyAddress)
+	}
+
 	promCfg := api.Config{
-		Address: a.config["address"],
+		Address: a.config[configKeyAddress],
 	}
 
 	// create Prometheus client


### PR DESCRIPTION
When setting the configuration on the Prometheus APM plugin, it is
not required to pass the address config param. When the plugin
performs a query, it will error as the SDK does not add any
default address and so the HTTP call uses an address of "". This
change therefore suggests returning an error if the user specified
address is empty at the set config phase. This will provide
quicker user feedback on an error which will always occur
eventually.