### PR TITLE
Limit factor precision in target-value plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ IMPROVEMENTS:
  * cli: always use cli library exit code when exiting main function [[GH-130](https://github.com/hashicorp/nomad-autoscaler/pull/130)]
  * core: update Nomad API dependency to 0.11.2 [[GH-128](https://github.com/hashicorp/nomad-autoscaler/pull/128)]
  * plugins/prometheus: use the logger rather than fmt.Print to output Prometheus query warnings [[GH-107](https://github.com/hashicorp/nomad-autoscaler/pull/107)]
+ * plugins/target-value: add new policy configuration `precision` [[GH-132](https://github.com/hashicorp/nomad-autoscaler/issues/132)]
 
 BUG FIXES:
  * agent: fix issue where Nomad Autoscaler would fail to re-connect to Nomad [[GH-119](https://github.com/hashicorp/nomad-autoscaler/issues/119)]

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -87,7 +87,7 @@ policy {
 
     config = {
       target    = 20
-      precision = 0.0001
+      threshold = 0.0001
     }
   }
   ...
@@ -96,4 +96,4 @@ policy {
 ##### Policy configuration
 
 * `target` `(float: <required>)` - Specifies the metric value the Autscaler should try to meet.
-* `precision` `(float: 0.01)` - Specifies how significant a change in the input metric should be considered. Small precision values can lead to output fluctuation.
+* `threshold` `(float: 0.01)` - Specifies how significant a change in the input metric should be considered. Small threshold values can lead to output fluctuation.

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -86,7 +86,7 @@ policy {
     name = "target-value"
 
     config = {
-      target = 20
+      target    = 20
       precision = 0.0001
     }
   }

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -77,7 +77,7 @@ next_count = current_count * (metric_value / target)
 ```
 
 ##### Sample policy
-An example would be attempting to keep the number of active connections to a web server at 20 per instance of the application.  
+An example would be attempting to keep the number of active connections to a web server at 20 per instance of the application.
 
 ```hcl
 policy {
@@ -87,7 +87,13 @@ policy {
 
     config = {
       target = 20
+      precision = 0.0001
     }
   }
   ...
 ```
+
+##### Policy configuration
+
+* `target` `(float: <required>)` - Specifies the metric value the Autscaler should try to meet.
+* `precision` `(float: 0.01)` - Specifies how significant a change in the input metric should be considered. Small precision values can lead to output fluctuation.

--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -180,7 +180,7 @@ func (s *StrategyPlugin) calculateDirection(count int64, factor, e float64) scal
 		if factor > 0 {
 			return scaleDirectionUp
 		}
-		return scaleDirectionDown
+		return scaleDirectionNone
 	default:
 		if factor < (1 - e) {
 			return scaleDirectionDown

--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -18,11 +18,11 @@ const (
 
 	// These are the keys read from the RunRequest.Config map.
 	runConfigKeyTarget    = "target"
-	runConfigKeyPrecision = "precision"
+	runConfigKeyThreshold = "threshold"
 
-	// defaultPrecision controls how significant is a change in the input
+	// defaultThreshold controls how significant is a change in the input
 	// metric value.
-	defaultPrecision = "0.01"
+	defaultThreshold = "0.01"
 )
 
 var (
@@ -106,15 +106,15 @@ func (s *StrategyPlugin) Run(req strategy.RunRequest) (strategy.RunResponse, err
 		return resp, fmt.Errorf("invalid value for `target`: %v (%T)", t, t)
 	}
 
-	// Read and parse precision value from req.Config.
-	p := req.Config[runConfigKeyPrecision]
-	if p == "" {
-		p = defaultPrecision
+	// Read and parse threshold value from req.Config.
+	th := req.Config[runConfigKeyThreshold]
+	if th == "" {
+		th = defaultThreshold
 	}
 
-	precision, err := strconv.ParseFloat(p, 64)
+	threshold, err := strconv.ParseFloat(th, 64)
 	if err != nil {
-		return resp, fmt.Errorf("invalid value for `precision`: %v (%T)", p, p)
+		return resp, fmt.Errorf("invalid value for `threshold`: %v (%T)", th, th)
 	}
 
 	var factor float64
@@ -130,7 +130,7 @@ func (s *StrategyPlugin) Run(req strategy.RunRequest) (strategy.RunResponse, err
 	}
 
 	// Identify the direction of scaling, if any.
-	direction := s.calculateDirection(req.Count, factor, precision)
+	direction := s.calculateDirection(req.Count, factor, threshold)
 	if direction == scaleDirectionNone {
 		return resp, nil
 	}

--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -15,6 +15,14 @@ const (
 	// pluginName is the unique name of the this plugin amongst strategy
 	// plugins.
 	pluginName = "target-value"
+
+	// These are the keys read from the RunRequest.Config map.
+	runConfigKeyTarget    = "target"
+	runConfigKeyPrecision = "precision"
+
+	// defaultPrecision controls how significant is a change in the input
+	// metric value.
+	defaultPrecision = "0.01"
 )
 
 var (
@@ -43,6 +51,27 @@ type StrategyPlugin struct {
 	logger hclog.Logger
 }
 
+// scaleDirection is used to indicate if the resulting count should increase
+// (scale up), descrease (scale down), or stay the same (none).
+type scaleDirection int8
+
+const (
+	scaleDirectionUp scaleDirection = iota
+	scaleDirectionDown
+	scaleDirectionNone
+)
+
+func (d scaleDirection) String() string {
+	switch d {
+	case scaleDirectionUp:
+		return "up"
+	case scaleDirectionDown:
+		return "down"
+	default:
+		return ""
+	}
+}
+
 // NewTargetValuePlugin returns the TargetValue implementation of the
 // strategy.Strategy interface.
 func NewTargetValuePlugin(log hclog.Logger) strategy.Strategy {
@@ -66,7 +95,8 @@ func (s *StrategyPlugin) PluginInfo() (*base.PluginInfo, error) {
 func (s *StrategyPlugin) Run(req strategy.RunRequest) (strategy.RunResponse, error) {
 	resp := strategy.RunResponse{Actions: []strategy.Action{}}
 
-	t := req.Config["target"]
+	// Read and parse target value from req.Config.
+	t := req.Config[runConfigKeyTarget]
 	if t == "" {
 		return resp, fmt.Errorf("missing required field `target`")
 	}
@@ -74,6 +104,17 @@ func (s *StrategyPlugin) Run(req strategy.RunRequest) (strategy.RunResponse, err
 	target, err := strconv.ParseFloat(t, 64)
 	if err != nil {
 		return resp, fmt.Errorf("invalid value for `target`: %v (%T)", t, t)
+	}
+
+	// Read and parse precision value from req.Config.
+	p := req.Config[runConfigKeyPrecision]
+	if p == "" {
+		p = defaultPrecision
+	}
+
+	precision, err := strconv.ParseFloat(p, 64)
+	if err != nil {
+		return resp, fmt.Errorf("invalid value for `precision`: %v (%T)", p, p)
 	}
 
 	var factor float64
@@ -89,8 +130,8 @@ func (s *StrategyPlugin) Run(req strategy.RunRequest) (strategy.RunResponse, err
 	}
 
 	// Identify the direction of scaling, if any.
-	direction := s.calculateDirection(req.Count, factor)
-	if direction == "" {
+	direction := s.calculateDirection(req.Count, factor, precision)
+	if direction == scaleDirectionNone {
 		return resp, nil
 	}
 
@@ -131,23 +172,22 @@ func (s *StrategyPlugin) Run(req strategy.RunRequest) (strategy.RunResponse, err
 // occur, if any at all. It takes into account the current task group count in
 // order to correctly account for 0 counts.
 //
-// TODO(jrasell) the direction should probably be a type, rather than a plain
-// 	string so we don't have to return an empty string for no direction.
-func (s *StrategyPlugin) calculateDirection(count int64, factor float64) string {
+// The input factor value is padded by e, such that no action will be taken if
+// factor is within [1-e; 1+e].
+func (s *StrategyPlugin) calculateDirection(count int64, factor, e float64) scaleDirection {
 	switch count {
 	case 0:
 		if factor > 0 {
-			return "up"
-		} else {
-			return "down"
+			return scaleDirectionUp
 		}
+		return scaleDirectionDown
 	default:
-		if factor < 1 {
-			return "down"
-		} else if factor > 1 {
-			return "up"
+		if factor < (1 - e) {
+			return scaleDirectionDown
+		} else if factor > (1 + e) {
+			return scaleDirectionUp
 		} else {
-			return ""
+			return scaleDirectionNone
 		}
 	}
 }

--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -56,9 +56,9 @@ type StrategyPlugin struct {
 type scaleDirection int8
 
 const (
-	scaleDirectionUp scaleDirection = iota
+	scaleDirectionNone scaleDirection = iota
+	scaleDirectionUp
 	scaleDirectionDown
-	scaleDirectionNone
 )
 
 func (d scaleDirection) String() string {

--- a/plugins/builtin/strategy/target-value/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin_test.go
@@ -54,10 +54,10 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		{
 			inputReq: strategy.RunRequest{
 				PolicyID: "test-policy",
-				Config:   map[string]string{"target": "0", "precision": "not-the-float-you're-looking-for"},
+				Config:   map[string]string{"target": "0", "threshold": "not-the-float-you're-looking-for"},
 			},
 			expectedResp:  strategy.RunResponse{Actions: []strategy.Action{}},
-			expectedError: fmt.Errorf("invalid value for `precision`: not-the-float-you're-looking-for (string)"),
+			expectedError: fmt.Errorf("invalid value for `threshold`: not-the-float-you're-looking-for (string)"),
 			name:          "incorrect input config target value",
 		},
 		{
@@ -160,7 +160,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		{
 			inputReq: strategy.RunRequest{
 				PolicyID: "test-policy",
-				Config:   map[string]string{"target": "5", "precision": "0.000001"},
+				Config:   map[string]string{"target": "5", "threshold": "0.000001"},
 				Metric:   5.00001,
 				Count:    8,
 			},
@@ -171,7 +171,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 				},
 			}},
 			expectedError: nil,
-			name:          "scale up on small changes if precision is small",
+			name:          "scale up on small changes if threshold is small",
 		},
 	}
 
@@ -188,22 +188,22 @@ func TestStrategyPlugin_calculateDirection(t *testing.T) {
 	testCases := []struct {
 		inputCount     int64
 		inputFactor    float64
-		precision      float64
+		threshold      float64
 		expectedOutput scaleDirection
 	}{
 		{inputCount: 0, inputFactor: 1, expectedOutput: scaleDirectionUp},
 		{inputCount: 5, inputFactor: 1, expectedOutput: scaleDirectionNone},
 		{inputCount: 4, inputFactor: 0.5, expectedOutput: scaleDirectionDown},
 		{inputCount: 5, inputFactor: 2, expectedOutput: scaleDirectionUp},
-		{inputCount: 5, inputFactor: 1.0001, precision: 0.01, expectedOutput: scaleDirectionNone},
-		{inputCount: 5, inputFactor: 1.02, precision: 0.01, expectedOutput: scaleDirectionUp},
-		{inputCount: 5, inputFactor: 0.99, precision: 0.01, expectedOutput: scaleDirectionNone},
-		{inputCount: 5, inputFactor: 0.98, precision: 0.01, expectedOutput: scaleDirectionDown},
+		{inputCount: 5, inputFactor: 1.0001, threshold: 0.01, expectedOutput: scaleDirectionNone},
+		{inputCount: 5, inputFactor: 1.02, threshold: 0.01, expectedOutput: scaleDirectionUp},
+		{inputCount: 5, inputFactor: 0.99, threshold: 0.01, expectedOutput: scaleDirectionNone},
+		{inputCount: 5, inputFactor: 0.98, threshold: 0.01, expectedOutput: scaleDirectionDown},
 	}
 
 	s := &StrategyPlugin{}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedOutput, s.calculateDirection(tc.inputCount, tc.inputFactor, tc.precision))
+		assert.Equal(t, tc.expectedOutput, s.calculateDirection(tc.inputCount, tc.inputFactor, tc.threshold))
 	}
 }


### PR DESCRIPTION
This PR introduces the `precision` key for a `RunRequest.Config` for the `target-value` plugin.  `precision` limits how big of a change in the input metric should be considered significant to trigger a scaling event. It also includes small refactorings to improve the `target-value` plugin code.

I set the default precision as `0.01` as a guesstimate. It means the metric needs to change more that 1% of the target value in order for a scale up action to happen. Scaling down is a little higher because we use `math.Ceil` when calculating the next count, so `precision` doesn't affect it as much.

Closes #132 