### PR TITLE
plugin/target: allow operators to limit the amount of change.

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,166 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/nomad-autoscaler/plugins/strategy"
+	"github.com/hashicorp/nomad-autoscaler/plugins/target"
+	"github.com/hashicorp/nomad-autoscaler/policy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgent_enforceActionLimits(t *testing.T) {
+	testCases := []struct {
+		inputPolicy          *policy.Policy
+		inputAction          strategy.Action
+		inputStatus          *target.Status
+		expectedOutputAction strategy.Action
+		expectedOutputError  error
+		name                 string
+	}{
+		{
+			inputPolicy: &policy.Policy{
+				Min: 2,
+				Max: 20,
+				Target: &policy.Target{
+					Config: map[string]string{"max_change": "4"},
+				},
+			},
+			inputAction: strategy.Action{
+				Count:  21,
+				Reason: "",
+				Error:  false,
+				Meta:   map[string]interface{}{},
+			},
+			inputStatus: &target.Status{Count: 15},
+			expectedOutputAction: strategy.Action{
+				Count:  19,
+				Reason: "modified desired count from 20 to 19 to limit change to 4",
+				Error:  false,
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.count.capped":   true,
+					"nomad_autoscaler.count.original": int64(21),
+					"nomad_autoscaler.reason_history": []string{
+						"capped count from 21 to 20 to stay within limits",
+					},
+				},
+			},
+			expectedOutputError: nil,
+			name:                "desired count capped and change limited",
+		},
+		{
+			inputPolicy: &policy.Policy{
+				Min: 2,
+				Max: 20,
+				Target: &policy.Target{
+					Config: map[string]string{"max_change": "4"},
+				},
+			},
+			inputAction: strategy.Action{
+				Count:  21,
+				Reason: "",
+				Error:  false,
+				Meta:   map[string]interface{}{},
+			},
+			inputStatus: &target.Status{Count: 19},
+			expectedOutputAction: strategy.Action{
+				Count:  20,
+				Reason: "capped count from 21 to 20 to stay within limits",
+				Error:  false,
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.count.capped":   true,
+					"nomad_autoscaler.count.original": int64(21),
+					"nomad_autoscaler.reason_history": []string{},
+				},
+			},
+			expectedOutputError: nil,
+			name:                "desired count capped only",
+		},
+		{
+			inputPolicy: &policy.Policy{
+				Min: 2,
+				Max: 20,
+				Target: &policy.Target{
+					Config: map[string]string{"max_change": "5"},
+				},
+			},
+			inputAction: strategy.Action{
+				Count:  20,
+				Reason: "",
+				Error:  false,
+				Meta:   map[string]interface{}{},
+			},
+			inputStatus: &target.Status{Count: 10},
+			expectedOutputAction: strategy.Action{
+				Count:  15,
+				Reason: "modified desired count from 20 to 15 to limit change to 5",
+				Error:  false,
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.count.original": int64(20),
+					"nomad_autoscaler.reason_history": []string{},
+				},
+			},
+			expectedOutputError: nil,
+			name:                "desired count limited only",
+		},
+		{
+			inputPolicy: &policy.Policy{
+				Min: 2,
+				Max: 20,
+				Target: &policy.Target{
+					Config: map[string]string{"max_change": "3"},
+				},
+			},
+			inputAction: strategy.Action{
+				Count:  20,
+				Reason: "",
+				Error:  false,
+				Meta:   map[string]interface{}{},
+			},
+			inputStatus: &target.Status{Count: 18},
+			expectedOutputAction: strategy.Action{
+				Count:  20,
+				Reason: "",
+				Error:  false,
+				Meta:   map[string]interface{}{},
+			},
+			expectedOutputError: nil,
+			name:                "no enforcement required",
+		},
+		{
+			inputPolicy: &policy.Policy{
+				Min: 2,
+				Max: 20,
+				Target: &policy.Target{
+					Config: map[string]string{"max_change": "three"},
+				},
+			},
+			inputAction: strategy.Action{
+				Count:  20,
+				Reason: "",
+				Error:  false,
+				Meta:   map[string]interface{}{},
+			},
+			inputStatus: &target.Status{Count: 18},
+			expectedOutputAction: strategy.Action{
+				Count:  20,
+				Reason: "",
+				Error:  false,
+				Meta:   map[string]interface{}{},
+			},
+			expectedOutputError: errors.New("failed to convert max_change value to int64: strconv.ParseInt: parsing \"three\": invalid syntax"),
+			name:                "incorrectly formatted max_change parameter",
+		},
+	}
+
+	a := Agent{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualError := a.enforceActionLimits(tc.inputPolicy, &tc.inputAction, tc.inputStatus)
+			assert.Equal(t, tc.expectedOutputError, actualError, tc.name)
+			assert.Equal(t, tc.expectedOutputAction, tc.inputAction, tc.name)
+		})
+	}
+}

--- a/plugins/target/target.go
+++ b/plugins/target/target.go
@@ -21,11 +21,18 @@ type Status struct {
 	Meta  map[string]string
 }
 
-// MetaKeyLastEvent is an optional meta key that can be added to the status
-// return. The value represents the last scaling event of the target as seen by
-// the remote providers view point. This helps enforce cooldown where
-// out-of-band scaling activities have been triggered.
-const MetaKeyLastEvent = "nomad_autoscaler.last_event"
+const (
+	// MetaKeyLastEvent is an optional meta key that can be added to the status
+	// return. The value represents the last scaling event of the target as
+	// seen by the remote providers view point. This helps enforce cooldown
+	// where out-of-band scaling activities have been triggered.
+	MetaKeyLastEvent = "nomad_autoscaler.last_event"
+
+	// ConfigKeyMaxChange is the optional target config parameter that
+	// operators can use to limit the change the autoscaler makes in a single
+	// evaluation.
+	ConfigKeyMaxChange = "max_change"
+)
 
 // RPC is a plugin implementation that talks over net/rpc
 type RPC struct {


### PR DESCRIPTION
Currently there is no method to limit the amount of change made in
a single evaluation. The only enforcements made are to ensure the
lower and upper limits are never breached. This change introduces
an optional target config parameter "max_change" which can limit
the maximum change in count actioned during a single evaluation.

Docs and CHANGELOG.md entry to come in follow up PR.

closes #149 