### PR TITLE
strategy: use single action for Run response rather than array.

### DIFF
--- a/plugins/strategy/action.go
+++ b/plugins/strategy/action.go
@@ -27,7 +27,44 @@ type Action struct {
 
 	Reason string
 	Error  bool
-	Meta   map[string]interface{}
+
+	// Direction is the scaling direction the strategy has decided should
+	// happen. This is particularly helpful for non-Nomad target
+	// implementations whose APIs dead with increment changes rather than
+	// absolute counts.
+	Direction ScaleDirection
+
+	Meta map[string]interface{}
+}
+
+// ScaleDirection is an identifier used by strategy plugins to identify how the
+// target should scale the named resource.
+type ScaleDirection int8
+
+const (
+	// ScaleDirectionNone indicates no scaling is required.
+	ScaleDirectionNone = iota
+
+	// ScaleDirectionDown indicates the target should lower the number of running
+	// instances of the resource.
+	ScaleDirectionDown
+
+	// ScaleDirectionUp indicates the target should increase the number of
+	// running instances of the resource.
+	ScaleDirectionUp
+)
+
+// String satisfies the Stringer interface and returns as string representation
+// of the scaling direction.
+func (d ScaleDirection) String() string {
+	switch d {
+	case ScaleDirectionDown:
+		return "down"
+	case ScaleDirectionUp:
+		return "up"
+	default:
+		return "none"
+	}
 }
 
 // Canonicalize ensures Action has proper default values.

--- a/plugins/strategy/action_test.go
+++ b/plugins/strategy/action_test.go
@@ -6,6 +6,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestScaleDirection_String(t *testing.T) {
+	testCases := []struct {
+		inputDirection       ScaleDirection
+		expectedOutputString string
+	}{
+		{inputDirection: ScaleDirectionNone, expectedOutputString: "none"},
+		{inputDirection: ScaleDirectionDown, expectedOutputString: "down"},
+		{inputDirection: ScaleDirectionUp, expectedOutputString: "up"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expectedOutputString, func(t *testing.T) {
+			actualOutput := tc.inputDirection.String()
+			assert.Equal(t, tc.expectedOutputString, actualOutput, tc.expectedOutputString)
+		})
+	}
+}
+
 func TestAction_Canonicalize(t *testing.T) {
 	testCases := []struct {
 		inputAction          *Action

--- a/plugins/strategy/strategy.go
+++ b/plugins/strategy/strategy.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Strategy interface {
-	Run(req RunRequest) (RunResponse, error)
+	Run(req RunRequest) (Action, error)
 	PluginInfo() (*base.PluginInfo, error)
 	SetConfig(config map[string]string) error
 }
@@ -41,10 +41,6 @@ type RunRequest struct {
 	Config   map[string]string
 }
 
-type RunResponse struct {
-	Actions []Action
-}
-
 func (r *RPC) SetConfig(config map[string]string) error {
 	var resp error
 	err := r.client.Call("Plugin.SetConfig", config, &resp)
@@ -54,11 +50,11 @@ func (r *RPC) SetConfig(config map[string]string) error {
 	return resp
 }
 
-func (r *RPC) Run(req RunRequest) (RunResponse, error) {
-	var resp RunResponse
+func (r *RPC) Run(req RunRequest) (Action, error) {
+	var resp Action
 	err := r.client.Call("Plugin.Run", req, &resp)
 	if err != nil {
-		return RunResponse{}, err
+		return Action{}, err
 	}
 
 	return resp, nil
@@ -74,7 +70,7 @@ func (s *RPCServer) SetConfig(config map[string]string, resp *error) error {
 	return err
 }
 
-func (s *RPCServer) Run(req RunRequest, resp *RunResponse) error {
+func (s *RPCServer) Run(req RunRequest, resp *Action) error {
 	r, err := s.Impl.Run(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
The array response from a strategy run was legacy left over from
initial designs and has become redundant. This commit therefore
removes the use of an array in favour of a single action response.

The single response makes the agent evaluation code simpler and
will also make future multi-check work easier to implement.

It was discovered that the length of the response was used to
perform some evaluation logic. The strategy response object has
therefore been updated to include a direction. This is not a new
concept to the Autoscaler and was used in the target-value
strategy plugin originally. It is also used within infra provider
target plugins as they have to deal with calling APIs with
incremental count changes rather than absolute. I believe this is
therefore an acceptable change to the interface and provides wide
benefit.

closes #169 