### PR TITLE
policy/nomad: fix fast loop when Nomad policy syntax is incorrect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 
 BUG FIXES:
  * cli: fix incorrect flag help detail for `nomad-ca-path` [[GH-168](https://github.com/hashicorp/nomad-autoscaler/pull/168)]
+ * policy/nomad: fix fast loop when Nomad policy syntax is incorrect [[GH-179](https://github.com/hashicorp/nomad-autoscaler/pull/179)]
 
 ## 0.0.2 (May 21, 2020)
 

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -167,6 +167,11 @@ func (s *Source) MonitorPolicy(ctx context.Context, ID policy.PolicyID, resultCh
 				continue
 			}
 
+			// GH-165: update the wait index. After this point there is a
+			// possibility of continuing the loop and without setting the index
+			// we will just fast loop indefinitely.
+			q.WaitIndex = meta.LastIndex
+
 			if err := validateScalingPolicy(p); err != nil {
 				errMsg := "policy validation failed"
 				if _, ok := err.(*multierror.Error); ok {
@@ -184,7 +189,6 @@ func (s *Source) MonitorPolicy(ctx context.Context, ID policy.PolicyID, resultCh
 			s.canonicalizePolicy(&autoPolicy)
 
 			resultCh <- autoPolicy
-			q.WaitIndex = meta.LastIndex
 		}
 	}
 }


### PR DESCRIPTION
closes #165 