### PR TITLE
Fix error when loading external plugins

### DIFF
--- a/plugins/manager/external.go
+++ b/plugins/manager/external.go
@@ -15,12 +15,18 @@ func (pm *PluginManager) loadExternalPlugin(cfg *config.Plugin, pluginType strin
 	info := &pluginInfo{
 		args:    cfg.Args,
 		config:  cfg.Config,
-		exePath: filepath.Join(pm.pluginDir, cleanPluginExecutable(cfg.Name)),
+		exePath: filepath.Join(pm.pluginDir, cleanPluginExecutable(cfg.Driver)),
 	}
 
 	// Add the plugin.
+	pluginID := plugins.PluginID{
+		Name:       cfg.Name,
+		Driver:     cfg.Driver,
+		PluginType: pluginType,
+	}
+
 	pm.pluginsLock.Lock()
-	pm.plugins[plugins.PluginID{Name: cfg.Name, PluginType: pluginType}] = info
+	pm.plugins[pluginID] = info
 	pm.pluginsLock.Unlock()
 
 }

--- a/plugins/manager/manager.go
+++ b/plugins/manager/manager.go
@@ -242,7 +242,7 @@ func (pm *PluginManager) pluginLaunchCheck(id plugins.PluginID, raw interface{})
 	// has returned its metadata that is different to the configured. This is a
 	// problem, particularly in the PluginType sense as it means it will be
 	// unable to fulfill its role.
-	if pluginInfo.Name != id.Name || pluginInfo.PluginType != id.PluginType {
+	if pluginInfo.Name != id.Driver || pluginInfo.PluginType != id.PluginType {
 		return nil, fmt.Errorf("plugin %s remote info doesn't match local config: %v", id.Name, err)
 	}
 

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -64,6 +64,7 @@ type InternalPluginConfig struct{ Factory PluginFactory }
 // within PluginInfo, but will not include all.
 type PluginID struct {
 	Name       string
+	Driver     string
 	PluginType string
 }
 


### PR DESCRIPTION
`cfg.Name` is the name of the block, but we need the name of the binary when starting the plugin, which is stored in the `driver` field:

```hcl
apm "name" {
  driver = "actual-binary-name"
}
```