### PR TITLE
policy: fix Nomad target parsing when target block is empty.

### DIFF
--- a/plugins/builtin/target/nomad/plugin/plugin.go
+++ b/plugins/builtin/target/nomad/plugin/plugin.go
@@ -21,8 +21,8 @@ const (
 
 	// configKeys are the accepted configuration map keys which can be
 	// processed when performing SetConfig().
-	configKeyJobID = "job_id"
-	configKeyGroup = "group"
+	configKeyJobID = "Job"
+	configKeyGroup = "Group"
 
 	// garbageCollectionNanoSecondThreshold is the nanosecond threshold used
 	// when performing garbage collection of job status handlers.
@@ -107,8 +107,8 @@ func (t *TargetPlugin) Scale(action strategy.Action, config map[string]string) e
 		countIntPtr = &countInt
 	}
 
-	_, _, err := t.client.Jobs().Scale(config["job_id"],
-		config["group"],
+	_, _, err := t.client.Jobs().Scale(config[configKeyJobID],
+		config[configKeyGroup],
 		countIntPtr,
 		action.Reason,
 		action.Error,

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -112,27 +112,23 @@ func parseStrategy(s interface{}) *policy.Strategy {
 //    }
 //  }
 func parseTarget(targetBlock interface{}, targetAttr map[string]string) *policy.Target {
-	if targetBlock == nil && targetAttr == nil {
-		return nil
-	}
 
 	targetMap := parseBlock(targetBlock)
-	if targetMap == nil {
+	if targetMap == nil && targetAttr == nil {
 		return nil
 	}
 
-	var configMapString map[string]string
-	configMap := parseBlock(targetMap["config"])
+	configMapString := make(map[string]string)
+	for k, v := range targetAttr {
+		configMapString[k] = v
+	}
+	if targetMap != nil {
+		configMap := parseBlock(targetMap["config"])
 
-	if configMap != nil {
-		configMapString = make(map[string]string)
-
-		for k, v := range targetAttr {
-			configMapString[k] = v
-		}
-
-		for k, v := range configMap {
-			configMapString[k] = fmt.Sprintf("%v", v)
+		if configMap != nil {
+			for k, v := range configMap {
+				configMapString[k] = fmt.Sprintf("%v", v)
+			}
 		}
 	}
 

--- a/policy/nomad/parser_test.go
+++ b/policy/nomad/parser_test.go
@@ -81,6 +81,59 @@ func Test_parsePolicy(t *testing.T) {
 			},
 		},
 		{
+			name: "policy with empty policy target",
+			input: &api.ScalingPolicy{
+				ID:        "id",
+				Namespace: "default",
+				Target: map[string]string{
+					"Namespace": "namespace",
+					"Job":       "example",
+					"Group":     "cache",
+				},
+				Min: ptr.Int64ToPtr(1),
+				Max: 5,
+				Policy: map[string]interface{}{
+					keySource:             "source",
+					keyQuery:              "query",
+					keyEvaluationInterval: "5s",
+					keyStrategy: []interface{}{
+						map[string]interface{}{
+							"name": "strategy",
+							"config": []interface{}{
+								map[string]interface{}{
+									"bool_config": true,
+								},
+							},
+						},
+					},
+				},
+				Enabled: ptr.BoolToPtr(true),
+			},
+			expected: policy.Policy{
+				ID:                 "id",
+				Min:                1,
+				Max:                5,
+				Source:             "source",
+				Query:              "query",
+				Enabled:            true,
+				EvaluationInterval: 5 * time.Second,
+				Target: &policy.Target{
+					Name: "",
+					Config: map[string]string{
+						"Namespace": "namespace",
+						"Job":       "example",
+						"Group":     "cache",
+					},
+				},
+				Strategy: &policy.Strategy{
+					Name: "strategy",
+					Config: map[string]string{
+						"bool_config": "true",
+					},
+				},
+			},
+		},
+		{
 			name:  "empty policy",
 			input: &api.ScalingPolicy{},
 			expected: policy.Policy{

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -207,23 +207,6 @@ func (s *Source) canonicalizePolicy(p *policy.Policy) {
 		p.Target.Config = make(map[string]string)
 	}
 
-	// Map values from the original api.ScalingPolicy.Target into
-	// policy.Policy.Target.Config
-	// TODO(luiz): is this really necessay? We should probably just use what's returned in Target
-	targetConfigKeyMapping := map[string]string{
-		"Job":   "job_id",
-		"Group": "group",
-	}
-
-	for k1, k2 := range targetConfigKeyMapping {
-		v, hasK1 := p.Target.Config[k1]
-		_, hasK2 := p.Target.Config[k2]
-
-		if hasK1 && !hasK2 {
-			p.Target.Config[k2] = v
-		}
-	}
-
 	// Default source to the Nomad APM.
 	if p.Source == "" {
 		p.Source = plugins.InternalAPMNomad
@@ -233,7 +216,7 @@ func (s *Source) canonicalizePolicy(p *policy.Policy) {
 	// <job> must be the last element so we can parse the query correctly
 	// since Nomad allows "/" in job IDs.
 	if p.Source == plugins.InternalAPMNomad && isShortQuery(p.Query) {
-		p.Query = fmt.Sprintf("%s/%s/%s", p.Query, p.Target.Config["group"], p.Target.Config["job_id"])
+		p.Query = fmt.Sprintf("%s/%s/%s", p.Query, p.Target.Config["Group"], p.Target.Config["Job"])
 	}
 }
 

--- a/policy/nomad/source_test.go
+++ b/policy/nomad/source_test.go
@@ -91,8 +91,6 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 						"target_config2": "no",
 						"Job":            "job",
 						"Group":          "group",
-						"job_id":         "job",
-						"group":          "group",
 					},
 				},
 				Strategy: &policy.Strategy{
@@ -142,10 +140,8 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Target: &policy.Target{
 					Name: plugins.InternalTargetNomad,
 					Config: map[string]string{
-						"Job":    "job",
-						"Group":  "group",
-						"job_id": "job",
-						"group":  "group",
+						"Job":   "job",
+						"Group": "group",
 					},
 				},
 				Strategy: &policy.Strategy{
@@ -172,10 +168,8 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Target: &policy.Target{
 					Name: plugins.InternalTargetNomad,
 					Config: map[string]string{
-						"Job":    "job",
-						"Group":  "group",
-						"job_id": "job",
-						"group":  "group",
+						"Job":   "job",
+						"Group": "group",
 					},
 				},
 				Strategy: &policy.Strategy{
@@ -189,10 +183,8 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Query: "avg_cpu",
 				Target: &policy.Target{
 					Config: map[string]string{
-						"Job":    "job",
-						"Group":  "group",
-						"job_id": "my_job",
-						"group":  "my_group",
+						"Job":   "my_job",
+						"Group": "my_group",
 					},
 				},
 			},
@@ -203,10 +195,8 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Target: &policy.Target{
 					Name: plugins.InternalTargetNomad,
 					Config: map[string]string{
-						"Job":    "job",
-						"Group":  "group",
-						"job_id": "my_job",
-						"group":  "my_group",
+						"Job":   "my_job",
+						"Group": "my_group",
 					},
 				},
 				Strategy: &policy.Strategy{
@@ -233,10 +223,8 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Target: &policy.Target{
 					Name: plugins.InternalTargetNomad,
 					Config: map[string]string{
-						"Job":    "job",
-						"Group":  "group",
-						"job_id": "job",
-						"group":  "group",
+						"Job":   "job",
+						"Group": "group",
 					},
 				},
 				Strategy: &policy.Strategy{
@@ -262,10 +250,8 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Target: &policy.Target{
 					Name: plugins.InternalTargetNomad,
 					Config: map[string]string{
-						"Job":    "job",
-						"Group":  "group",
-						"job_id": "job",
-						"group":  "group",
+						"Job":   "job",
+						"Group": "group",
 					},
 				},
 				Strategy: &policy.Strategy{


### PR DESCRIPTION
When parsing a scaling policy from Nomad which did not contain a
target block within the policy map, the outer target map which
contained both the job and group information was ignored. This
resulted in evaluation failures and rendered the policy incapable
of being used by the autoscaler.

The fix updates the target parsing to correctly handle the above
described situation. Whilst also figuring this out, it made sense
to remove the unnecessary additional target mapping within
canonicalizePolicy() as pointed out in comments by @lgfa29. This
requires a small change to the Nomad target plugin, but results in
a simpler workflow.