### PR TITLE
plugin: add tests to strategy action.

### DIFF
--- a/plugins/strategy/action.go
+++ b/plugins/strategy/action.go
@@ -54,13 +54,13 @@ func (a *Action) CapCount(min, max int64) {
 	if newCount != oldCount {
 		a.Meta[metaKeyCountCapped] = true
 		a.Meta[metaKeyCountOriginal] = oldCount
-		a.PushReason(fmt.Sprintf("capped count from %d to %d to stay within limits", oldCount, newCount))
+		a.pushReason(fmt.Sprintf("capped count from %d to %d to stay within limits", oldCount, newCount))
 		a.Count = &newCount
 	}
 }
 
 // PushReason updates the Reason value and stores previous Reason into Meta.
-func (a *Action) PushReason(r string) {
+func (a *Action) pushReason(r string) {
 	history := []string{}
 
 	// Check if we already have a reason stack in Meta
@@ -70,7 +70,7 @@ func (a *Action) PushReason(r string) {
 		}
 	}
 
-	// Append current reason to history and update action
-	a.Meta[metaKeyReasonHistory] = append(history, a.Reason)
+	// Append current reason to history and update action.
 	a.Reason = r
+	a.Meta[metaKeyReasonHistory] = append(history, a.Reason)
 }

--- a/plugins/strategy/action_test.go
+++ b/plugins/strategy/action_test.go
@@ -6,6 +6,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAction_Canonicalize(t *testing.T) {
+	testCases := []struct {
+		inputAction          *Action
+		expectedOutputAction *Action
+		name                 string
+	}{
+		{
+			inputAction:          &Action{},
+			expectedOutputAction: &Action{Meta: map[string]interface{}{}},
+			name:                 "empty input action",
+		},
+		{
+			inputAction:          &Action{Meta: map[string]interface{}{"foo": "bar"}},
+			expectedOutputAction: &Action{Meta: map[string]interface{}{"foo": "bar"}},
+			name:                 "populated input action meta",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.inputAction.Canonicalize()
+			assert.Equal(t, tc.expectedOutputAction, tc.inputAction)
+		})
+	}
+}
+
 func TestAction_SetDryRun(t *testing.T) {
 	testCases := []struct {
 		inputAction          *Action
@@ -38,8 +64,140 @@ func TestAction_SetDryRun(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc.inputAction.SetDryRun()
-		assert.Equal(t, tc.expectedOutputAction, tc.inputAction, tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			tc.inputAction.SetDryRun()
+			assert.Equal(t, tc.expectedOutputAction, tc.inputAction)
+		})
+	}
+}
+
+func TestAction_CapCount(t *testing.T) {
+	testCases := []struct {
+		inputAction          *Action
+		inputMin             int64
+		inputMax             int64
+		expectedOutputAction *Action
+		name                 string
+	}{
+		{
+			inputAction:          &Action{},
+			inputMin:             0,
+			inputMax:             0,
+			expectedOutputAction: &Action{},
+			name:                 "empty input action",
+		},
+		{
+			inputAction: &Action{
+				Count: int64ToPointer(4),
+				Meta:  map[string]interface{}{},
+			},
+			inputMin: 5,
+			inputMax: 10,
+			expectedOutputAction: &Action{
+				Count: int64ToPointer(5),
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.count.capped":   true,
+					"nomad_autoscaler.count.original": int64(4),
+					"nomad_autoscaler.reason_history": []string{
+						"capped count from 4 to 5 to stay within limits",
+					},
+				},
+				Reason: "capped count from 4 to 5 to stay within limits",
+			},
+			name: "desired count lower than min threshold",
+		},
+		{
+			inputAction: &Action{
+				Count: int64ToPointer(15),
+				Meta:  map[string]interface{}{},
+			},
+			inputMin: 5,
+			inputMax: 10,
+			expectedOutputAction: &Action{
+				Count: int64ToPointer(10),
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.count.capped":   true,
+					"nomad_autoscaler.count.original": int64(15),
+					"nomad_autoscaler.reason_history": []string{
+						"capped count from 15 to 10 to stay within limits",
+					},
+				},
+				Reason: "capped count from 15 to 10 to stay within limits",
+			},
+			name: "desired count higher than max threshold",
+		},
+		{
+			inputAction: &Action{
+				Count: int64ToPointer(7),
+				Meta:  map[string]interface{}{},
+			},
+			inputMin: 5,
+			inputMax: 10,
+			expectedOutputAction: &Action{
+				Count: int64ToPointer(7),
+				Meta:  map[string]interface{}{},
+			},
+			name: "desired count doesn't break thresholds",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.inputAction.CapCount(tc.inputMin, tc.inputMax)
+			assert.Equal(t, tc.expectedOutputAction, tc.inputAction)
+		})
+	}
+}
+
+func TestAction_pushReason(t *testing.T) {
+	testCases := []struct {
+		inputAction          *Action
+		inputReason          string
+		expectedOutputAction *Action
+		name                 string
+	}{
+		{
+			inputAction: &Action{Meta: map[string]interface{}{}},
+			inputReason: "capped count from 0 to 1 to stay within limits",
+			expectedOutputAction: &Action{
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.reason_history": []string{
+						"capped count from 0 to 1 to stay within limits",
+					},
+				},
+				Reason: "capped count from 0 to 1 to stay within limits",
+			},
+			name: "no existing reason history",
+		},
+
+		{
+			inputAction: &Action{
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.reason_history": []string{
+						"capped count from 0 to 1 to stay within limits",
+					},
+				},
+				Reason: "capped count from 0 to 1 to stay within limits",
+			},
+			inputReason: "capped count from 10 to 20 to stay within limits",
+			expectedOutputAction: &Action{
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.reason_history": []string{
+						"capped count from 0 to 1 to stay within limits",
+						"capped count from 10 to 20 to stay within limits",
+					},
+				},
+				Reason: "capped count from 10 to 20 to stay within limits",
+			},
+			name: "existing reason history",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.inputAction.pushReason(tc.inputReason)
+			assert.Equal(t, tc.expectedOutputAction, tc.inputAction)
+		})
 	}
 }
 


### PR DESCRIPTION
Adds tests to the strategy Action set of functions. The tests
uncovered a bug and lint enhancement which are fixed within this
commit.

The lint enhancement changes the PushReason function to be
un-exported as it is currently only used within the strategy pkg.

The bug occured where a reason was added to the action in
situations where no reason previously existed. The meta reason
history was appended to from the empty reason string, before the
reason string was subsequently set.