### PR TITLE
Fix reason stack to avoid overwriting previous reason

### DIFF
--- a/plugins/strategy/action.go
+++ b/plugins/strategy/action.go
@@ -80,6 +80,9 @@ func (a *Action) pushReason(r string) {
 	}
 
 	// Append current reason to history and update action.
-	a.Meta[metaKeyReasonHistory] = append(history, a.Reason)
+	if a.Reason != "" {
+		history = append(history, a.Reason)
+	}
+	a.Meta[metaKeyReasonHistory] = history
 	a.Reason = r
 }

--- a/plugins/strategy/action.go
+++ b/plugins/strategy/action.go
@@ -80,6 +80,6 @@ func (a *Action) pushReason(r string) {
 	}
 
 	// Append current reason to history and update action.
-	a.Reason = r
 	a.Meta[metaKeyReasonHistory] = append(history, a.Reason)
+	a.Reason = r
 }


### PR DESCRIPTION
The current implementation of `pushReason` updates the action before pushing the action's reason into the stack. This causes the previous reason to be lost.

<img width="493" alt="image" src="https://user-images.githubusercontent.com/775380/83427901-78fc2580-a3ff-11ea-881a-d0fc6b73db9d.png">

In the screenshot above, the event at the top has the right stack, while the event at the bottom has the current, wrong stack logic.