### PR TITLE
agent: only enter out-of-bounds cooldown if time greater than 1s.

### DIFF
--- a/policy/handler.go
+++ b/policy/handler.go
@@ -15,6 +15,10 @@ import (
 	targetpkg "github.com/hashicorp/nomad-autoscaler/plugins/target"
 )
 
+const (
+	cooldownIgnoreTime = 1 * time.Second
+)
+
 // Handler monitors a policy for changes and controls when them are sent for
 // evaluation.
 type Handler struct {
@@ -202,10 +206,11 @@ func (h *Handler) handleTick(ctx context.Context, policy *Policy) (*Evaluation, 
 		return eval, nil
 	}
 
-	// Calculate the remaining time period left on the cooldown. If this is 0
-	// or below, we do not need to enter cooldown.
+	// Calculate the remaining time period left on the cooldown. If this is
+	// cooldownIgnoreTime or below, we do not need to enter cooldown. Reasoning
+	// on ignoring small variations can be seen within GH-138.
 	cdPeriod := h.calculateRemainingCooldown(policy.Cooldown, curTime, int64(lastTS))
-	if cdPeriod <= 0 {
+	if cdPeriod <= cooldownIgnoreTime {
 		return eval, nil
 	}
 


### PR DESCRIPTION
Even on local setups, the network traversal when calling for task
group scaling meant the policy handler would exit cooldown and
re-enter for roughly 50ms based on the external last event check.

This seems over zealous so the handler now checks any remaining
cooldown against a default threshold of 1 second. If the remaining
cooldown is less than a second, the handler will not enter cooldown
and continue with normal operations.

The second value was chosen as any less seems to be worthless;
anything higher could impact certain configurations more than
desired.

closes #138 