### PR TITLE
Re-connect to Nomad if connection is lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ IMPROVEMENTS:
  * plugin: use the logger rather than fmt.Print to output Prometheus query warnings [[GH-107](https://github.com/hashicorp/nomad-autoscaler/pull/107)]
 
 BUG FIXES:
+ * agent: fix issue where Nomad Autoscaler would fail to re-connect to Nomad [[GH-119](https://github.com/hashicorp/nomad-autoscaler/issues/119)]
  * plugin: fix Nomad APM bug when querying groups on multiple clients [[GH-125](https://github.com/hashicorp/nomad-autoscaler/pull/125)]
  * plugin: fix bug in external strategy plugins suggesting scale to zero [[GH-112](https://github.com/hashicorp/nomad-autoscaler/pull/122)]
 

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -94,6 +94,12 @@ func (s *Source) MonitorIDs(ctx context.Context, resultCh chan<- []policy.Policy
 				continue
 			}
 
+			// If the index has not changed, the query returned because the timeout
+			// was reached, therefore start the next query loop.
+			if !blocking.IndexHasChanged(meta.LastIndex, q.WaitIndex) {
+				continue
+			}
+
 			var policyIDs []policy.PolicyID
 
 			// Iterate over all policies in the list and filter out policies

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -94,12 +94,6 @@ func (s *Source) MonitorIDs(ctx context.Context, resultCh chan<- []policy.Policy
 				continue
 			}
 
-			// If the index has not changed, the query returned because the timeout
-			// was reached, therefore start the next query loop.
-			if !blocking.IndexHasChanged(meta.LastIndex, q.WaitIndex) {
-				continue
-			}
-
 			var policyIDs []policy.PolicyID
 
 			// Iterate over all policies in the list and filter out policies


### PR DESCRIPTION
This PR fixes an issue where the Autoscaler would fail to re-connect to the Nomad server if the connection was dropped.

The main cause for this issue is that the `policyIDsErrCh` was not being consumed, and so the goroutine monitoring the list of policy IDs would block in case of an error.

I also uncovered some more subtle ways that the Autoscaler could fail to re-connect properly:
* policy handlers would exit in case of connection error and never be re-created.
* the policy list ID monitor would silently `continue` if the Autoscler re-connected to a Nomad cluster where the list of policies were different but the modify index had the same value.

To fix these problems I made a few assumptions:
* Policy handlers only exit when their context is closed. They will keep looping even if an error occurs.
* The policy manager is responsible for stopping handlers in case of an [unrecoverable errors](https://github.com/hashicorp/nomad-autoscaler/pull/134/files#diff-bbdb50489b1a80cb45d42cf486e5870bR184-R193).
* The policy manager will re-run if it exists until its context is closed.

Closes #119 