### PR TITLE
Improve validation log

### DIFF
--- a/policy/manager.go
+++ b/policy/manager.go
@@ -79,7 +79,7 @@ func (m *Manager) Run(ctx context.Context, evalCh chan<- *Evaluation) {
 
 				h := NewHandler(
 					policyID,
-					m.log.ResetNamed("policy_handler"),
+					m.log.ResetNamed(""),
 					m.pluginManager,
 					m.policySource)
 				m.handlers[policyID] = h

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -28,20 +28,20 @@ func validateScalingPolicy(policy *api.ScalingPolicy) error {
 	//   3. Max must be positive.
 	//   4. Min must be smaller than Max.
 	if policy.Min == nil {
-		result = multierror.Append(result, fmt.Errorf("scaling->min is missing"))
+		result = multierror.Append(result, fmt.Errorf("scaling.min is missing"))
 	} else {
 		min := *policy.Min
 		if min < 0 {
-			result = multierror.Append(result, fmt.Errorf("scaling->min can't be negative"))
+			result = multierror.Append(result, fmt.Errorf("scaling.min can't be negative"))
 		}
 
 		if min > policy.Max {
-			result = multierror.Append(result, fmt.Errorf("scaling->min must be smaller than scaling->max"))
+			result = multierror.Append(result, fmt.Errorf("scaling.min must be smaller than scaling.max"))
 		}
 	}
 
 	if policy.Max < 0 {
-		result = multierror.Append(result, fmt.Errorf("scaling->max can't be negative"))
+		result = multierror.Append(result, fmt.Errorf("scaling.max can't be negative"))
 	}
 
 	// Validate Target.
@@ -67,7 +67,7 @@ func validateScalingPolicy(policy *api.ScalingPolicy) error {
 //   +----------+
 //  }
 func validatePolicy(p map[string]interface{}) error {
-	const path = "scaling->policy"
+	const path = "scaling.policy"
 
 	var result *multierror.Error
 
@@ -81,7 +81,7 @@ func validatePolicy(p map[string]interface{}) error {
 	if ok {
 		_, ok := source.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, keySource, source))
+			result = multierror.Append(result, fmt.Errorf("%s.%s must be string, found %T", path, keySource, source))
 		}
 	}
 
@@ -91,14 +91,14 @@ func validatePolicy(p map[string]interface{}) error {
 	//   3. Query must not be empty.
 	query, ok := p[keyQuery]
 	if !ok {
-		result = multierror.Append(result, fmt.Errorf("%s->%s is missing", path, keyQuery))
+		result = multierror.Append(result, fmt.Errorf("%s.%s is missing", path, keyQuery))
 	} else {
 		queryStr, ok := query.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, keyQuery, query))
+			result = multierror.Append(result, fmt.Errorf("%s.%s must be string, found %T", path, keyQuery, query))
 		} else {
 			if queryStr == "" {
-				result = multierror.Append(result, fmt.Errorf("%s->%s can't be empty", path, keyQuery))
+				result = multierror.Append(result, fmt.Errorf("%s.%s can't be empty", path, keyQuery))
 			}
 		}
 	}
@@ -110,10 +110,10 @@ func validatePolicy(p map[string]interface{}) error {
 	if ok {
 		evalIntervalString, ok := evalInterval.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, keyEvaluationInterval, evalInterval))
+			result = multierror.Append(result, fmt.Errorf("%s.%s must be string, found %T", path, keyEvaluationInterval, evalInterval))
 		} else {
 			if _, err := time.ParseDuration(evalIntervalString); err != nil {
-				result = multierror.Append(result, fmt.Errorf("%s->%s must have time.Duration format", path, keyEvaluationInterval))
+				result = multierror.Append(result, fmt.Errorf("%s.%s must have time.Duration format", path, keyEvaluationInterval))
 			}
 		}
 	}
@@ -154,7 +154,7 @@ func validatePolicy(p map[string]interface{}) error {
 //    }
 //  }
 func validateStrategy(s map[string]interface{}) error {
-	var path = fmt.Sprintf("scaling->policy->%s", keyStrategy)
+	var path = fmt.Sprintf("scaling.policy.%s", keyStrategy)
 
 	var result *multierror.Error
 
@@ -170,14 +170,14 @@ func validateStrategy(s map[string]interface{}) error {
 	nameKey := "name"
 	nameInterface, ok := s[nameKey]
 	if !ok {
-		result = multierror.Append(result, fmt.Errorf("%s->%s is missing", path, nameKey))
+		result = multierror.Append(result, fmt.Errorf("%s.%s is missing", path, nameKey))
 	} else {
 		nameString, ok := nameInterface.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, nameKey, nameInterface))
+			result = multierror.Append(result, fmt.Errorf("%s.%s must be string, found %T", path, nameKey, nameInterface))
 		} else {
 			if nameString == "" {
-				result = multierror.Append(result, fmt.Errorf("%s->%s can't be empty", path, nameKey))
+				result = multierror.Append(result, fmt.Errorf("%s.%s can't be empty", path, nameKey))
 			}
 		}
 	}
@@ -210,7 +210,7 @@ func validateStrategy(s map[string]interface{}) error {
 //    }
 //  }
 func validateTarget(t map[string]interface{}) error {
-	var path = fmt.Sprintf("scaling->policy->%s", keyTarget)
+	var path = fmt.Sprintf("scaling.policy.%s", keyTarget)
 
 	var result *multierror.Error
 
@@ -227,10 +227,10 @@ func validateTarget(t map[string]interface{}) error {
 	if ok {
 		nameString, ok := nameInterface.(string)
 		if !ok {
-			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, nameKey, nameInterface))
+			result = multierror.Append(result, fmt.Errorf("%s.%s must be string, found %T", path, nameKey, nameInterface))
 		} else {
 			if nameString == "" {
-				result = multierror.Append(result, fmt.Errorf("%s->%s can't be empty", path, nameKey))
+				result = multierror.Append(result, fmt.Errorf("%s.%s can't be empty", path, nameKey))
 			}
 		}
 	}
@@ -269,16 +269,16 @@ func validateBlock(in interface{}, path, key string, validator func(in map[strin
 
 	list, ok := in.([]interface{})
 	if !ok {
-		return multierror.Append(result, fmt.Errorf("%s->%s must be []interface{}, found %T", path, key, in))
+		return multierror.Append(result, fmt.Errorf("%s.%s must be []interface{}, found %T", path, key, in))
 	}
 
 	if len(list) != 1 {
-		return multierror.Append(result, fmt.Errorf("%s->%s must have length 1, found %d", path, key, len(list)))
+		return multierror.Append(result, fmt.Errorf("%s.%s must have length 1, found %d", path, key, len(list)))
 	}
 
 	inMap, ok := list[0].(map[string]interface{})
 	if !ok {
-		return multierror.Append(result, fmt.Errorf("%s->%s[0] must be map[string]interface{}, found %T", path, key, list[0]))
+		return multierror.Append(result, fmt.Errorf("%s.%s[0] must be map[string]interface{}, found %T", path, key, list[0]))
 	}
 
 	runValidator(inMap)


### PR DESCRIPTION
Policy validation uses `multierror` to potentially return multiple error messages depending on how many fields are incorrect. 

The default formatter for `multierror` generates a string that is not ideal for structured log libraries, such as `hclog`:

#### Standard format:
```
2020-05-04T15:33:01.798-0400 [ERROR] policy_handler.policy_handler: invalid policy: 2 errors occurred:
        * scaling->policy->query is missing
        * scaling->policy->strategy->name is missing

: policy_id=eec161ee-c8f0-d998-2b3f-12a84d6083d2
```

#### JSON format:
```json
{
  "@level":"error",
  "@message":"invalid policy: 2 errors occurred:\n\t* scaling-\u003epolicy-\u003equery is missing\n\t* scaling-\u003epolicy-\u003estrategy-\u003ename is missing\n\n",
  "@module":"policy_handler.policy_handler",
  "@timestamp":"2020-05-04T15:36:14.313933-04:00",
  "policy_id":"eec161ee-c8f0-d998-2b3f-12a84d6083d2"
}
```

`hclog` also escapes HTML characters such as `<` and `>` making the arrow (`->`) separator harder to read. It was also being misused causing the module name to be duplicated as `policy_handler.policy_handler`.

This PR fixes the issues described above by:
*  logging validation errors as a list of strings
* replacing the arrow (`->`) separator with a dot (`.`)
* removing the extra `policy_handler` from the module name

#### Standard format:
```
2020-05-04T15:41:50.590-0400 [ERROR] policy_handler: policy validation failed: policy_id=eec161ee-c8f0-d998-2b3f-12a84d6083d2 errors=["scaling.policy.query is missing", "scaling.policy.strategy.name is missing"]
```

#### JSON format:
```json
{
  "@level": "error",
  "@message": "policy validation failed",
  "@module": "policy_handler",
  "@timestamp": "2020-05-04T15:41:08.573369-04:00",
  "errors": [
    "scaling.policy.query is missing",
    "scaling.policy.strategy.name is missing"
  ],
  "policy_id": "eec161ee-c8f0-d998-2b3f-12a84d6083d2"
}
```