### PR TITLE
Skip disabled policies when monitoring policy list from Nomad

### DIFF
--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -100,9 +100,12 @@ func (s *Source) MonitorIDs(ctx context.Context, resultCh chan<- []policy.Policy
 
 			var policyIDs []policy.PolicyID
 
-			// Iterate all policies in the list.
+			// Iterate over all policies in the list and filter out policies
+			// that are not enabled.
 			for _, p := range policies {
-				policyIDs = append(policyIDs, policy.PolicyID(p.ID))
+				if p.Enabled {
+					policyIDs = append(policyIDs, policy.PolicyID(p.ID))
+				}
 			}
 
 			// Update the Nomad API wait index to start long polling from the


### PR DESCRIPTION
Small change to remove disabled policies from the list of IDs being monitored. This allows stopping unnecessary policy evaluations earlier and from outside the individual policy handler.