### PR TITLE
plugin: fix bug in ext. strategy plugins suggesting scale to zero.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -220,12 +220,12 @@ func (a *Agent) handlePolicy(p *policy.Policy) {
 
 		if currentStatus.Count < p.Min {
 			minMaxAction = &strategypkg.Action{
-				Count:  &p.Min,
+				Count:  p.Min,
 				Reason: fmt.Sprintf("current count (%d) below limit (%d)", currentStatus.Count, p.Min),
 			}
 		} else if currentStatus.Count > p.Max {
 			minMaxAction = &strategypkg.Action{
-				Count:  &p.Max,
+				Count:  p.Max,
 				Reason: fmt.Sprintf("current count (%d) above limit (%d)", currentStatus.Count, p.Max),
 			}
 		}
@@ -257,18 +257,18 @@ func (a *Agent) handlePolicy(p *policy.Policy) {
 			action.SetDryRun()
 		}
 
-		if action.Count == nil {
+		if action.Count == strategypkg.MetaValueDryRunCount {
 			actionLogger.Info("registering scaling event",
 				"count", currentStatus.Count, "reason", action.Reason, "meta", action.Meta)
 		} else {
 			// Skip action if count doesn't change.
-			if currentStatus.Count == *action.Count {
-				actionLogger.Info("nothing to do", "from", currentStatus.Count, "to", *action.Count)
+			if currentStatus.Count == action.Count {
+				actionLogger.Info("nothing to do", "from", currentStatus.Count, "to", action.Count)
 				continue
 			}
 
 			actionLogger.Info("scaling target",
-				"from", currentStatus.Count, "to", *action.Count,
+				"from", currentStatus.Count, "to", action.Count,
 				"reason", action.Reason, "meta", action.Meta)
 		}
 

--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -120,7 +120,7 @@ func (s *StrategyPlugin) Run(req strategy.RunRequest) (strategy.RunResponse, err
 	}
 
 	action := strategy.Action{
-		Count:  &newCount,
+		Count:  newCount,
 		Reason: fmt.Sprintf("scaling %s because factor is %f", direction, factor),
 	}
 	resp.Actions = append(resp.Actions, action)

--- a/plugins/builtin/strategy/target-value/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin_test.go
@@ -71,7 +71,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			expectedResp: strategy.RunResponse{Actions: []strategy.Action{
 				{
-					Count:  intToPointer(4),
+					Count:  4,
 					Reason: "scaling up because factor is 2.000000",
 				},
 			}},
@@ -87,7 +87,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			expectedResp: strategy.RunResponse{Actions: []strategy.Action{
 				{
-					Count:  intToPointer(2),
+					Count:  2,
 					Reason: "scaling up because factor is 2.000000",
 				},
 			}},
@@ -114,7 +114,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			expectedResp: strategy.RunResponse{Actions: []strategy.Action{
 				{
-					Count:  intToPointer(1),
+					Count:  1,
 					Reason: "scaling up because factor is 1.000000",
 				},
 			}},
@@ -130,7 +130,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			expectedResp: strategy.RunResponse{Actions: []strategy.Action{
 				{
-					Count:  intToPointer(0),
+					Count:  0,
 					Reason: "scaling down because factor is 0.000000",
 				},
 			}},
@@ -166,5 +166,3 @@ func TestStrategyPlugin_calculateDirection(t *testing.T) {
 		assert.Equal(t, tc.expectedOutput, s.calculateDirection(tc.inputCount, tc.inputFactor))
 	}
 }
-
-func intToPointer(i int64) *int64 { return &i }

--- a/plugins/builtin/target/nomad/plugin/plugin.go
+++ b/plugins/builtin/target/nomad/plugin/plugin.go
@@ -102,8 +102,8 @@ func (t *TargetPlugin) PluginInfo() (*base.PluginInfo, error) {
 // Scale satisfies the Scale function on the target.Target interface.
 func (t *TargetPlugin) Scale(action strategy.Action, config map[string]string) error {
 	var countIntPtr *int
-	if action.Count != nil {
-		countInt := int(*action.Count)
+	if action.Count != strategy.MetaValueDryRunCount {
+		countInt := int(action.Count)
 		countIntPtr = &countInt
 	}
 

--- a/plugins/strategy/action.go
+++ b/plugins/strategy/action.go
@@ -9,11 +9,22 @@ const (
 	metaKeyCountCapped   = "nomad_autoscaler.count.capped"
 	metaKeyCountOriginal = "nomad_autoscaler.count.original"
 	metaKeyReasonHistory = "nomad_autoscaler.reason_history"
+
+	// MetaValueDryRunCount is a special count value used when performing
+	// dry-run scaling activities. The Autoscaler will never set a count to a
+	// negative value during normal operation, so the agent is safe to assume a
+	// count set to this value implies dry-run.
+	MetaValueDryRunCount = -1
 )
 
 // Action represents a Strategy's intention to modify.
 type Action struct {
-	Count  *int64
+
+	// Count represents the desired count of the target resource. It should
+	// always be zero or above, expect in the event of dry-run where it can use
+	// the MetaValueDryRunCount value.
+	Count int64
+
 	Reason string
 	Error  bool
 	Meta   map[string]interface{}
@@ -31,20 +42,18 @@ func (a *Action) Canonicalize() {
 // count value.
 func (a *Action) SetDryRun() {
 	a.Meta[metaKeyDryRun] = true
-	if a.Count != nil {
-		a.Meta[metaKeyDryRunCount] = *a.Count
-	}
-	a.Count = nil
+	a.Meta[metaKeyDryRunCount] = a.Count
+	a.Count = MetaValueDryRunCount
 }
 
 // CapCount caps the value of Count so it remains within the specified limits.
-// If Count is nil this method has no effect.
+// If Count is MetaValueDryRunCount this method has no effect.
 func (a *Action) CapCount(min, max int64) {
-	if a.Count == nil {
+	if a.Count == MetaValueDryRunCount {
 		return
 	}
 
-	oldCount, newCount := *a.Count, *a.Count
+	oldCount, newCount := a.Count, a.Count
 	if newCount < min {
 		newCount = min
 	} else if newCount > max {
@@ -55,7 +64,7 @@ func (a *Action) CapCount(min, max int64) {
 		a.Meta[metaKeyCountCapped] = true
 		a.Meta[metaKeyCountOriginal] = oldCount
 		a.pushReason(fmt.Sprintf("capped count from %d to %d to stay within limits", oldCount, newCount))
-		a.Count = &newCount
+		a.Count = newCount
 	}
 }
 

--- a/plugins/strategy/action_test.go
+++ b/plugins/strategy/action_test.go
@@ -40,26 +40,17 @@ func TestAction_SetDryRun(t *testing.T) {
 	}{
 		{
 			inputAction: &Action{
-				Count: int64ToPointer(3),
+				Count: 3,
 				Meta:  map[string]interface{}{},
 			},
 			expectedOutputAction: &Action{
-				Count: nil,
+				Count: -1,
 				Meta: map[string]interface{}{
 					"nomad_autoscaler.dry_run":       true,
 					"nomad_autoscaler.dry_run.count": int64(3),
 				},
 			},
 			name: "count greater than zero",
-		},
-		{
-			inputAction: &Action{
-				Meta: map[string]interface{}{},
-			},
-			expectedOutputAction: &Action{
-				Count: nil,
-				Meta:  map[string]interface{}{"nomad_autoscaler.dry_run": true}},
-			name: "count not set",
 		},
 	}
 
@@ -88,13 +79,13 @@ func TestAction_CapCount(t *testing.T) {
 		},
 		{
 			inputAction: &Action{
-				Count: int64ToPointer(4),
+				Count: 4,
 				Meta:  map[string]interface{}{},
 			},
 			inputMin: 5,
 			inputMax: 10,
 			expectedOutputAction: &Action{
-				Count: int64ToPointer(5),
+				Count: 5,
 				Meta: map[string]interface{}{
 					"nomad_autoscaler.count.capped":   true,
 					"nomad_autoscaler.count.original": int64(4),
@@ -108,13 +99,13 @@ func TestAction_CapCount(t *testing.T) {
 		},
 		{
 			inputAction: &Action{
-				Count: int64ToPointer(15),
+				Count: 15,
 				Meta:  map[string]interface{}{},
 			},
 			inputMin: 5,
 			inputMax: 10,
 			expectedOutputAction: &Action{
-				Count: int64ToPointer(10),
+				Count: 10,
 				Meta: map[string]interface{}{
 					"nomad_autoscaler.count.capped":   true,
 					"nomad_autoscaler.count.original": int64(15),
@@ -128,13 +119,13 @@ func TestAction_CapCount(t *testing.T) {
 		},
 		{
 			inputAction: &Action{
-				Count: int64ToPointer(7),
+				Count: 7,
 				Meta:  map[string]interface{}{},
 			},
 			inputMin: 5,
 			inputMax: 10,
 			expectedOutputAction: &Action{
-				Count: int64ToPointer(7),
+				Count: 7,
 				Meta:  map[string]interface{}{},
 			},
 			name: "desired count doesn't break thresholds",
@@ -200,5 +191,3 @@ func TestAction_pushReason(t *testing.T) {
 		})
 	}
 }
-
-func int64ToPointer(i int64) *int64 { return &i }


### PR DESCRIPTION
The way in which stdlib encoding/gob works means a pointer to a
types default value will result in the RPC translation becoming
nil. This meant external strategy plugins were not able to suggest
scaling to zero, as the pointer to zero would be translated to nil
which inturn is classed as dry-run.

This change removes the use of a pointer for count within strategy
action struct. Allowing the use of zero to indicate scaling to
zero. Dry run situations use a special -1 count field, to indicate
a dry run workflow should be triggered.

closes #83 