### PR TITLE
plugins/target/aws-asg: Add new target plugin for AWS ASGs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/aws/aws-sdk-go-v2 v0.23.0
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -3,14 +3,18 @@ github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go-v2 v0.23.0 h1:+E1q1LLSfHSDn/DzOtdJOX+pLZE2HiNV2yO5AjZINwM=
+github.com/aws/aws-sdk-go-v2 v0.23.0/go.mod h1:2LhT7UgHOXK3UXONKI5OMgIyoQL6zTAw/jwIeX6yqzw=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -31,6 +35,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -74,6 +79,8 @@ github.com/hashicorp/nomad/api v0.0.0-20200514223145-f2210cedd9d6 h1:Sp9lwJLD841
 github.com/hashicorp/nomad/api v0.0.0-20200514223145-f2210cedd9d6/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -143,6 +150,7 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -166,6 +174,8 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowKpJ8y4AmooUzdBSR9GU=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -196,6 +206,7 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.14.0 h1:ArxJuB1NWfPY6r9Gp9gqwplT0Ge7nqv9msgu03lHLmo=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/helper/scaleutils/request.go
+++ b/helper/scaleutils/request.go
@@ -7,6 +7,12 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 )
 
+const (
+	// DefaultDrainDeadline is the drainSpec deadline used if one is not
+	// specified by an operator.
+	DefaultDrainDeadline = 15 * time.Minute
+)
+
 // ScaleInReq represents an individual cluster scaling request and encompasses
 // all the information needed to perform the pre-termination tasks.
 type ScaleInReq struct {

--- a/plugins/builtin/target/aws-asg/main.go
+++ b/plugins/builtin/target/aws-asg/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/plugins"
+	awsASG "github.com/hashicorp/nomad-autoscaler/plugins/builtin/target/aws-asg/plugin"
+)
+
+func main() {
+	plugins.Serve(factory)
+}
+
+// factory returns a new instance of the AWS ASG plugin.
+func factory(log hclog.Logger) interface{} {
+	return awsASG.NewAWSASGPlugin(log)
+}

--- a/plugins/builtin/target/aws-asg/plugin/aws.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws.go
@@ -1,0 +1,331 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/external"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/hashicorp/nomad-autoscaler/helper/scaleutils"
+)
+
+const (
+	defaultRetryInterval = 10 * time.Second
+	defaultRetryLimit    = 15
+)
+
+// setupAWSClients takes the passed config mapping and instantiates the
+// required AWS service clients.
+func (t *TargetPlugin) setupAWSClients(config map[string]string) error {
+
+	// Load our default AWS config. This handles pulling configuration from
+	// default profiles and environment variables.
+	cfg, err := external.LoadDefaultAWSConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load default AWS config: %v", err)
+	}
+
+	// Check for a configured region and set the value to our internal default
+	// if nothing is found.
+	region, ok := config[configKeyRegion]
+	if !ok {
+		region = configValueRegionDefault
+	}
+
+	// If the default config is empty, update it.
+	if cfg.Region == "" {
+		t.logger.Trace("setting AWS region for client", "region", region)
+		cfg.Region = region
+	}
+
+	// Attempt to pull access credentials for the AWS client from the user
+	// supplied configuration. In order to use these static credentials both
+	// the access key and secret key need to be present; the session token is
+	// optional.
+	keyID, idOK := config[configKeyAccessID]
+	secretKey, keyOK := config[configKeySecretKey]
+	session, _ := config[configKeySessionToken]
+
+	if idOK && keyOK {
+		t.logger.Trace("setting AWS access credentials from config map")
+		cfg.Credentials = aws.NewStaticCredentialsProvider(keyID, secretKey, session)
+	}
+
+	// Set up our AWS clients.
+	t.ec2 = ec2.New(cfg)
+	t.asg = autoscaling.New(cfg)
+
+	return nil
+}
+
+// scaleOut updates the Auto Scaling Group desired count to match what the
+// Autoscaler has deemed required.
+func (t *TargetPlugin) scaleOut(ctx context.Context, asg *autoscaling.AutoScalingGroup, count int64) error {
+
+	input := autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: asg.AutoScalingGroupName,
+		AvailabilityZones:    asg.AvailabilityZones,
+		DesiredCapacity:      aws.Int64(count),
+	}
+
+	// Ignore the response from Send() as its empty.
+	_, err := t.asg.UpdateAutoScalingGroupRequest(&input).Send(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to update Autoscaling Group: %v", err)
+	}
+	return t.ensureASGInstancesCount(ctx, count, *asg.AutoScalingGroupName)
+}
+
+func (t *TargetPlugin) scaleIn(ctx context.Context, asg *autoscaling.AutoScalingGroup, num int64, config map[string]string) error {
+
+	scaleReq, err := t.generateScaleReq(num, config)
+	if err != nil {
+		return fmt.Errorf("failed to generate scale in request: %v", err)
+	}
+
+	ids, err := t.scaleInUtils.RunPreScaleInTasks(ctx, scaleReq)
+	if err != nil {
+		return fmt.Errorf("failed to perform Nomad scale in tasks: %v", err)
+	}
+
+	// Grab the instanceIDs once as it is used multiple times throughout the
+	// scale in event.
+	var instanceIDs []string
+
+	for _, node := range ids {
+		instanceIDs = append(instanceIDs, node.RemoteID)
+	}
+
+	// Create the event writer and write that the drain event has been
+	// completed which is part of the RunPreScaleInTasks() function.
+	eWriter := newEventWriter(t.logger, t.asg, instanceIDs, *asg.AutoScalingGroupName)
+	eWriter.write(ctx, scalingEventDrain)
+
+	// Create a logger for this action to pre-populate useful information we
+	// would like on all log lines.
+	log := t.logger.With("action", "scale_in", "asg_name", *asg.AutoScalingGroupName,
+		"instances", instanceIDs)
+
+	// Detach the desired instances.
+	log.Debug("detaching instances from AutoScaling Group")
+
+	if err := t.detachInstances(ctx, asg.AutoScalingGroupName, instanceIDs); err != nil {
+		return fmt.Errorf("failed to scale in AWS AutoScaling Group: %v", err)
+	}
+	log.Debug("successfully detached instances from AutoScaling Group")
+	eWriter.write(ctx, scalingEventDetach)
+
+	// Terminate the detached instances.
+	log.Debug("terminating EC2 instances")
+
+	if err := t.terminateInstances(ctx, instanceIDs); err != nil {
+		return fmt.Errorf("failed to scale in AWS AutoScaling Group: %v", err)
+	}
+	log.Debug("successfully terminated EC2 instances")
+	eWriter.write(ctx, scalingEventTerminate)
+
+	return nil
+}
+
+func (t *TargetPlugin) generateScaleReq(num int64, config map[string]string) (*scaleutils.ScaleInReq, error) {
+
+	// Pull the class key from the config mapping. This is a required value and
+	// we cannot scale without this.
+	class, ok := config[configKeyClass]
+	if !ok {
+		return nil, fmt.Errorf("required config param %q not found", configKeyClass)
+	}
+
+	// The drain_deadline is an optional parameter so define out default and
+	// then attempt to find an operator specified value.
+	drain := scaleutils.DefaultDrainDeadline
+
+	if drainString, ok := config[configKeyDrainDeadline]; ok {
+		d, err := time.ParseDuration(drainString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %q as time duration", drainString)
+		}
+		drain = d
+	}
+
+	return &scaleutils.ScaleInReq{
+		Num:           int(num),
+		DrainDeadline: drain,
+		PoolIdentifier: &scaleutils.PoolIdentifier{
+			IdentifierKey: scaleutils.IdentifierKeyClass,
+			Value:         class,
+		},
+		RemoteProvider: scaleutils.RemoteProviderAWSInstanceID,
+		NodeIDStrategy: scaleutils.IDStrategyNewestCreateIndex,
+	}, nil
+}
+
+func (t *TargetPlugin) detachInstances(ctx context.Context, asgName *string, instanceIDs []string) error {
+
+	asgInput := autoscaling.DetachInstancesInput{
+		AutoScalingGroupName:           asgName,
+		InstanceIds:                    instanceIDs,
+		ShouldDecrementDesiredCapacity: aws.Bool(true),
+	}
+
+	asgResp, err := t.asg.DetachInstancesRequest(&asgInput).Send(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to detach intances from Autoscaling Group: %v", err)
+	}
+
+	// Identify the activities that were created as a result of the detachment
+	// request so that we can go ahead and track these to completion.
+	var activityIDs []string
+
+	for _, activity := range asgResp.Activities {
+		activityIDs = append(activityIDs, *activity.ActivityId)
+	}
+
+	// Confirm that the detachments complete before moving on. I (jrasell) am
+	// not exactly sure what happens if we terminate an instance which is still
+	// detaching from an ASG, but we might as well avoid finding out if we can.
+	if err := t.ensureActivitiesComplete(ctx, activityIDs, *asgName); err != nil {
+		err = fmt.Errorf("failed to detached instances from AutoScaling Group: %v", err)
+	}
+	return err
+}
+
+func (t *TargetPlugin) terminateInstances(ctx context.Context, instanceIDs []string) error {
+
+	ec2Input := ec2.TerminateInstancesInput{InstanceIds: instanceIDs}
+
+	// TODO(jrasell) the response includes information about instance status
+	//  changes which we may want to validate in the future.
+	_, err := t.ec2.TerminateInstancesRequest(&ec2Input).Send(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to terminate EC2 intances: %v", err)
+	}
+
+	// Confirm that the instances have indeed terminated properly. This allows
+	// us to handle reconciliation if the error is transient, or at least
+	// allows operators to see the error and perform manual actions to resolve.
+	if err := t.ensureInstancesTerminate(ctx, instanceIDs); err != nil {
+		err = fmt.Errorf("failed to terminate EC2 instances: %v", err)
+	}
+	return err
+}
+
+func (t *TargetPlugin) describeASG(ctx context.Context, asgName string) (*autoscaling.AutoScalingGroup, error) {
+
+	input := autoscaling.DescribeAutoScalingGroupsInput{AutoScalingGroupNames: []string{asgName}}
+
+	resp, err := t.asg.DescribeAutoScalingGroupsRequest(&input).Send(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.AutoScalingGroups) != 1 {
+		return nil, fmt.Errorf("expected 1 Autoscaling Group, got %v", len(resp.AutoScalingGroups))
+	}
+	return &resp.AutoScalingGroups[0], nil
+}
+
+func (t *TargetPlugin) describeActivities(ctx context.Context, asgName string, ids []string) ([]autoscaling.Activity, error) {
+
+	input := autoscaling.DescribeScalingActivitiesInput{AutoScalingGroupName: aws.String(asgName)}
+
+	// If an ID is specified, add this to the request so we only pull
+	// information regarding this.
+	if len(ids) > 0 {
+		input.ActivityIds = ids
+	}
+
+	resp, err := t.asg.DescribeScalingActivitiesRequest(&input).Send(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the caller passed a list of IDs to describe, ensure the returned list
+	// is the current length.
+	if len(ids) > 0 && len(resp.Activities) != len(ids) {
+		return nil, fmt.Errorf("expected %v activities, got %v", len(ids), len(resp.Activities))
+	}
+	return resp.Activities, nil
+}
+
+func (t *TargetPlugin) ensureActivitiesComplete(ctx context.Context, ids []string, asg string) error {
+
+	f := func(ctx context.Context) (bool, error) {
+
+		activities, err := t.describeActivities(ctx, asg, ids)
+		if err != nil {
+			return true, err
+		}
+
+		// Reset the scaling activity IDs we are waiting to complete so we can
+		// re-populate with a modified list later.
+		ids = []string{}
+
+		// Iterate each activity, check the progress and add any incomplete
+		// activities to the ID list for rechecking.
+		for _, activity := range activities {
+			if *activity.Progress != 100 {
+				ids = append(ids, *activity.ActivityId)
+			}
+		}
+
+		// If we dont have any remaining IDs to check, we can finish.
+		if len(ids) == 0 {
+			return true, nil
+		}
+		return false, fmt.Errorf("waiting for %v activities to finish", len(ids))
+	}
+
+	return retry(ctx, defaultRetryInterval, defaultRetryLimit, f)
+}
+
+func (t *TargetPlugin) ensureInstancesTerminate(ctx context.Context, ids []string) error {
+
+	f := func(ctx context.Context) (bool, error) {
+
+		input := ec2.DescribeInstanceStatusInput{InstanceIds: ids}
+
+		resp, err := t.ec2.DescribeInstanceStatusRequest(&input).Send(ctx)
+		if err != nil {
+			return true, err
+		}
+
+		// Reset the instance IDs we want to check so this can be populated again
+		// once we have processed their current status information.
+		ids = []string{}
+
+		for _, instanceStatus := range resp.InstanceStatuses {
+			if instanceStatus.InstanceState.Name != ec2.InstanceStateNameTerminated {
+				ids = append(ids, *instanceStatus.InstanceId)
+			}
+		}
+
+		// If we dont have any remaining IDs to check, we can finish.
+		if len(ids) == 0 {
+			return true, nil
+		}
+		return false, fmt.Errorf("waiting for %v instances to terminate", len(ids))
+	}
+
+	return retry(ctx, defaultRetryInterval, defaultRetryLimit, f)
+}
+
+func (t *TargetPlugin) ensureASGInstancesCount(ctx context.Context, desired int64, asgName string) error {
+
+	f := func(ctx context.Context) (bool, error) {
+		asg, err := t.describeASG(ctx, asgName)
+		if err != nil {
+			return true, err
+		}
+
+		if len(asg.Instances) == int(desired) {
+			return true, nil
+		}
+		return false, fmt.Errorf("AutoScaling Group at %v instances of desired %v", asg.Instances, desired)
+	}
+
+	return retry(ctx, defaultRetryInterval, defaultRetryLimit, f)
+}

--- a/plugins/builtin/target/aws-asg/plugin/aws_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws_test.go
@@ -1,0 +1,85 @@
+package plugin
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad-autoscaler/helper/scaleutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTargetPlugin_generateScaleReq(t *testing.T) {
+	testCases := []struct {
+		inputNum            int64
+		inputConfig         map[string]string
+		expectedOutputReq   *scaleutils.ScaleInReq
+		expectedOutputError error
+		name                string
+	}{
+		{
+			inputNum: 2,
+			inputConfig: map[string]string{
+				"class":          "high-memory",
+				"drain_deadline": "5m",
+			},
+			expectedOutputReq: &scaleutils.ScaleInReq{
+				Num:           2,
+				DrainDeadline: 5 * time.Minute,
+				PoolIdentifier: &scaleutils.PoolIdentifier{
+					IdentifierKey: scaleutils.IdentifierKeyClass,
+					Value:         "high-memory",
+				},
+				RemoteProvider: scaleutils.RemoteProviderAWSInstanceID,
+				NodeIDStrategy: scaleutils.IDStrategyNewestCreateIndex,
+			},
+			expectedOutputError: nil,
+			name:                "valid request with drain_deadline in config",
+		},
+		{
+			inputNum:            2,
+			inputConfig:         map[string]string{},
+			expectedOutputReq:   nil,
+			expectedOutputError: errors.New("required config param \"class\" not found"),
+			name:                "no class key found in config",
+		},
+		{
+			inputNum: 2,
+			inputConfig: map[string]string{
+				"class": "high-memory",
+			},
+			expectedOutputReq: &scaleutils.ScaleInReq{
+				Num:           2,
+				DrainDeadline: 15 * time.Minute,
+				PoolIdentifier: &scaleutils.PoolIdentifier{
+					IdentifierKey: scaleutils.IdentifierKeyClass,
+					Value:         "high-memory",
+				},
+				RemoteProvider: scaleutils.RemoteProviderAWSInstanceID,
+				NodeIDStrategy: scaleutils.IDStrategyNewestCreateIndex,
+			},
+			expectedOutputError: nil,
+			name:                "drain_deadline not specified within config",
+		},
+		{
+			inputNum: 2,
+			inputConfig: map[string]string{
+				"class":          "high-memory",
+				"drain_deadline": "time to make a cuppa",
+			},
+			expectedOutputReq:   nil,
+			expectedOutputError: errors.New("failed to parse \"time to make a cuppa\" as time duration"),
+			name:                "malformed drain_deadline config value",
+		},
+	}
+
+	tp := TargetPlugin{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualReq, actualErr := tp.generateScaleReq(tc.inputNum, tc.inputConfig)
+			assert.Equal(t, tc.expectedOutputReq, actualReq, tc.name)
+			assert.Equal(t, tc.expectedOutputError, actualErr, tc.name)
+		})
+	}
+}

--- a/plugins/builtin/target/aws-asg/plugin/event.go
+++ b/plugins/builtin/target/aws-asg/plugin/event.go
@@ -1,0 +1,111 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+// scalingEvent represents an individual task within a long running cluster
+// scaling event. Once we start to build more infrastructure provider target
+// plugins we may wish to move this to plugins/target for public consumption.
+type scalingEvent string
+
+const (
+	scalingEventDrain     scalingEvent = "drain"
+	scalingEventDetach    scalingEvent = "detach"
+	scalingEventTerminate scalingEvent = "terminate"
+)
+
+const (
+	tagKey          = "nomad_autoscaler_lifecycle_phase"
+	tagResourceType = "auto-scaling-group"
+
+	// tagValueCharLimit is the size limit of an AWS AutoScaling Group tag and
+	// is calculated using the current autoscaling limit, taking into account
+	// that the tag will have the scalingEvent along with an underscore
+	// prefixed on every write.
+	tagValueCharLimit = 265 - len(scalingEventTerminate) - 1
+)
+
+type eventWriter struct {
+	logger  hclog.Logger
+	asg     *autoscaling.Client
+	ids     []string
+	asgName string
+}
+
+func newEventWriter(log hclog.Logger, asgClient *autoscaling.Client, ids []string, asg string) *eventWriter {
+	return &eventWriter{
+		logger:  log,
+		asg:     asgClient,
+		ids:     chunkIDs(ids, tagValueCharLimit),
+		asgName: asg,
+	}
+}
+
+// write creates or updates the AutoScaling Group with the appropriate event
+// tags.
+func (e *eventWriter) write(ctx context.Context, event scalingEvent) {
+
+	input := autoscaling.CreateOrUpdateTagsInput{Tags: e.buildTags(event)}
+
+	// Call the AWS API. If we get an error when creating/updating the tag we
+	// do not bail on the whole process. It does inhibit our ability to perform
+	// reconciliation, but not necessarily scaling actions. This could fail if
+	// the AWS credentials are missing the autoscaling:CreateOrUpdateTags IAM
+	// action.
+	if _, err := e.asg.CreateOrUpdateTagsRequest(&input).Send(ctx); err != nil {
+		e.logger.Error("failed to update AutoScaling Group tag", "error", err, "event", event)
+	}
+	e.logger.Trace("successfully updated AutoScaling Group tag", "event", event)
+}
+
+// buildTags iterates the eventWriters ID chunks and creates a list of AWS
+// autoscaling tags for the specified event.
+func (e *eventWriter) buildTags(event scalingEvent) []autoscaling.Tag {
+
+	var tags []autoscaling.Tag
+
+	for i, chunk := range e.ids {
+		tags = append(tags, autoscaling.Tag{
+			Key:               aws.String(fmt.Sprintf("%v_%v", tagKey, i+1)),
+			Value:             aws.String(fmt.Sprintf("%v_%v", event, chunk)),
+			PropagateAtLaunch: aws.Bool(false),
+			ResourceId:        aws.String(e.asgName),
+			ResourceType:      aws.String(tagResourceType),
+		})
+	}
+	return tags
+}
+
+// chunkIDs is used to format the ID strings used when creating tag ensuring
+// each string of concatenated IDs does not exceed the limit.
+func chunkIDs(s []string, size int) []string {
+
+	index := 0
+
+	// This feels wrong, but I(jrasell) have not found an alternate way to get
+	// this to work. This at least works.
+	values := []string{""}
+
+	for _, val := range s {
+
+		if len(values[index]) == 0 {
+			values[index] = val
+			continue
+		}
+
+		if len(values[index])+len(val)+1 > size {
+			values = append(values, val)
+			index++
+			continue
+		}
+		values[index] = fmt.Sprintf("%v_%s", values[index], val)
+	}
+
+	return values
+}

--- a/plugins/builtin/target/aws-asg/plugin/event_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/event_test.go
@@ -1,0 +1,115 @@
+package plugin
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_eventWriter_buildTags(t *testing.T) {
+	testCases := []struct {
+		inputIDs       []string
+		inputASGName   string
+		inputEvent     scalingEvent
+		expectedOutput []autoscaling.Tag
+		name           string
+	}{
+		{
+			inputIDs:     generateIDs(1),
+			inputASGName: "test-test-asg",
+			inputEvent:   scalingEventDrain,
+			expectedOutput: []autoscaling.Tag{
+				{
+					Key:               aws.String("nomad_autoscaler_lifecycle_phase_1"),
+					Value:             aws.String("drain_i-036e43a14e8f81001"),
+					PropagateAtLaunch: aws.Bool(false),
+					ResourceId:        aws.String("test-test-asg"),
+					ResourceType:      aws.String("auto-scaling-group"),
+				},
+			},
+			name: "single ID within event",
+		},
+		{
+			inputIDs:     generateIDs(14),
+			inputASGName: "test-test-asg",
+			inputEvent:   scalingEventDrain,
+			expectedOutput: []autoscaling.Tag{
+				{
+					Key:               aws.String("nomad_autoscaler_lifecycle_phase_1"),
+					Value:             aws.String("drain_i-036e43a14e8f81001_i-036e43a14e8f81002_i-036e43a14e8f81003_i-036e43a14e8f81004_i-036e43a14e8f81005_i-036e43a14e8f81006_i-036e43a14e8f81007_i-036e43a14e8f81008_i-036e43a14e8f81009_i-036e43a14e8f81010_i-036e43a14e8f81011_i-036e43a14e8f81012"),
+					PropagateAtLaunch: aws.Bool(false),
+					ResourceId:        aws.String("test-test-asg"),
+					ResourceType:      aws.String("auto-scaling-group"),
+				},
+				{
+					Key:               aws.String("nomad_autoscaler_lifecycle_phase_2"),
+					Value:             aws.String("drain_i-036e43a14e8f81013_i-036e43a14e8f81014"),
+					PropagateAtLaunch: aws.Bool(false),
+					ResourceId:        aws.String("test-test-asg"),
+					ResourceType:      aws.String("auto-scaling-group"),
+				},
+			},
+			name: "many IDs resulting in more than 1 tag",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ew := newEventWriter(hclog.NewNullLogger(), nil, tc.inputIDs, tc.inputASGName)
+			actualOutput := ew.buildTags(tc.inputEvent)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}
+
+func Test_chunkIDs(t *testing.T) {
+	testCases := []struct {
+		inputStrings   []string
+		inputSize      int
+		expectedOutput []string
+		name           string
+	}{
+		{
+			inputStrings: generateIDs(3),
+			inputSize:    50,
+			expectedOutput: []string{
+				"i-036e43a14e8f81001_i-036e43a14e8f81002",
+				"i-036e43a14e8f81003",
+			},
+			name: "3 items resulting in two array elements",
+		},
+		{
+			inputStrings: generateIDs(2),
+			inputSize:    50,
+			expectedOutput: []string{
+				"i-036e43a14e8f81001_i-036e43a14e8f81002",
+			},
+			name: "2 items resulting in single array element",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := chunkIDs(tc.inputStrings, tc.inputSize)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}
+
+func generateIDs(num int) []string {
+
+	if num > 8999 {
+		panic("cannot generate more than 8999 IDs")
+	}
+
+	var ids []string
+
+	for i := 1; i <= num; i++ {
+		ids = append(ids, fmt.Sprintf("i-036e43a14e8f8%v", 1000+i))
+	}
+	return ids
+}

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -1,0 +1,181 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/helper/nomad"
+	"github.com/hashicorp/nomad-autoscaler/helper/scaleutils"
+	"github.com/hashicorp/nomad-autoscaler/plugins"
+	"github.com/hashicorp/nomad-autoscaler/plugins/base"
+	"github.com/hashicorp/nomad-autoscaler/plugins/strategy"
+	"github.com/hashicorp/nomad-autoscaler/plugins/target"
+)
+
+const (
+	// pluginName is the unique name of the this plugin amongst Target plugins.
+	pluginName = "aws-asg"
+
+	// configKeys represents the known configuration parameters required at
+	// varying points throughout the plugins lifecycle.
+	configKeyRegion        = "region"
+	configKeyAccessID      = "aws_access_key_id"
+	configKeySecretKey     = "aws_secret_access_key"
+	configKeySessionToken  = "session_token"
+	configKeyASGName       = "asg_name"
+	configKeyClass         = "class"
+	configKeyDrainDeadline = "drain_deadline"
+
+	// configValues are the default values used when a configuration key is not
+	// supplied by the operator that are specific to the plugin.
+	configValueRegionDefault = "us-east-1"
+)
+
+var (
+	PluginConfig = &plugins.InternalPluginConfig{
+		Factory: func(l hclog.Logger) interface{} { return NewAWSASGPlugin(l) },
+	}
+
+	pluginInfo = &base.PluginInfo{
+		Name:       pluginName,
+		PluginType: plugins.PluginTypeTarget,
+	}
+)
+
+// Assert that TargetPlugin meets the target.Target interface.
+var _ target.Target = (*TargetPlugin)(nil)
+
+// TargetPlugin is the AWS ASG implementation of the target.Target interface.
+type TargetPlugin struct {
+	config       map[string]string
+	logger       hclog.Logger
+	asg          *autoscaling.Client
+	ec2          *ec2.Client
+	scaleInUtils *scaleutils.ScaleIn
+}
+
+// NewAWSASGPlugin returns the AWS ASG implementation of the target.Target
+// interface.
+func NewAWSASGPlugin(log hclog.Logger) *TargetPlugin {
+	return &TargetPlugin{
+		logger: log,
+	}
+}
+
+// SetConfig satisfies the SetConfig function on the base.Plugin interface.
+func (t *TargetPlugin) SetConfig(config map[string]string) error {
+
+	t.config = config
+
+	if err := t.setupAWSClients(config); err != nil {
+		return err
+	}
+
+	utils, err := scaleutils.NewScaleInUtils(nomad.ConfigFromMap(config), t.logger)
+	if err != nil {
+		return err
+	}
+	t.scaleInUtils = utils
+
+	return nil
+}
+
+// PluginInfo satisfies the PluginInfo function on the base.Plugin interface.
+func (t *TargetPlugin) PluginInfo() (*base.PluginInfo, error) {
+	return pluginInfo, nil
+}
+
+// Scale satisfies the Scale function on the target.Target interface.
+func (t *TargetPlugin) Scale(action strategy.Action, config map[string]string) error {
+
+	// We cannot scale an ASG without knowing the ASG name.
+	asgName, ok := config[configKeyASGName]
+	if !ok {
+		return fmt.Errorf("required config param %s not found", configKeyASGName)
+	}
+	ctx := context.Background()
+
+	// Describe the ASG. This serves to both validate the config value is
+	// correct and ensure the AWS client is configured correctly. The response
+	// can also be used when performing the scaling, meaning we only need to
+	// call it once.
+	curASG, err := t.describeASG(ctx, asgName)
+	if err != nil {
+		return fmt.Errorf("failed to describe AWS Autoscaling Group: %v", err)
+	}
+
+	// The AWS ASG target requires different details depending on which
+	// direction we want to scale. Therefore calculate the direction and the
+	// relevant number so we can correctly perform the AWS work.
+	num, direction := t.calculateDirection(*curASG.DesiredCapacity, action.Count)
+
+	switch direction {
+	case "in":
+		err = t.scaleIn(ctx, curASG, num, config)
+	case "out":
+		err = t.scaleOut(ctx, curASG, num)
+	default:
+		return fmt.Errorf("scaling not required, ASG count %v and Autoscaler desired count %v",
+			*curASG.DesiredCapacity, action.Count)
+	}
+
+	// If we received an error while scaling, format this with an outer message
+	// so its nice for the operators and then return any error to the caller.
+	if err != nil {
+		err = fmt.Errorf("failed to perform scaling action: %v", err)
+	}
+	return err
+}
+
+// Status satisfies the Status function on the target.Target interface.
+func (t *TargetPlugin) Status(config map[string]string) (*target.Status, error) {
+
+	// We cannot get the status of an ASG if we don't know its name.
+	asgName, ok := config[configKeyASGName]
+	if !ok {
+		return nil, fmt.Errorf("required config param %s not found", configKeyASGName)
+	}
+	ctx := context.Background()
+
+	asg, err := t.describeASG(ctx, asgName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe AWS Autoscaling Group: %v", err)
+	}
+
+	events, err := t.describeActivities(ctx, asgName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe AWS Autoscaling Group activities: %v", err)
+	}
+
+	resp := target.Status{
+		Ready: asg.Status == nil,
+		Count: *asg.DesiredCapacity,
+	}
+
+	// If the ASG has scaling activities listed ensure the status takes into
+	// account the most recent activity. Most importantly if the last event has
+	// not finished, the ASG is not ready for scaling.
+	if events != nil {
+		resp.Ready = resp.Ready || *events[0].Progress == 100
+		resp.Meta = map[string]string{
+			target.MetaKeyLastEvent: strconv.FormatInt(events[0].EndTime.UnixNano(), 10),
+		}
+	}
+
+	return &resp, nil
+}
+
+func (t *TargetPlugin) calculateDirection(asgDesired, strategyDesired int64) (int64, string) {
+
+	if strategyDesired < asgDesired {
+		return asgDesired - strategyDesired, "in"
+	}
+	if strategyDesired > asgDesired {
+		return strategyDesired, "out"
+	}
+	return 0, ""
+}

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -119,8 +119,9 @@ func (t *TargetPlugin) Scale(action strategy.Action, config map[string]string) e
 	case "out":
 		err = t.scaleOut(ctx, curASG, num)
 	default:
-		return fmt.Errorf("scaling not required, ASG count %v and Autoscaler desired count %v",
-			*curASG.DesiredCapacity, action.Count)
+		t.logger.Info("scaling not required", "asg_name", asgName,
+			"current_count", *curASG.DesiredCapacity, "strategy_count", action.Count)
+		return nil
 	}
 
 	// If we received an error while scaling, format this with an outer message
@@ -159,7 +160,7 @@ func (t *TargetPlugin) Status(config map[string]string) (*target.Status, error) 
 	// If the ASG has scaling activities listed ensure the status takes into
 	// account the most recent activity. Most importantly if the last event has
 	// not finished, the ASG is not ready for scaling.
-	if events != nil {
+	if events != nil && len(events) > 0 {
 		resp.Ready = resp.Ready || *events[0].Progress == 100
 		resp.Meta = map[string]string{
 			target.MetaKeyLastEvent: strconv.FormatInt(events[0].EndTime.UnixNano(), 10),

--- a/plugins/builtin/target/aws-asg/plugin/plugin_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin_test.go
@@ -1,0 +1,49 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTargetPlugin_calculateDirection(t *testing.T) {
+	testCases := []struct {
+		inputAsgDesired      int64
+		inputStrategyDesired int64
+		expectedOutputNum    int64
+		expectedOutputString string
+		name                 string
+	}{
+		{
+			inputAsgDesired:      10,
+			inputStrategyDesired: 11,
+			expectedOutputNum:    11,
+			expectedOutputString: "out",
+			name:                 "scale out desired",
+		},
+		{
+			inputAsgDesired:      10,
+			inputStrategyDesired: 9,
+			expectedOutputNum:    1,
+			expectedOutputString: "in",
+			name:                 "scale in desired",
+		},
+		{
+			inputAsgDesired:      10,
+			inputStrategyDesired: 10,
+			expectedOutputNum:    0,
+			expectedOutputString: "",
+			name:                 "scale not desired",
+		},
+	}
+
+	tp := TargetPlugin{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualNum, actualString := tp.calculateDirection(tc.inputAsgDesired, tc.inputStrategyDesired)
+			assert.Equal(t, tc.expectedOutputNum, actualNum, tc.name)
+			assert.Equal(t, tc.expectedOutputString, actualString, tc.name)
+		})
+	}
+}

--- a/plugins/builtin/target/aws-asg/plugin/retry.go
+++ b/plugins/builtin/target/aws-asg/plugin/retry.go
@@ -1,0 +1,57 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// retryFunc is the function signature for a function which is retryable. The
+// stop bool indicates whether or not the retry should be halted indicating a
+// terminal error. The error return can accompany either a true or false stop
+// return to provide context when needed.
+type retryFunc func(ctx context.Context) (stop bool, err error)
+
+// retry will retry the passed function f until any of the following conditions
+// are met:
+//  - the function returns stop=true and err=nil
+//  - the retryAttempts limit is reached
+//  - the context is cancelled
+func retry(ctx context.Context, retryInterval time.Duration, retryAttempts int, f retryFunc) error {
+
+	var (
+		retryCount int
+		lastErr    error
+	)
+
+	for {
+
+		if ctx.Err() != nil {
+			if lastErr != nil {
+				return fmt.Errorf("retry failed with %v; last error: %v", ctx.Err(), lastErr)
+			}
+			return ctx.Err()
+		}
+
+		stop, err := f(ctx)
+		if stop {
+			return err
+		}
+
+		if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+			lastErr = err
+		}
+
+		if err == nil {
+			return nil
+		}
+
+		retryCount++
+
+		if retryCount == retryAttempts {
+			return errors.New("reached retry limit")
+		}
+		time.Sleep(retryInterval)
+	}
+}

--- a/plugins/builtin/target/aws-asg/plugin/retry_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/retry_test.go
@@ -1,0 +1,49 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_retry(t *testing.T) {
+	testCases := []struct {
+		inputContext   context.Context
+		inputInterval  time.Duration
+		inputRetry     int
+		inputFunc      retryFunc
+		expectedOutput error
+		name           string
+	}{
+		{
+			inputContext:  context.Background(),
+			inputInterval: 1 * time.Millisecond,
+			inputRetry:    1,
+			inputFunc: func(ctx context.Context) (stop bool, err error) {
+				return true, nil
+			},
+			expectedOutput: nil,
+			name:           "successful function first time",
+		},
+		{
+			inputContext:  context.Background(),
+			inputInterval: 1 * time.Millisecond,
+			inputRetry:    1,
+			inputFunc: func(ctx context.Context) (stop bool, err error) {
+				return false, errors.New("error")
+			},
+			expectedOutput: errors.New("reached retry limit"),
+			name:           "function never successful and reaches retry limit",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := retry(tc.inputContext, tc.inputInterval, tc.inputRetry, tc.inputFunc)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}


### PR DESCRIPTION
This commit adds to initial work for the new AWS AutoScaling Group
target plugin which allows for the scaling of AWS ASGs.

The plugin attempts to perform some basic validation that actions
taken against the AWS API are completed as desired. There is at
this point no reconciliation of failed steps, which should be
added at a later date.

The plugin is within the main repository as we do not currently
have a story of building and releasing plugins from separate repos
which should be looked at in the future. The plugin is also not
launched within the plugin manager, this will be added later when
all the cluster scaling work is tied together.

closes #154 