### PR TITLE
Small demo improvements

### DIFF
--- a/demo/vagrant/jobs/grafana.nomad
+++ b/demo/vagrant/jobs/grafana.nomad
@@ -22,7 +22,7 @@ job "grafana" {
         volumes = [
           "local/datasources:/etc/grafana/provisioning/datasources",
           "local/dashboards:/etc/grafana/provisioning/dashboards",
-          "local/dashboards/src:/var/lib/grafana/dashboards",
+          "/home/vagrant/nomad-autoscaler/files:/var/lib/grafana/dashboards",
         ]
       }
 
@@ -64,12 +64,6 @@ providers:
 EOH
 
         destination = "local/dashboards/nomad-autoscaler.yaml"
-      }
-
-      artifact {
-        source      = "https://raw.githubusercontent.com/hashicorp/nomad-autoscaler/master/demo/vagrant/files/dashboard.json"
-        destination = "local/dashboards/src/nomad-autoscaler.json"
-        mode        = "file"
       }
 
       volume_mount {

--- a/demo/vagrant/jobs/webapp.nomad
+++ b/demo/vagrant/jobs/webapp.nomad
@@ -10,8 +10,9 @@ job "webapp" {
       max     = 20
 
       policy {
-        source = "prometheus"
-        query  = "scalar(avg((haproxy_server_current_sessions{backend=\"http_back\"}) and (haproxy_server_up{backend=\"http_back\"} == 1)))"
+        source   = "prometheus"
+        query    = "scalar(avg((haproxy_server_current_sessions{backend=\"http_back\"}) and (haproxy_server_up{backend=\"http_back\"} == 1)))"
+        cooldown = "20s"
 
         strategy = {
           name = "target-value"


### PR DESCRIPTION
This PR adds a short `cooldown` value to that webapp scaling policy to avoid having to wait the default 5 minutes for the count to return to 1 once `hey` stops.

It also loads the built-in Grafana dashboard from a Docker volume rather than having to download it from the Internet. This removes the need to point to a different GitHub URL when making changes to the dashboard.