### PR TITLE
cli: always use cli exit code when exiting main function.

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,6 @@ func main() {
 	exitCode, err := c.Run()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error executing CLI: %v\n", err)
-		os.Exit(1)
 	}
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
closes #129 