### PR TITLE
plugin: add the plugin name to the logger when launching internal.

### DIFF
--- a/plugins/manager/manager.go
+++ b/plugins/manager/manager.go
@@ -176,7 +176,7 @@ func (pm *PluginManager) dispensePlugins() error {
 // launchInternalPlugin is used to dispense internal plugins.
 func (pm *PluginManager) launchInternalPlugin(id plugins.PluginID, info *pluginInfo) (PluginInstance, *base.PluginInfo, error) {
 
-	raw := info.factory(pm.logger.ResetNamed("internal_plugin"))
+	raw := info.factory(pm.logger.ResetNamed("internal_plugin." + id.Name))
 
 	pInfo, err := pm.pluginLaunchCheck(id, raw)
 	if err != nil {


### PR DESCRIPTION
When launching internal plugins, the named logger was being set
to the same value on all plugins. This makes it hard to understand
the logs of internal plugins. Adding the plugin name to the logger
helps differentiate.