### PR TITLE
Improve policy validation

### DIFF
--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -67,7 +67,7 @@ func validateScalingPolicy(policy *api.ScalingPolicy) error {
 //   +----------+
 //  }
 func validatePolicy(p map[string]interface{}) error {
-	const path = "ScalingPolicy.Policy"
+	const path = "scaling->policy"
 
 	var result *multierror.Error
 
@@ -81,7 +81,7 @@ func validatePolicy(p map[string]interface{}) error {
 	if ok {
 		_, ok := source.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s[%s] must be string, found %T", path, keySource, source))
+			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, keySource, source))
 		}
 	}
 
@@ -91,14 +91,14 @@ func validatePolicy(p map[string]interface{}) error {
 	//   3. Query must not be empty.
 	query, ok := p[keyQuery]
 	if !ok {
-		result = multierror.Append(result, fmt.Errorf(`%s is missing key "%s"`, path, keyQuery))
+		result = multierror.Append(result, fmt.Errorf("%s->%s is missing", path, keyQuery))
 	} else {
 		queryStr, ok := query.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s[%s] must be string, found %T", path, keyQuery, query))
+			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, keyQuery, query))
 		} else {
 			if queryStr == "" {
-				result = multierror.Append(result, fmt.Errorf("%s[%s] can't be empty", path, keyQuery))
+				result = multierror.Append(result, fmt.Errorf("%s->%s can't be empty", path, keyQuery))
 			}
 		}
 	}
@@ -110,10 +110,10 @@ func validatePolicy(p map[string]interface{}) error {
 	if ok {
 		evalIntervalString, ok := evalInterval.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s[%s] must be string, found %T", path, keyEvaluationInterval, evalInterval))
+			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, keyEvaluationInterval, evalInterval))
 		} else {
 			if _, err := time.ParseDuration(evalIntervalString); err != nil {
-				result = multierror.Append(result, fmt.Errorf("%s[%s] must have time.Duration format", path, keyEvaluationInterval))
+				result = multierror.Append(result, fmt.Errorf("%s->%s must have time.Duration format", path, keyEvaluationInterval))
 			}
 		}
 	}
@@ -154,7 +154,7 @@ func validatePolicy(p map[string]interface{}) error {
 //    }
 //  }
 func validateStrategy(s map[string]interface{}) error {
-	var path = fmt.Sprintf("ScalingPolicy.Policy[%s]", keyStrategy)
+	var path = fmt.Sprintf("scaling->policy->%s", keyStrategy)
 
 	var result *multierror.Error
 
@@ -169,14 +169,14 @@ func validateStrategy(s map[string]interface{}) error {
 	nameKey := "name"
 	nameInterface, ok := s[nameKey]
 	if !ok {
-		result = multierror.Append(result, fmt.Errorf(`%s is missing key "%s"`, path, nameKey))
+		result = multierror.Append(result, fmt.Errorf("%s->%s is missing", path, nameKey))
 	} else {
 		nameString, ok := nameInterface.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s[%s] must be string, found %T", path, nameKey, nameInterface))
+			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, nameKey, nameInterface))
 		} else {
 			if nameString == "" {
-				result = multierror.Append(result, fmt.Errorf("%s[%s] can't be empty", path, nameKey))
+				result = multierror.Append(result, fmt.Errorf("%s->%s can't be empty", path, nameKey))
 			}
 		}
 	}
@@ -209,7 +209,7 @@ func validateStrategy(s map[string]interface{}) error {
 //    }
 //  }
 func validateTarget(t map[string]interface{}) error {
-	var path = fmt.Sprintf("ScalingPolicy.Policy[%s]", keyTarget)
+	var path = fmt.Sprintf("scaling->policy->%s", keyTarget)
 
 	var result *multierror.Error
 
@@ -221,10 +221,10 @@ func validateTarget(t map[string]interface{}) error {
 	if ok {
 		nameString, ok := nameInterface.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s[%s] must be string, found %T", path, nameKey, nameInterface))
+			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, nameKey, nameInterface))
 		} else {
 			if nameString == "" {
-				result = multierror.Append(result, fmt.Errorf("%s[%s] can't be empty", path, nameKey))
+				result = multierror.Append(result, fmt.Errorf("%s->%s can't be empty", path, nameKey))
 			}
 		}
 	}
@@ -248,16 +248,16 @@ func validateHCLBlock(in interface{}, path, key string, validator func(in map[st
 
 	list, ok := in.([]interface{})
 	if !ok {
-		return multierror.Append(result, fmt.Errorf("%s[%s] must be []interface{}, found %T", path, key, in))
+		return multierror.Append(result, fmt.Errorf("%s->%s must be []interface{}, found %T", path, key, in))
 	}
 
 	if len(list) != 1 {
-		return multierror.Append(result, fmt.Errorf("%s[%s] must have length 1, found %d", path, key, len(list)))
+		return multierror.Append(result, fmt.Errorf("%s->%s must have length 1, found %d", path, key, len(list)))
 	}
 
 	inMap, ok := list[0].(map[string]interface{})
 	if !ok {
-		return multierror.Append(result, fmt.Errorf("%s[%s][0] must be map[string]interface{}, found %T", path, key, list[0]))
+		return multierror.Append(result, fmt.Errorf("%s->%s[0] must be map[string]interface{}, found %T", path, key, list[0]))
 	}
 
 	if validator != nil {

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -19,7 +19,7 @@ func validateScalingPolicy(policy *api.ScalingPolicy) error {
 
 	// Validate ID.
 	if policy.ID == "" {
-		result = multierror.Append(result, fmt.Errorf("ScalingPolicy.ID is empty"))
+		result = multierror.Append(result, fmt.Errorf("ID is empty"))
 	}
 
 	// Validate Min and Max values.
@@ -28,25 +28,25 @@ func validateScalingPolicy(policy *api.ScalingPolicy) error {
 	//   3. Max must be positive.
 	//   4. Min must be smaller than Max.
 	if policy.Min == nil {
-		result = multierror.Append(result, fmt.Errorf("ScalingPolicy.Min is nil"))
+		result = multierror.Append(result, fmt.Errorf("scaling->min is missing"))
 	} else {
 		min := *policy.Min
 		if min < 0 {
-			result = multierror.Append(result, fmt.Errorf("ScalingPolicy.Min can't be negative"))
+			result = multierror.Append(result, fmt.Errorf("scaling->min can't be negative"))
 		}
 
 		if min > policy.Max {
-			result = multierror.Append(result, fmt.Errorf("ScalingPolicy.Min must be smaller than ScalingPolicy.Max"))
+			result = multierror.Append(result, fmt.Errorf("scaling->min must be smaller than scaling->max"))
 		}
 	}
 
 	if policy.Max < 0 {
-		result = multierror.Append(result, fmt.Errorf("ScalingPolicy.Max can't be negative"))
+		result = multierror.Append(result, fmt.Errorf("scaling->max can't be negative"))
 	}
 
 	// Validate Target.
 	if policy.Target == nil {
-		result = multierror.Append(result, fmt.Errorf("ScalingPolicy.Target is nil"))
+		result = multierror.Append(result, fmt.Errorf("Target is nil"))
 	}
 
 	// Validate Policy.

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -120,17 +120,17 @@ func validatePolicy(p map[string]interface{}) error {
 
 	// Validate Strategy.
 	//   1. Strategy key must exist.
-	//   2. Strategy must be a valid HCL block.
-	strategyErrs := validateHCLBlock(p[keyStrategy], path, keyStrategy, validateStrategy)
+	//   2. Strategy must be a valid block.
+	strategyErrs := validateBlock(p[keyStrategy], path, keyStrategy, validateStrategy)
 	if strategyErrs != nil {
 		result = multierror.Append(result, strategyErrs)
 	}
 
 	// Validate Target (optional).
-	//   1. Target must be a valid HCL block if present.
+	//   1. Target must be a valid block if present.
 	targetInterface, ok := p[keyTarget]
 	if ok {
-		targetErr := validateHCLBlock(targetInterface, path, keyTarget, validateTarget)
+		targetErr := validateBlock(targetInterface, path, keyTarget, validateTarget)
 		if targetErr != nil {
 			result = multierror.Append(result, targetErr)
 		}
@@ -183,10 +183,10 @@ func validateStrategy(s map[string]interface{}) error {
 	}
 
 	// Validate config (optional).
-	//   1. Config must be an HCL block if present.
+	//   1. Config must be a block if present.
 	configKey := "config"
 	if config, ok := s[configKey]; ok {
-		err := validateHCLBlock(config, path, configKey, nil)
+		err := validateBlock(config, path, configKey, nil)
 		if err != nil {
 			result = multierror.Append(result, err)
 		}
@@ -236,10 +236,10 @@ func validateTarget(t map[string]interface{}) error {
 	}
 
 	// Validate config (optional).
-	//   1. Config must be an HCL block if present.
+	//   1. Config must be a block if present.
 	configKey := "config"
 	if config, ok := t[configKey]; ok {
-		err := validateHCLBlock(config, path, configKey, nil)
+		err := validateBlock(config, path, configKey, nil)
 		if err != nil {
 			result = multierror.Append(result, err)
 		}
@@ -248,8 +248,8 @@ func validateTarget(t map[string]interface{}) error {
 	return result.ErrorOrNil()
 }
 
-// validateHCLBlock validates the kind of unusual structure we receive when the policy HCL block is parsed.
-func validateHCLBlock(in interface{}, path, key string, validator func(in map[string]interface{}) error) error {
+// validateBlock validates the kind of unusual structure we receive when the policy is parsed.
+func validateBlock(in interface{}, path, key string, validator func(in map[string]interface{}) error) error {
 	var result *multierror.Error
 
 	list, ok := in.([]interface{})

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -158,6 +158,7 @@ func validateStrategy(s map[string]interface{}) error {
 
 	var result *multierror.Error
 
+	// It shouldn't happen, but it's better to prevent a panic.
 	if s == nil {
 		return multierror.Append(result, fmt.Errorf("%s is nil", path))
 	}
@@ -212,6 +213,11 @@ func validateTarget(t map[string]interface{}) error {
 	var path = fmt.Sprintf("scaling->policy->%s", keyTarget)
 
 	var result *multierror.Error
+
+	// It shouldn't happen, but it's better to prevent a panic.
+	if t == nil {
+		return multierror.Append(result, fmt.Errorf("%s is nil", path))
+	}
 
 	// Validate name (optional).
 	//   1. Name must have string value if present.

--- a/policy/nomad/validate_test.go
+++ b/policy/nomad/validate_test.go
@@ -546,6 +546,13 @@ func Test_validateBlock(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "valid block map",
+			input: map[string]interface{}{
+				"key": "value",
+			},
+			expectError: false,
+		},
+		{
 			name:        "block root has wrong type",
 			input:       true,
 			expectError: true,
@@ -576,6 +583,16 @@ func Test_validateBlock(t *testing.T) {
 				map[string]interface{}{
 					"key": "value",
 				},
+			},
+			validator: func(in map[string]interface{}) error {
+				return fmt.Errorf("error from validator")
+			},
+			expectError: true,
+		},
+		{
+			name: "validator is called with map",
+			input: map[string]interface{}{
+				"key": "value",
 			},
 			validator: func(in map[string]interface{}) error {
 				return fmt.Errorf("error from validator")

--- a/policy/nomad/validate_test.go
+++ b/policy/nomad/validate_test.go
@@ -529,7 +529,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 	}
 }
 
-func Test_validateHCLBlock(t *testing.T) {
+func Test_validateBlock(t *testing.T) {
 	testCases := []struct {
 		name        string
 		input       interface{}
@@ -586,7 +586,7 @@ func Test_validateHCLBlock(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateHCLBlock(tc.input, "path", "key", tc.validator)
+			err := validateBlock(tc.input, "path", "key", tc.validator)
 			if err != nil {
 				t.Log(err)
 			}

--- a/policy/nomad/validate_test.go
+++ b/policy/nomad/validate_test.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"flag"
 	"fmt"
 	"testing"
 
@@ -8,6 +9,8 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/stretchr/testify/assert"
 )
+
+var showValidationError = flag.Bool("show-validation-error", false, "")
 
 func Test_validateScalingPolicy(t *testing.T) {
 	testCases := []struct {
@@ -515,8 +518,8 @@ func Test_validateScalingPolicy(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := validateScalingPolicy(tc.input)
-			if err != nil {
-				t.Log(err)
+			if err != nil && *showValidationError {
+				fmt.Println(err)
 			}
 
 			assertFunc := assert.NoError
@@ -604,8 +607,8 @@ func Test_validateBlock(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := validateBlock(tc.input, "path", "key", tc.validator)
-			if err != nil {
-				t.Log(err)
+			if err != nil && *showValidationError {
+				fmt.Println(err)
 			}
 
 			assertFunc := assert.NoError


### PR DESCRIPTION
This PR improves policy validation in a few ways:
1. **validate the right target component**: the initial implementation only validated `ScalingPolicy.Target` which is a `map[string]string` and doesn't actually need validation.
2. **encapsulate the logic to validate an HCL block in a function**: this allows us to re-use the validation logic in different places, such as `strategy` and `target`.
3. **return error messages related to the jobspec when possible**: previously the error messages would be related to the specific internal structure of the policy, which is not significant to end users. New error messages use the same `block1->block2` notation from the Nomad docs.
4. **only test `validateScalingPolicy`**: this is the main function that calls all the others. Testing individual sub-functions failed to capture some cases.
5. **expand test cases**: test cases now have a full policy as input, as opposed to selectively remove fields from a known valid input. This makes it more clear to understand what is being tested.
6. **show validation error message in tests**: it's useful to see how validation messages will be displayed to users. You can use the `-show-validation-error` flag when running tests to seem them:
```sh
go test -v -run Test_validate ./policy/nomad/ -show-validation-error
```