### PR TITLE
turning exposed meta information into labels

### DIFF
--- a/demo/vagrant/files/dashboard.json
+++ b/demo/vagrant/files/dashboard.json
@@ -6,7 +6,7 @@
         "builtIn": 1,
         "datasource": "Loki",
         "enable": true,
-        "expr": "{job=\"autoscaler\"} |= \"scaling target\"",
+        "expr": "{task=\"autoscaler\"} |= \"scaling target\"",
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "limit": 100,

--- a/demo/vagrant/jobs/autoscaler.nomad
+++ b/demo/vagrant/jobs/autoscaler.nomad
@@ -121,8 +121,22 @@ scrape_configs:
   - targets:
       - localhost
     labels:
-      job: autoscaler
+      task: autoscaler
       __path__: /alloc/logs/autoscaler*
+  pipeline_stages:
+  - match:
+      selector: '{task="autoscaler"}'
+      stages:
+      - regex:
+          expression: '.*policy_id=(?P<policy_id>[a-zA-Z0-9_-]+).*source=(?P<source>[a-zA-Z0-9_-]+).*strategy=(?P<strategy>[a-zA-Z0-9_-]+).*target=(?P<target>[a-zA-Z0-9_-]+).*Group:(?P<group>[a-zA-Z0-9]+).*Job:(?P<job>[a-zA-Z0-9_-]+).*Namespace:(?P<namespace>[a-zA-Z0-9_-]+)'
+      - labels:
+          policy_id:
+          source:
+          strategy:
+          target:
+          group:
+          job:
+          namespace:
 EOH
 
         destination = "local/promtail.yaml"


### PR DESCRIPTION
![no_labels](https://user-images.githubusercontent.com/163633/83068582-de9b8b00-a068-11ea-87cf-fd556ed22d07.png)
![with_labels](https://user-images.githubusercontent.com/163633/83068583-df342180-a068-11ea-9d63-b0f534911119.png)

I refactored the promtail config a bit to turn most of the key value pairs into loki labels, which can be used easily in (future) queries.