### PR TITLE
agent: support scaling cooldowns to aid oscillation migration.

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -123,7 +123,7 @@ type Policy struct {
 	// DefaultCooldown is the default cooldown parameter added to all policies
 	// which do not explicitly configure the parameter.
 	DefaultCooldown    time.Duration
-	DefaultCooldownHCL string `hcl:"default_cooldown,optional" json:"-"`
+	DefaultCooldownHCL string `hcl:"default_cooldown,optional"`
 }
 
 const (

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -46,6 +46,9 @@ type Agent struct {
 	// Nomad is the configuration used to setup the Nomad client.
 	Nomad *Nomad `hcl:"nomad,block"`
 
+	// Policy is the configuration used to setup the policy manager.
+	Policy *Policy `hcl:"policy,block"`
+
 	APMs       []*Plugin `hcl:"apm,block"`
 	Targets    []*Plugin `hcl:"target,block"`
 	Strategies []*Plugin `hcl:"strategy,block"`
@@ -113,6 +116,16 @@ type Plugin struct {
 	Config map[string]string `hcl:"config,optional"`
 }
 
+// Policy holds the configuration information specific to the policy manager
+// and resulting policy parsing.
+type Policy struct {
+
+	// DefaultCooldown is the default cooldown parameter added to all policies
+	// which do not explicitly configure the parameter.
+	DefaultCooldown    time.Duration
+	DefaultCooldownHCL string `hcl:"default_cooldown,optional" json:"-"`
+}
+
 const (
 	// defaultLogLevel is the default log level used for the Autoscaler agent.
 	defaultLogLevel = "info"
@@ -139,6 +152,10 @@ const (
 	// defaultNomadRegion is the default Nomad region to use when performing
 	// Nomad API calls.
 	defaultNomadRegion = "global"
+
+	// defaultPolicyCooldown is the default time duration applied to policies
+	// which do not explicitly configure a cooldown.
+	defaultPolicyCooldown = 5 * time.Minute
 )
 
 // Default is used to generate a new default agent configuration.
@@ -162,6 +179,9 @@ func Default() (*Agent, error) {
 		Nomad: &Nomad{
 			Address: defaultNomadAddress,
 			Region:  defaultNomadRegion,
+		},
+		Policy: &Policy{
+			DefaultCooldown: defaultPolicyCooldown,
 		},
 		APMs:    []*Plugin{{Name: plugins.InternalAPMNomad, Driver: plugins.InternalAPMNomad}},
 		Targets: []*Plugin{{Name: plugins.InternalTargetNomad, Driver: plugins.InternalTargetNomad}},
@@ -191,6 +211,10 @@ func (a *Agent) Merge(b *Agent) *Agent {
 
 	if b.Nomad != nil {
 		result.Nomad = result.Nomad.merge(b.Nomad)
+	}
+
+	if b.Policy != nil {
+		result.Policy = result.Policy.merge(b.Policy)
 	}
 
 	if len(result.APMs) == 0 && len(b.APMs) != 0 {
@@ -305,6 +329,15 @@ func (p *Plugin) copy() *Plugin {
 	return &c
 }
 
+func (p *Policy) merge(b *Policy) *Policy {
+	result := *p
+
+	if b.DefaultCooldown != 0 {
+		result.DefaultCooldown = b.DefaultCooldown
+	}
+	return &result
+}
+
 // pluginConfigSetMerge merges two sets of plugin configs. For plugins with the
 // same name, the configs are merged.
 func pluginConfigSetMerge(first, second []*Plugin) []*Plugin {
@@ -356,6 +389,15 @@ func parseFile(file string, cfg *Agent) error {
 		}
 		cfg.DefaultEvaluationInterval = d
 	}
+
+	if cfg.Policy != nil && cfg.Policy.DefaultCooldownHCL != "" {
+		d, err := time.ParseDuration(cfg.Policy.DefaultCooldownHCL)
+		if err != nil {
+			return err
+		}
+		cfg.Policy.DefaultCooldown = d
+	}
+
 	return nil
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -22,7 +22,7 @@ func Test_Default(t *testing.T) {
 	assert.Equal(t, def.Nomad.Address, "http://127.0.0.1:4646")
 	assert.Equal(t, "127.0.0.1", def.HTTP.BindAddress)
 	assert.Equal(t, 8080, def.HTTP.BindPort)
-	assert.Equal(t, def.Policy.DefaultCooldown, time.Duration(300000000000))
+	assert.Equal(t, def.Policy.DefaultCooldown, 5 * time.Minute)
 	assert.Len(t, def.APMs, 1)
 	assert.Len(t, def.Targets, 1)
 }

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -22,6 +22,7 @@ func Test_Default(t *testing.T) {
 	assert.Equal(t, def.Nomad.Address, "http://127.0.0.1:4646")
 	assert.Equal(t, "127.0.0.1", def.HTTP.BindAddress)
 	assert.Equal(t, 8080, def.HTTP.BindPort)
+	assert.Equal(t, def.Policy.DefaultCooldown, time.Duration(300000000000))
 	assert.Len(t, def.APMs, 1)
 	assert.Len(t, def.Targets, 1)
 }
@@ -69,6 +70,9 @@ func TestAgent_Merge(t *testing.T) {
 			TLSServerName: "cows-or-pets",
 			SkipVerify:    true,
 		},
+		Policy: &Policy{
+			DefaultCooldown: 20 * time.Minute,
+		},
 		APMs: []*Plugin{
 			{
 				Name:   "influx-db",
@@ -111,6 +115,9 @@ func TestAgent_Merge(t *testing.T) {
 			TLSServerName: "cows-or-pets",
 			SkipVerify:    true,
 		},
+		Policy: &Policy{
+			DefaultCooldown: 20 * time.Minute,
+		},
 		APMs: []*Plugin{
 			{
 				Name:   "nomad-apm",
@@ -150,6 +157,7 @@ func TestAgent_Merge(t *testing.T) {
 	assert.Equal(t, expectedResult.Nomad, actualResult.Nomad)
 	assert.Equal(t, expectedResult.PluginDir, actualResult.PluginDir)
 	assert.Equal(t, expectedResult.DefaultEvaluationInterval, actualResult.DefaultEvaluationInterval)
+	assert.Equal(t, expectedResult.Policy, actualResult.Policy)
 	assert.ElementsMatch(t, expectedResult.APMs, actualResult.APMs)
 	assert.ElementsMatch(t, expectedResult.Targets, actualResult.Targets)
 	assert.ElementsMatch(t, expectedResult.Strategies, actualResult.Strategies)

--- a/plugins/builtin/target/nomad/plugin/state.go
+++ b/plugins/builtin/target/nomad/plugin/state.go
@@ -73,34 +73,47 @@ func (jsh *jobScaleStatusHandler) status(group string) (*target.Status, error) {
 		return nil, nil
 	}
 
-	var (
-		count int
-		found bool
-	)
+	// Use a variable to sort the task group status if we find it. Using a
+	// pointer allows us to perform a nil check to see if we found the task
+	// group or not.
+	var status *api.TaskGroupScaleStatus
 
+	// Iterate the task groups until we find the one we are looking for.
 	for name, tg := range jsh.scaleStatus.TaskGroups {
 		if name == group {
-			// Currently "Running" is not populated:
-			//  https://github.com/hashicorp/nomad/issues/7789
-			count = tg.Healthy
-			found = true
+			status = &tg
 			break
 		}
 	}
 
 	// If we did not find the task group in the status list, we can't reliably
 	// inform the caller of any details. Therefore return an error.
-	if !found {
+	if status == nil {
 		return nil, fmt.Errorf("task group %q not found", group)
 	}
 
-	return &target.Status{
+	// Hydrate the response object with the information we have collected that
+	// is nil safe. Currently "Running" is not populated in a tagged release:
+	//  https://github.com/hashicorp/nomad/issues/7789
+	resp := target.Status{
 		Ready: !jsh.scaleStatus.JobStopped,
-		Count: int64(count),
+		Count: int64(status.Healthy),
 		Meta: map[string]string{
 			metaKeyPrefix + jsh.jobID + metaKeyJobStoppedSuffix: strconv.FormatBool(jsh.scaleStatus.JobStopped),
 		},
-	}, nil
+	}
+
+	// Scaling events are an ordered list. If we have entries take the
+	// timestamp of the most recent and add this to our meta.
+	//
+	// Currently any event registered will cause the cooldown period to take
+	// effect. If we use the scale endpoint in the future to register events
+	// such as policy parsing errors, we should filter those out.
+	if len(status.Events) > 0 {
+		resp.Meta[target.MetaKeyLastEvent] = strconv.FormatUint(status.Events[0].Time, 10)
+	}
+
+	return &resp, nil
 }
 
 // start runs the blocking query loop that processes changes from the API and

--- a/plugins/builtin/target/nomad/plugin/state.go
+++ b/plugins/builtin/target/nomad/plugin/state.go
@@ -93,7 +93,8 @@ func (jsh *jobScaleStatusHandler) status(group string) (*target.Status, error) {
 	}
 
 	// Hydrate the response object with the information we have collected that
-	// is nil safe. Currently "Running" is not populated in a tagged release:
+	// is nil safe.
+	// TODO(jrasell) Currently "Running" is not populated in a tagged release:
 	//  https://github.com/hashicorp/nomad/issues/7789
 	resp := target.Status{
 		Ready: !jsh.scaleStatus.JobStopped,

--- a/plugins/builtin/target/nomad/plugin/state_test.go
+++ b/plugins/builtin/target/nomad/plugin/state_test.go
@@ -102,9 +102,11 @@ func Test_jobStateHandler_status(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actualReturn, actualErr := tc.inputJSH.status(tc.inputGroup)
-		assert.Equal(t, tc.expectedReturn, actualReturn, tc.name)
-		assert.Equal(t, tc.expectedError, actualErr, tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			actualReturn, actualErr := tc.inputJSH.status(tc.inputGroup)
+			assert.Equal(t, tc.expectedReturn, actualReturn, tc.name)
+			assert.Equal(t, tc.expectedError, actualErr, tc.name)
+		})
 	}
 }
 

--- a/plugins/manager/manager.go
+++ b/plugins/manager/manager.go
@@ -105,7 +105,7 @@ func (pm *PluginManager) Dispense(name, pluginType string) (PluginInstance, erro
 	//  exited.
 	inst, ok := pm.pluginInstances[plugins.PluginID{Name: name, PluginType: pluginType}]
 	if !ok {
-		return nil, fmt.Errorf("failed to dispense plugin: %s of type %s is not stored", name, pluginType)
+		return nil, fmt.Errorf("failed to dispense plugin: %q of type %q is not stored", name, pluginType)
 	}
 	return inst, nil
 }

--- a/plugins/target/target.go
+++ b/plugins/target/target.go
@@ -21,6 +21,12 @@ type Status struct {
 	Meta  map[string]string
 }
 
+// MetaKeyLastEvent is an optional meta key that can be added to the status
+// return. The value represents the last scaling event of the target as seen by
+// the remote providers view point. This helps enforce cooldown where
+// out-of-band scaling activities have been triggered.
+const MetaKeyLastEvent = "nomad_autoscaler.last_event"
+
 // RPC is a plugin implementation that talks over net/rpc
 type RPC struct {
 	client *rpc.Client

--- a/policy/handler_test.go
+++ b/policy/handler_test.go
@@ -8,40 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHandler_isInCooldown(t *testing.T) {
-	testCases := []struct {
-		inputCooldown  time.Duration
-		inputTimestamp int64
-		inputLastEvent uint64
-		expectedOutput bool
-		name           string
-	}{
-		{
-			inputCooldown:  100 * time.Hour,
-			inputTimestamp: time.Date(2020, time.April, 1, 9, 10, 0, 0, time.UTC).UnixNano(),
-			inputLastEvent: uint64(time.Date(2020, time.April, 1, 9, 9, 0, 0, time.UTC).UnixNano()),
-			expectedOutput: true,
-			name:           "policy is in current cooldown",
-		},
-		{
-			inputCooldown:  1 * time.Hour,
-			inputTimestamp: time.Date(2020, time.April, 1, 9, 10, 0, 0, time.UTC).UnixNano(),
-			inputLastEvent: uint64(time.Date(2020, time.April, 1, 8, 9, 0, 0, time.UTC).UnixNano()),
-			expectedOutput: false,
-			name:           "policy should not be in cooldown",
-		},
-	}
-
-	h := NewHandler("", hclog.NewNullLogger(), nil, nil)
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actualOutput := h.isInCooldown(tc.inputCooldown, tc.inputTimestamp, tc.inputLastEvent)
-			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
-		})
-	}
-}
-
 func TestHandler_calculateRemainingCooldown(t *testing.T) {
 
 	baseTime := time.Now().UTC().UnixNano()
@@ -59,6 +25,13 @@ func TestHandler_calculateRemainingCooldown(t *testing.T) {
 			inputLastEvent: baseTime - 10*time.Minute.Nanoseconds(),
 			expectedOutput: 10 * time.Minute,
 			name:           "resulting cooldown of 10 minutes",
+		},
+		{
+			inputCooldown:  20 * time.Minute,
+			inputTimestamp: baseTime,
+			inputLastEvent: baseTime - 25*time.Minute.Nanoseconds(),
+			expectedOutput: -5 * time.Minute,
+			name:           "negative cooldown period; ie. no cooldown",
 		},
 	}
 

--- a/policy/handler_test.go
+++ b/policy/handler_test.go
@@ -1,0 +1,73 @@
+package policy
+
+import (
+	"testing"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandler_isInCooldown(t *testing.T) {
+	testCases := []struct {
+		inputCooldown  time.Duration
+		inputTimestamp int64
+		inputLastEvent uint64
+		expectedOutput bool
+		name           string
+	}{
+		{
+			inputCooldown:  100 * time.Hour,
+			inputTimestamp: time.Date(2020, time.April, 1, 9, 10, 0, 0, time.UTC).UnixNano(),
+			inputLastEvent: uint64(time.Date(2020, time.April, 1, 9, 9, 0, 0, time.UTC).UnixNano()),
+			expectedOutput: true,
+			name:           "policy is in current cooldown",
+		},
+		{
+			inputCooldown:  1 * time.Hour,
+			inputTimestamp: time.Date(2020, time.April, 1, 9, 10, 0, 0, time.UTC).UnixNano(),
+			inputLastEvent: uint64(time.Date(2020, time.April, 1, 8, 9, 0, 0, time.UTC).UnixNano()),
+			expectedOutput: false,
+			name:           "policy should not be in cooldown",
+		},
+	}
+
+	h := NewHandler("", hclog.NewNullLogger(), nil, nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := h.isInCooldown(tc.inputCooldown, tc.inputTimestamp, tc.inputLastEvent)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}
+
+func TestHandler_calculateRemainingCooldown(t *testing.T) {
+
+	baseTime := time.Now().UTC().UnixNano()
+
+	testCases := []struct {
+		inputCooldown  time.Duration
+		inputTimestamp int64
+		inputLastEvent int64
+		expectedOutput time.Duration
+		name           string
+	}{
+		{
+			inputCooldown:  20 * time.Minute,
+			inputTimestamp: baseTime,
+			inputLastEvent: baseTime - 10*time.Minute.Nanoseconds(),
+			expectedOutput: 10 * time.Minute,
+			name:           "resulting cooldown of 10 minutes",
+		},
+	}
+
+	h := NewHandler("", hclog.NewNullLogger(), nil, nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := h.calculateRemainingCooldown(tc.inputCooldown, tc.inputTimestamp, tc.inputLastEvent)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}

--- a/policy/manager.go
+++ b/policy/manager.go
@@ -146,6 +146,6 @@ func (m *Manager) EnforceCooldown(id string, t time.Duration) {
 	if handler, ok := m.handlers[PolicyID(id)]; ok && handler.cooldownCh != nil {
 		handler.cooldownCh <- t
 	} else {
-		m.log.Debug("attempted to set cooldown on on-existent handler", "policy_id", id)
+		m.log.Debug("attempted to set cooldown on non-existent handler", "policy_id", id)
 	}
 }

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -45,6 +45,12 @@ func parsePolicy(p *api.ScalingPolicy) policy.Policy {
 		to.EvaluationInterval, _ = time.ParseDuration(eval)
 	}
 
+	// Parse cooldown as time.Duraction
+	// Ignore error since we assume policy has been validated.
+	if cooldown, ok := p.Policy[keyCooldown].(string); ok {
+		to.Cooldown, _ = time.ParseDuration(cooldown)
+	}
+
 	return to
 }
 

--- a/policy/nomad/parser_test.go
+++ b/policy/nomad/parser_test.go
@@ -162,6 +162,30 @@ func Test_parsePolicy(t *testing.T) {
 				Enabled: true,
 			},
 		},
+		{
+			name: "policy with evaluation_interval",
+			input: &api.ScalingPolicy{
+				Policy: map[string]interface{}{
+					keyEvaluationInterval: "7s",
+				},
+			},
+			expected: policy.Policy{
+				Enabled: true,
+				EvaluationInterval: 7*time.Second,
+			},
+		},
+		{
+			name: "policy with cooldown",
+			input: &api.ScalingPolicy{
+				Policy: map[string]interface{}{
+					keyCooldown: "7s",
+				},
+			},
+			expected: policy.Policy{
+				Enabled: true,
+				Cooldown: 7*time.Second,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -22,6 +22,7 @@ const (
 	keyEvaluationInterval = "evaluation_interval"
 	keyTarget             = "target"
 	keyStrategy           = "strategy"
+	keyCooldown           = "cooldown"
 )
 
 // Ensure NomadSource satisfies the Source interface.
@@ -30,6 +31,7 @@ var _ policy.Source = (*Source)(nil)
 // SourceConfig holds configuration values for the Nomad source.
 type SourceConfig struct {
 	DefaultEvaluationInterval time.Duration
+	DefaultCooldown           time.Duration
 }
 
 func (c *SourceConfig) canonicalize() {
@@ -192,6 +194,11 @@ func (s *Source) canonicalizePolicy(p *policy.Policy) {
 	// Default EvaluationInterval to the agent's DefaultEvaluationInterval.
 	if p.EvaluationInterval == 0 {
 		p.EvaluationInterval = s.config.DefaultEvaluationInterval
+	}
+
+	// If the operator did not set a cooldown, use the agent's DefaultCooldown.
+	if p.Cooldown == 0 {
+		p.Cooldown = s.config.DefaultCooldown
 	}
 
 	// Set default values for Strategy.

--- a/policy/nomad/source_test.go
+++ b/policy/nomad/source_test.go
@@ -277,6 +277,25 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				sourceConfig.DefaultEvaluationInterval = 5 * time.Second
 			},
 		},
+		{
+			name:  "sets cooldown from agent",
+			input: &policy.Policy{},
+			expected: &policy.Policy{
+				Source:             plugins.InternalAPMNomad,
+				EvaluationInterval: 10 * time.Second,
+				Cooldown:           1 * time.Hour,
+				Target: &policy.Target{
+					Name:   plugins.InternalTargetNomad,
+					Config: map[string]string{},
+				},
+				Strategy: &policy.Strategy{
+					Config: map[string]string{},
+				},
+			},
+			cb: func(_ *api.Config, sourceConfig *SourceConfig) {
+				sourceConfig.DefaultCooldown = 1 * time.Hour
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -118,6 +118,20 @@ func validatePolicy(p map[string]interface{}) error {
 		}
 	}
 
+	// Validate Cooldown.
+	//   1. Cooldown must have string value if defined.
+	//   2. Cooldown must have time.Duration format if defined.
+	if cooldown, ok := p[keyCooldown]; ok {
+		cooldownString, ok := cooldown.(string)
+		if !ok {
+			result = multierror.Append(result, fmt.Errorf("%s->%s must be string, found %T", path, keyCooldown, evalInterval))
+		} else {
+			if _, err := time.ParseDuration(cooldownString); err != nil {
+				result = multierror.Append(result, fmt.Errorf("%s->%s must have time.Duration format", path, keyCooldown))
+			}
+		}
+	}
+
 	// Validate Strategy.
 	//   1. Strategy key must exist.
 	//   2. Strategy must be a valid block.

--- a/policy/nomad/validate_test.go
+++ b/policy/nomad/validate_test.go
@@ -513,6 +513,50 @@ func Test_validateScalingPolicy(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "policy.cooldown has wrong type",
+			input: &api.ScalingPolicy{
+				ID: "id",
+				Target: map[string]string{
+					"key": "value",
+				},
+				Min: ptr.Int64ToPtr(1),
+				Max: 5,
+				Policy: map[string]interface{}{
+					keySource:   "source",
+					keyQuery:    "query",
+					keyCooldown: 5,
+					keyStrategy: []interface{}{
+						map[string]interface{}{
+							"name": "strategy",
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "policy.cooldown has wrong format",
+			input: &api.ScalingPolicy{
+				ID: "id",
+				Target: map[string]string{
+					"key": "value",
+				},
+				Min: ptr.Int64ToPtr(1),
+				Max: 5,
+				Policy: map[string]interface{}{
+					keySource:   "source",
+					keyQuery:    "query",
+					keyCooldown: "5 seconds",
+					keyStrategy: []interface{}{
+						map[string]interface{}{
+							"name": "strategy",
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -13,6 +13,7 @@ type Policy struct {
 	Source             string
 	Query              string
 	Enabled            bool
+	Cooldown           time.Duration
 	EvaluationInterval time.Duration
 	Target             *Target
 	Strategy           *Strategy


### PR DESCRIPTION
Cooldown is now supported within a scaling policy as a time
duration. If the scaling policy omits the cooldown field, a
default value will be used. The default value can be controlled
by the CLI and has a default value of 5mins.

In the event the agent successfully registers a scaling action,
the policy manager will be instructed to place the policy eval
handler in cooldown by updating the ticker to the cooldown time
duration. The ticker is reset to its eval time duration on the
first tick out of cooldown.

Target plugins can optionally return a meta entry to detail the
last scaling event from their prespective. This allows the
autoscaler to enforce cooldowns, even when scaling actions have
been triggered manually by operators. The flow is similar to that
mentioned above, the only difference being that the ticker update
is based on the calculated remaning cooldown time from the last
event timestamp.

closes #12