### PR TITLE
agent: add policy dir config param to allow policies from disk.

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -120,6 +120,10 @@ type Plugin struct {
 // and resulting policy parsing.
 type Policy struct {
 
+	// Dir is the directory which contains scaling policies to be loaded from
+	// disk. This currently only supports cluster scaling policies.
+	Dir string `hcl:"dir,optional"`
+
 	// DefaultCooldown is the default cooldown parameter added to all policies
 	// which do not explicitly configure the parameter.
 	DefaultCooldown    time.Duration
@@ -333,6 +337,9 @@ func (p *Plugin) copy() *Plugin {
 func (p *Policy) merge(b *Policy) *Policy {
 	result := *p
 
+	if b.Dir != "" {
+		result.Dir = b.Dir
+	}
 	if b.DefaultCooldown != 0 {
 		result.DefaultCooldown = b.DefaultCooldown
 	}

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -72,6 +72,7 @@ func TestAgent_Merge(t *testing.T) {
 			SkipVerify:    true,
 		},
 		Policy: &Policy{
+			Dir:             "/etc/scaling/policies",
 			DefaultCooldown: 20 * time.Minute,
 		},
 		APMs: []*Plugin{
@@ -117,6 +118,7 @@ func TestAgent_Merge(t *testing.T) {
 			SkipVerify:    true,
 		},
 		Policy: &Policy{
+			Dir:             "/etc/scaling/policies",
 			DefaultCooldown: 20 * time.Minute,
 		},
 		APMs: []*Plugin{

--- a/command/agent.go
+++ b/command/agent.go
@@ -107,6 +107,10 @@ Nomad Options:
 
 Policy Options:
 
+  -policy-dir=<path>
+    The path to a directory used to load scaling policies. Currently only cluster
+    scaling policies can be loaded by this method.
+
   -policy-default-cooldown=<dur>
     The default cooldown that will be applied to all scaling policies which do
     not specify a cooldown period.
@@ -193,6 +197,7 @@ func (c *AgentCommand) readConfig() *config.Agent {
 	flags.BoolVar(&cmdConfig.Nomad.SkipVerify, "nomad-skip-verify", false, "")
 
 	// Specify our Policy CLI flags.
+	flags.StringVar(&cmdConfig.Policy.Dir, "policy-dir", "", "")
 	flags.Var((flaghelper.FuncDurationVar)(func(d time.Duration) error {
 		cmdConfig.Policy.DefaultCooldown = d
 		return nil


### PR DESCRIPTION
The name of the param was chosen to be vague and non-cluster specific so that we can in the future open up the possibility of configuring job scaling policies in the same manner. That being said if we want to change it, I have no feelings on the matter at all.

The config param is optional and defaults to an empty string to allow skipping setting up this policy source if not explicitly desired.

closes #156 