### PR TITLE
helper: add scaleutils to provide cluster scale in helper tasks.

### DIFF
--- a/helper/scaleutils/filter.go
+++ b/helper/scaleutils/filter.go
@@ -1,0 +1,99 @@
+package scaleutils
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+// NodeIDMap provides a mapping between the Nomad ID of a node and its remote
+// infrastructure provider specific ID.
+type NodeIDMap struct {
+	NomadID, RemoteID string
+}
+
+// IdentifierKey is the identifier to group nodes into a pool of resource and
+// thus forms the scalable object.
+type IdentifierKey string
+
+// IdentifierKeyClass uses the Node.Class field to identify nodes into pools of
+// resource. This is the default.
+const IdentifierKeyClass IdentifierKey = "class"
+
+// RemoteProvider is infrastructure provider which hosts and therefore manages
+// the Nomad client instances. This is used to understand how to translate the
+// Nomad NodeID to an ID that the provider understands.
+type RemoteProvider string
+
+// RemoteProviderAWS is the Amazon Web Services remote provider. This provider
+// will use the node attribute as defined by nodeAttrAWSInstanceID to perform
+// ID translation.
+const RemoteProviderAWS RemoteProvider = "aws"
+
+// NodeIDStrategy is the strategy used to identify nodes for removal as part of
+// scaling in.
+type NodeIDStrategy string
+
+// IDStrategyNewestCreateIndex uses the Nomad Nodes().List() output in the
+// order it is presented. This means we do not need additional sorting and thus
+// it is fastest. In an environment that uses bin-packing this may also be
+// preferable as nodes with older create indexes are expected to be most
+// packed.
+const IDStrategyNewestCreateIndex NodeIDStrategy = "newest_create_index"
+
+// nodeAttrAWSInstanceID is the node attribute to use when identifying the
+// AWS instanceID of a node.
+const nodeAttrAWSInstanceID = "unique.platform.aws.instance-id"
+
+// defaultClassIdentifier is the class used for nodes which have an empty class
+// parameter when using the IdentifierKeyClass.
+const defaultClassIdentifier = "autoscaler-default-pool"
+
+// filterByClass returns a filtered list of nodes which are active in the
+// cluster and where the specified class matches that of the nodes.
+func filterByClass(n []*api.NodeListStub, id string) []*api.NodeListStub {
+
+	// Create our output list object.
+	var out []*api.NodeListStub
+
+	for _, node := range n {
+
+		// Ignore nodes that are not in a ready state.
+		if node.Status != api.NodeStatusReady {
+			continue
+		}
+
+		// Ignore nodes that are not currently eligible.
+		if node.SchedulingEligibility != api.NodeSchedulingEligible {
+			continue
+		}
+
+		if node.Drain {
+			continue
+		}
+
+		// Perform the node class check. We ensure an empty class is treated as
+		// the default value.
+		if node.NodeClass != "" && node.NodeClass == id ||
+			node.NodeClass == "" && id == defaultClassIdentifier {
+			out = append(out, node)
+		}
+	}
+
+	return out
+}
+
+// nodeIDMapFunc is the function signature used to find the Nomad nodes remote
+// identifier. Specific implementations can be found below.
+type nodeIDMapFunc func(n *api.Node) (string, error)
+
+// awsNodeIDMap is used to identify the AWS InstanceID of a Nomad node using
+// the relevant attribute value.
+func awsNodeIDMap(n *api.Node) (string, error) {
+	var err error
+	val, ok := n.Attributes[nodeAttrAWSInstanceID]
+	if !ok {
+		err = fmt.Errorf("attribute %q not found", nodeAttrAWSInstanceID)
+	}
+	return val, err
+}

--- a/helper/scaleutils/filter_test.go
+++ b/helper/scaleutils/filter_test.go
@@ -1,0 +1,187 @@
+package scaleutils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_filterByClass(t *testing.T) {
+	testCases := []struct {
+		inputNodeList      []*api.NodeListStub
+		inputID            string
+		expectedOutputList []*api.NodeListStub
+		name               string
+	}{
+		{
+			inputNodeList: []*api.NodeListStub{
+				{
+					ID:                    "super-test-class-1",
+					NodeClass:             "super-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "super-test-class-2",
+					NodeClass:             "super-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusDown,
+				},
+				{
+					ID:                    "super-test-class-3",
+					NodeClass:             "super-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "worst-test-class-1",
+					NodeClass:             "worst-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "worst-test-class-2",
+					NodeClass:             "worst-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "no-test-class-2",
+					NodeClass:             "",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			inputID: "super-test-class",
+			expectedOutputList: []*api.NodeListStub{
+				{
+					ID:                    "super-test-class-1",
+					NodeClass:             "super-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "super-test-class-3",
+					NodeClass:             "super-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			name: "complex filter of multiclass input for named class",
+		},
+		{
+			inputNodeList: []*api.NodeListStub{
+				{
+					ID:                    "super-test-class-1",
+					NodeClass:             "super-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "super-test-class-2",
+					NodeClass:             "super-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusDown,
+				},
+				{
+					ID:                    "super-test-class-3",
+					NodeClass:             "super-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "worst-test-class-1",
+					NodeClass:             "worst-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "worst-test-class-2",
+					NodeClass:             "worst-test-class",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "no-test-class-1",
+					NodeClass:             "",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			inputID: "autoscaler-default-pool",
+			expectedOutputList: []*api.NodeListStub{
+				{
+					ID:                    "no-test-class-1",
+					NodeClass:             "",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			name: "complex filter of multiclass input for default class",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := filterByClass(tc.inputNodeList, tc.inputID)
+			assert.Equal(t, tc.expectedOutputList, actualOutput, tc.name)
+		})
+	}
+
+}
+
+func Test_awsNodeIDMap(t *testing.T) {
+	testCases := []struct {
+		inputNode            *api.Node
+		expectedOutputString string
+		expectedOutputError  error
+		name                 string
+	}{
+		{
+			inputNode: &api.Node{
+				ID: "8a3025c6-5739-5563-f5e2-46000113646a",
+				Attributes: map[string]string{
+					"unique.platform.aws.instance-id": "i-1234567890abcdef0",
+				},
+			},
+			expectedOutputString: "i-1234567890abcdef0",
+			expectedOutputError:  nil,
+			name:                 "attribute found",
+		},
+
+		{
+			inputNode: &api.Node{
+				ID:         "8a3025c6-5739-5563-f5e2-46000113646a",
+				Attributes: map[string]string{},
+			},
+			expectedOutputString: "",
+			expectedOutputError:  errors.New("attribute \"unique.platform.aws.instance-id\" not found"),
+			name:                 "attribute not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualString, actualError := awsNodeIDMap(tc.inputNode)
+			assert.Equal(t, tc.expectedOutputString, actualString, tc.name)
+			assert.Equal(t, tc.expectedOutputError, actualError, tc.name)
+		})
+	}
+}

--- a/helper/scaleutils/nomad.go
+++ b/helper/scaleutils/nomad.go
@@ -1,0 +1,260 @@
+package scaleutils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/api"
+)
+
+type ScaleIn struct {
+	log   hclog.Logger
+	nomad *api.Client
+}
+
+// PoolIdentifier is the information used to identify nodes into pools of
+// resources. This then forms our scalable unit.
+type PoolIdentifier struct {
+	IdentifierKey IdentifierKey
+	Value         string
+}
+
+// NewScaleInUtils returns a new ScaleIn implementation which provides helper
+// functions for performing scaling in operations.
+func NewScaleInUtils(cfg *api.Config, log hclog.Logger) (*ScaleIn, error) {
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to instantiate Nomad client: %v", err)
+	}
+
+	return &ScaleIn{
+		log:   log,
+		nomad: client,
+	}, nil
+}
+
+// RunPreScaleInTasks helps tie together all the tasks required prior to
+// scaling in Nomad nodes, and thus terminating the server in the remote
+// provider.
+func (si *ScaleIn) RunPreScaleInTasks(ctx context.Context, req *ScaleInReq) ([]NodeIDMap, error) {
+
+	if err := req.validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate request: %v", err)
+	}
+
+	nodes, err := si.identifyTargets(req.Num, req.PoolIdentifier, req.NodeIDStrategy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to identify nodes for removal: %v", err)
+	}
+
+	// Technically we do not need this information until after the nodes have
+	// been drained. However, this doesn't change cluster state and so do this
+	// first to make sure there are no issues in translating.
+	nodeIDMap, err := si.getRemoteIDMap(nodes, req.RemoteProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we have not been able to identify any nodes and get their remote
+	// provider ID we cannot continue.
+	if len(nodeIDMap) == 0 {
+		return nil, errors.New("failed to identify nodes for removal")
+	}
+
+	if err := si.drainNodes(ctx, req.DrainDeadline, nodeIDMap); err != nil {
+		return nil, err
+	}
+
+	return nodeIDMap, nil
+}
+
+// identifyTargets filters the current Nomad cluster node list and then sorts
+// and selects nodes for removal based on the specified strategy. It is
+// possible the list does not contain any many nodes as requested do to the
+// limited number available after filtering.
+func (si *ScaleIn) identifyTargets(num int, ident *PoolIdentifier, strategy NodeIDStrategy) ([]*api.NodeListStub, error) {
+
+	// Pull a current list of Nomad nodes from the API.
+	nodes, _, err := si.nomad.Nodes().List(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Nomad nodes from API: %v", err)
+	}
+
+	// Filter the node list depending on what pool identifier we are using.
+	si.log.Debug("filtering node list", "filter", ident.IdentifierKey, "value", ident.Value)
+
+	switch ident.IdentifierKey {
+	case IdentifierKeyClass:
+		si.log.Debug("filtering node list by class", "class", ident.Value)
+		nodes = filterByClass(nodes, ident.Value)
+	default:
+		return nil, fmt.Errorf("unsupported node pool identifier: %q", ident.IdentifierKey)
+	}
+
+	// Ensure we have not filtered out all the available nodes.
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no nodes unfiltered for %s with value %s", ident.IdentifierKey, ident.Value)
+	}
+
+	// Identify the strategy we are using to pick nodes for scale in and
+	// perform our list sorting.
+	switch strategy {
+	case IDStrategyNewestCreateIndex:
+	default:
+		return nil, fmt.Errorf("unsupported scale in node identification strategy: %q", strategy)
+	}
+
+	// If the caller has requested more nodes than we have available once
+	// filtered, adjust the value. This shouldn't cause the whole scaling
+	// action to fail, but we should warn.
+	if num > len(nodes) {
+		si.log.Warn("can only identify portion of requested nodes for removal",
+			"requested", num, "available", len(nodes))
+		num = len(nodes)
+	}
+
+	var out []*api.NodeListStub
+
+	// Iterate through our filtered and sorted list of nodes, selecting the
+	// required number of nodes to scale in.
+	for i := 0; i <= num-1; i++ {
+		si.log.Debug("identified Nomad node for removal", "node_id", nodes[i].ID)
+		out = append(out, nodes[i])
+	}
+
+	return out, nil
+}
+
+func (si *ScaleIn) getRemoteIDMap(nodes []*api.NodeListStub, remoteProvider RemoteProvider) ([]NodeIDMap, error) {
+
+	var idFunc nodeIDMapFunc
+
+	// Depending on the remote provider we are targeting, identify the function
+	// we need to use.
+	switch remoteProvider {
+	case RemoteProviderAWS:
+		idFunc = awsNodeIDMap
+	default:
+		return nil, fmt.Errorf("unsupported remote provider: %q", remoteProvider)
+	}
+
+	var (
+		out  []NodeIDMap
+		mErr *multierror.Error
+	)
+
+	for _, node := range nodes {
+
+		// Read the full node object from the API which will contain the full
+		// information required to identify the remote provider ID.
+		nodeInfo, _, err := si.nomad.Nodes().Info(node.ID, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		// Use the identification function to attempt to pull the remote
+		// provider ID information from the Node info.
+		id, err := idFunc(nodeInfo)
+		if err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+
+		// Add a nice log message for the operators so they can see the node
+		// that has been identified if they wish.
+		si.log.Debug("identified remote provider ID for node",
+			"node_id", nodeInfo.ID, "remote_id", id)
+
+		out = append(out, NodeIDMap{NomadID: node.ID, RemoteID: id})
+	}
+
+	return out, mErr.ErrorOrNil()
+}
+
+// drainNodes iterates the provides nodeID list and performs a drain on each
+// one.
+func (si *ScaleIn) drainNodes(ctx context.Context, deadline time.Duration, nodes []NodeIDMap) error {
+
+	// Define a WaitGroup. This allows us to trigger each node drain in a go
+	// routine and then wait for them all to complete before exiting.
+	var wg sync.WaitGroup
+
+	// All nodes to be drained form part of a pool of resource and all should
+	// use the same DrainSpec.
+	drainSpec := api.DrainSpec{Deadline: deadline}
+
+	// Define an error to collect errors from each drain routine.
+	var result error
+
+	for _, node := range nodes {
+
+		// Increment our WaitGroup delta.
+		wg.Add(1)
+
+		// Assign our node to a local variable as we are launching a go routine
+		// from within a for loop.
+		n := node
+
+		// Launch a routine to drain the node. Append any error returned to the
+		// error.
+		go func() {
+			if err := si.drainNode(ctx, &wg, n.NomadID, &drainSpec); err != nil {
+				result = multierror.Append(result, err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	return result
+}
+
+// drainNode triggers a drain on the supplied ID using the DrainSpec. The
+// function handles monitoring the drain and reporting its terminal status to
+// the caller.
+func (si *ScaleIn) drainNode(ctx context.Context, wg *sync.WaitGroup, nodeID string, spec *api.DrainSpec) error {
+
+	si.log.Info("triggering drain on node", "node_id", nodeID, "deadline", spec.Deadline)
+
+	// Ensure we call done on the WaitGroup to decrement the count remaining.
+	defer wg.Done()
+
+	// Update the drain on the node.
+	resp, err := si.nomad.Nodes().UpdateDrain(nodeID, spec, false, nil)
+	if err != nil {
+		return fmt.Errorf("failed to drain node: %v", err)
+	}
+
+	// Monitor the drain so we output the log messages. An error here indicates
+	// the drain failed to complete successfully.
+	if err := si.monitorNodeDrain(ctx, nodeID, resp.LastIndex); err != nil {
+		return fmt.Errorf("context done while monitoring node drain: %v", err)
+	}
+	return nil
+}
+
+// monitorNodeDrain follows the drain of a node, logging the messages we
+// receive to their appropriate level.
+//
+// TODO(jrasell): currently the ignoreSys param is hardcoded to false, we will
+//  probably want to expose this to operators in the future.
+func (si *ScaleIn) monitorNodeDrain(ctx context.Context, nodeID string, index uint64) error {
+	for msg := range si.nomad.Nodes().MonitorDrain(ctx, nodeID, index, false) {
+		switch msg.Level {
+		case api.MonitorMsgLevelInfo:
+			si.log.Info("received node drain message", "node_id", nodeID, "msg", msg)
+		case api.MonitorMsgLevelWarn:
+			si.log.Warn("received node drain message", "node_id", nodeID, "msg", msg)
+		case api.MonitorMsgLevelError:
+			return fmt.Errorf("received error while draining node: %s", msg.Message)
+		default:
+			si.log.Debug("received node drain message", "node_id", nodeID, "msg", msg)
+		}
+	}
+	return ctx.Err()
+}

--- a/helper/scaleutils/request.go
+++ b/helper/scaleutils/request.go
@@ -29,7 +29,7 @@ func (sr *ScaleInReq) validate() error {
 	var err *multierror.Error
 
 	if sr.Num < 1 {
-		err = multierror.Append(errors.New("num should be non-zero"), err)
+		err = multierror.Append(errors.New("num should be positive and non-zero"), err)
 	}
 
 	if sr.DrainDeadline == 0 {

--- a/helper/scaleutils/request.go
+++ b/helper/scaleutils/request.go
@@ -1,0 +1,52 @@
+package scaleutils
+
+import (
+	"errors"
+	"time"
+
+	multierror "github.com/hashicorp/go-multierror"
+)
+
+// ScaleInReq represents an individual cluster scaling request and encompasses
+// all the information needed to perform the pre-termination tasks.
+type ScaleInReq struct {
+
+	// Num is the number of nodes we should select and prepare for termination.
+	Num int
+
+	// DrainDeadline is the deadline used within the DrainSpec when performing
+	// Nomad Node drain.
+	DrainDeadline time.Duration
+
+	PoolIdentifier *PoolIdentifier
+	RemoteProvider RemoteProvider
+	NodeIDStrategy NodeIDStrategy
+}
+
+// validate is used to ensure that ScaleInReq is correctly populated.
+func (sr *ScaleInReq) validate() error {
+
+	var err *multierror.Error
+
+	if sr.Num < 1 {
+		err = multierror.Append(errors.New("num should be non-zero"), err)
+	}
+
+	if sr.DrainDeadline == 0 {
+		err = multierror.Append(errors.New("deadline should be non-zero"), err)
+	}
+
+	if sr.PoolIdentifier == nil {
+		err = multierror.Append(errors.New("pool identifier should be non-nil"), err)
+	}
+
+	if sr.RemoteProvider == "" {
+		err = multierror.Append(errors.New("remote provider should be set"), err)
+	}
+
+	if sr.NodeIDStrategy == "" {
+		err = multierror.Append(errors.New("node ID strategy should be set"), err)
+	}
+
+	return err.ErrorOrNil()
+}

--- a/helper/scaleutils/request_test.go
+++ b/helper/scaleutils/request_test.go
@@ -1,0 +1,112 @@
+package scaleutils
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScaleInReq_validate(t *testing.T) {
+	testCases := []struct {
+		inputScaleInReq     *ScaleInReq
+		expectedOutputError error
+		name                string
+	}{
+		{
+			inputScaleInReq: &ScaleInReq{
+				Num:           2,
+				DrainDeadline: 20 * time.Minute,
+				PoolIdentifier: &PoolIdentifier{
+					IdentifierKey: "class",
+					Value:         "myclass",
+				},
+				RemoteProvider: "aws",
+				NodeIDStrategy: "newest_create_index",
+			},
+			expectedOutputError: nil,
+			name:                "valid request",
+		},
+		{
+			inputScaleInReq: &ScaleInReq{
+				DrainDeadline: 20 * time.Minute,
+				PoolIdentifier: &PoolIdentifier{
+					IdentifierKey: "class",
+					Value:         "myclass",
+				},
+				RemoteProvider: "aws",
+				NodeIDStrategy: "newest_create_index",
+			},
+			expectedOutputError: &multierror.Error{
+				Errors: []error{errors.New("num should be non-zero")},
+			},
+			name: "missing num param",
+		},
+		{
+			inputScaleInReq: &ScaleInReq{
+				Num: 2,
+				PoolIdentifier: &PoolIdentifier{
+					IdentifierKey: "class",
+					Value:         "myclass",
+				},
+				RemoteProvider: "aws",
+				NodeIDStrategy: "newest_create_index",
+			},
+			expectedOutputError: &multierror.Error{
+				Errors: []error{errors.New("deadline should be non-zero")},
+			},
+			name: "missing drain deadline",
+		},
+		{
+			inputScaleInReq: &ScaleInReq{
+				Num:            2,
+				DrainDeadline:  20 * time.Minute,
+				RemoteProvider: "aws",
+				NodeIDStrategy: "newest_create_index",
+			},
+			expectedOutputError: &multierror.Error{
+				Errors: []error{errors.New("pool identifier should be non-nil")},
+			},
+			name: "missing pool identifier",
+		},
+		{
+			inputScaleInReq: &ScaleInReq{
+				Num:           2,
+				DrainDeadline: 20 * time.Minute,
+				PoolIdentifier: &PoolIdentifier{
+					IdentifierKey: "class",
+					Value:         "myclass",
+				},
+				NodeIDStrategy: "newest_create_index",
+			},
+			expectedOutputError: &multierror.Error{
+				Errors: []error{errors.New("remote provider should be set")},
+			},
+			name: "missing remote provider",
+		},
+		{
+			inputScaleInReq: &ScaleInReq{
+				Num:           2,
+				DrainDeadline: 20 * time.Minute,
+				PoolIdentifier: &PoolIdentifier{
+					IdentifierKey: "class",
+					Value:         "myclass",
+				},
+				RemoteProvider: "aws",
+			},
+			expectedOutputError: &multierror.Error{
+				Errors: []error{errors.New("node ID strategy should be set")},
+			},
+			name: "missing node ID strategy",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := tc.inputScaleInReq.validate()
+			assert.Equal(t, tc.expectedOutputError, actualOutput, tc.name)
+		})
+	}
+}

--- a/helper/scaleutils/request_test.go
+++ b/helper/scaleutils/request_test.go
@@ -40,7 +40,7 @@ func TestScaleInReq_validate(t *testing.T) {
 				NodeIDStrategy: "newest_create_index",
 			},
 			expectedOutputError: &multierror.Error{
-				Errors: []error{errors.New("num should be non-zero")},
+				Errors: []error{errors.New("num should be positive and non-zero")},
 			},
 			name: "missing num param",
 		},


### PR DESCRIPTION
When performing a scale in action on a pool of Nomad nodes, there
are a number of tasks which should be conducted before the
instances are terminated within the remote infrastructure provider.

The scaleutils helper package provides a method for performing
Nomad node identification, node draining, node drain monitoring
and nodeID translation. This is exposed as a single function so
that target plugin authors can consume the functionality in a
simple manner.

closes #153 