### PR TITLE
Move nomad query parsing

### DIFF
--- a/plugins/builtin/apm/nomad/plugin/metrics.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics.go
@@ -107,13 +107,13 @@ func parseQuery(q string) (*Query, error) {
 		Job:   mainParts[2],
 	}
 
-	opMetricParts := strings.Split(mainParts[0], "_")
-	if len(opMetricParts) < 2 {
+	opMetricParts := strings.SplitN(mainParts[0], "_", 2)
+	if len(opMetricParts) != 2 {
 		return nil, fmt.Errorf(`expected <operation>_<metric>, received "%s"`, mainParts[0])
 	}
 
 	op := opMetricParts[0]
-	metric := strings.Join(opMetricParts[1:], "_")
+	metric := opMetricParts[1]
 
 	switch metric {
 	case "cpu":

--- a/plugins/builtin/apm/nomad/plugin/metrics.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics.go
@@ -125,13 +125,7 @@ func parseQuery(q string) (*Query, error) {
 	}
 
 	switch op {
-	case "sum":
-		fallthrough
-	case "avg":
-		fallthrough
-	case "min":
-		fallthrough
-	case "max":
+	case "sum", "avg", "min", "max":
 		query.Operation = op
 	default:
 		return nil, fmt.Errorf(`invalid operation "%s", allowed values are sum, avg, min or max`, op)

--- a/plugins/builtin/apm/nomad/plugin/metrics.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics.go
@@ -97,14 +97,14 @@ func (a *APMPlugin) Query(q string) (float64, error) {
 }
 
 func parseQuery(q string) (*Query, error) {
-	mainParts := strings.Split(q, "/")
+	mainParts := strings.SplitN(q, "/", 3)
 	if len(mainParts) != 3 {
 		return nil, fmt.Errorf("expected <query>/<job>/group>, received %s", q)
 	}
 
 	query := &Query{
-		Job:   mainParts[1],
-		Group: mainParts[2],
+		Group: mainParts[1],
+		Job:   mainParts[2],
 	}
 
 	opMetricParts := strings.Split(mainParts[0], "_")

--- a/plugins/builtin/apm/nomad/plugin/metrics.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics.go
@@ -34,26 +34,28 @@ type Sample struct {
 	Counter
 }
 
+type Query struct {
+	Metric    string
+	Job       string
+	Group     string
+	Operation string
+}
+
 func (a *APMPlugin) Query(q string) (float64, error) {
-	parts := strings.Split(q, "/")
-	if len(parts) != 4 {
-		return 0, fmt.Errorf("invalid query %s, expected 4 parts, got %d", q, len(parts))
+	query, err := a.parseQuery(q)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse query: %v", err)
 	}
 
-	metric := parts[0]
-	job := parts[1]
-	group := parts[2]
-	op := parts[3]
-
 	var resp Metrics
-	_, err := a.client.Raw().Query("/v1/metrics", &resp, nil)
+	_, err = a.client.Raw().Query("/v1/metrics", &resp, nil)
 	if err != nil {
 		return 0, err
 	}
 
 	metrics := []Gauge{}
 	for _, g := range resp.Gauges {
-		if g.Name == metric && g.Labels["job"] == job && g.Labels["task_group"] == group {
+		if g.Name == query.Metric && g.Labels["job"] == query.Job && g.Labels["task_group"] == query.Group {
 			metrics = append(metrics, g)
 		}
 	}
@@ -63,7 +65,7 @@ func (a *APMPlugin) Query(q string) (float64, error) {
 	}
 
 	var result float64
-	switch op {
+	switch query.Operation {
 	case "sum":
 		for _, m := range metrics {
 			result += m.Value
@@ -90,4 +92,50 @@ func (a *APMPlugin) Query(q string) (float64, error) {
 	}
 
 	return result, nil
+}
+
+func (a *APMPlugin) parseQuery(q string) (*Query, error) {
+	mainParts := strings.Split(q, "/")
+	if len(mainParts) != 3 {
+		return nil, fmt.Errorf("expected <query>/<job>/group>, received %s", q)
+	}
+
+	query := &Query{
+		Job:   mainParts[1],
+		Group: mainParts[2],
+	}
+
+	opMetricParts := strings.Split(mainParts[0], "_")
+	if len(opMetricParts) != 2 {
+		return nil, fmt.Errorf(`expected <operation>_<metric>, received "%s"`, mainParts[0])
+	}
+
+	op := opMetricParts[0]
+	metric := opMetricParts[1]
+
+	switch metric {
+	case "cpu":
+		query.Metric = "nomad.client.allocs.cpu.total_percent"
+	case "memory":
+		query.Metric = "nomad.client.allocs.memory.usage"
+	default:
+		query.Metric = metric
+	}
+
+	switch op {
+	case "sum":
+		fallthrough
+	case "avg":
+		fallthrough
+	case "min":
+		fallthrough
+	case "max":
+		query.Operation = op
+	default:
+		return nil, fmt.Errorf(`invalid operation "%s", allowed values are sum, avg, min or max`, op)
+	}
+
+	a.logger.Debug("expanded query", "from", q, "to", fmt.Sprintf("%# v", query))
+
+	return query, nil
 }

--- a/plugins/builtin/apm/nomad/plugin/metrics_test.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics_test.go
@@ -1,0 +1,94 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseQuery(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expected    *Query
+		expectError bool
+	}{
+		{
+			name:  "avg_cpu",
+			input: "avg_cpu/job/group",
+			expected: &Query{
+				Metric:    "nomad.client.allocs.cpu.total_percent",
+				Job:       "job",
+				Group:     "group",
+				Operation: "avg",
+			},
+			expectError: false,
+		},
+		{
+			name:  "avg_memory",
+			input: "avg_memory/job/group",
+			expected: &Query{
+				Metric:    "nomad.client.allocs.memory.usage",
+				Job:       "job",
+				Group:     "group",
+				Operation: "avg",
+			},
+			expectError: false,
+		},
+		{
+			name:  "arbritary metric",
+			input: "avg_nomad.client.allocs.cpu.total_percent/job/group",
+			expected: &Query{
+				Metric:    "nomad.client.allocs.cpu.total_percent",
+				Job:       "job",
+				Group:     "group",
+				Operation: "avg",
+			},
+			expectError: false,
+		},
+		{
+			name:        "empty query",
+			input:       "",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid query format",
+			input:       "invalid",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "missing group",
+			input:       "avg_cpu/job",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid op_metric format",
+			input:       "invalid/job/group",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid operation",
+			input:       "op_invalid/job/group",
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := parseQuery(tc.input)
+
+			assert.Equal(t, tc.expected, actual)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/plugins/builtin/apm/nomad/plugin/metrics_test.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics_test.go
@@ -15,7 +15,7 @@ func Test_parseQuery(t *testing.T) {
 	}{
 		{
 			name:  "avg_cpu",
-			input: "avg_cpu/job/group",
+			input: "avg_cpu/group/job",
 			expected: &Query{
 				Metric:    "nomad.client.allocs.cpu.total_percent",
 				Job:       "job",
@@ -26,7 +26,7 @@ func Test_parseQuery(t *testing.T) {
 		},
 		{
 			name:  "avg_memory",
-			input: "avg_memory/job/group",
+			input: "avg_memory/group/job",
 			expected: &Query{
 				Metric:    "nomad.client.allocs.memory.usage",
 				Job:       "job",
@@ -37,10 +37,21 @@ func Test_parseQuery(t *testing.T) {
 		},
 		{
 			name:  "arbritary metric",
-			input: "avg_nomad.client.allocs.cpu.total_percent/job/group",
+			input: "avg_nomad.client.allocs.cpu.total_percent/group/job",
 			expected: &Query{
 				Metric:    "nomad.client.allocs.cpu.total_percent",
 				Job:       "job",
+				Group:     "group",
+				Operation: "avg",
+			},
+			expectError: false,
+		},
+		{
+			name:  "job with fwd slashes",
+			input: "avg_cpu/group/my/super/job//",
+			expected: &Query{
+				Metric:    "nomad.client.allocs.cpu.total_percent",
+				Job:       "my/super/job//",
 				Group:     "group",
 				Operation: "avg",
 			},
@@ -59,20 +70,20 @@ func Test_parseQuery(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "missing group",
-			input:       "avg_cpu/job",
+			name:        "missing job",
+			input:       "avg_cpu/group",
 			expected:    nil,
 			expectError: true,
 		},
 		{
 			name:        "invalid op_metric format",
-			input:       "invalid/job/group",
+			input:       "invalid/groups/job",
 			expected:    nil,
 			expectError: true,
 		},
 		{
 			name:        "invalid operation",
-			input:       "op_invalid/job/group",
+			input:       "op_invalid/group/job",
 			expected:    nil,
 			expectError: true,
 		},

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -105,6 +105,6 @@ func canonicalizePolicy(from *api.ScalingPolicy, to *policy.Policy) {
 	}
 
 	if to.Source == plugins.InternalAPMNomad {
-		to.Query = fmt.Sprintf("%s/%s/%s", to.Query, from.Target["Job"], from.Target["Group"])
+		to.Query = fmt.Sprintf("%s/%s/%s", to.Query, from.Target["Group"], from.Target["Job"])
 	}
 }

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -2,7 +2,6 @@ package nomad
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/nomad-autoscaler/plugins"
@@ -103,19 +102,9 @@ func canonicalizePolicy(from *api.ScalingPolicy, to *policy.Policy) {
 
 	if to.Source == "" {
 		to.Source = plugins.InternalAPMNomad
+	}
 
-		// TODO(luiz) move default query logic handling to the Nomad APM plugin
-		parts := strings.Split(to.Query, "_")
-		op := parts[0]
-		metric := parts[1]
-
-		switch metric {
-		case "cpu":
-			metric = "nomad.client.allocs.cpu.total_percent"
-		case "memory":
-			metric = "nomad.client.allocs.memory.usage"
-		}
-
-		to.Query = fmt.Sprintf("%s/%s/%s/%s", metric, from.Target["Job"], from.Target["Group"], op)
+	if to.Source == plugins.InternalAPMNomad {
+		to.Query = fmt.Sprintf("%s/%s/%s", to.Query, from.Target["Job"], from.Target["Group"])
 	}
 }


### PR DESCRIPTION
Moving the query parsing logic to the Nomad APM plugin keeps it closer to where it actually is used.