### PR TITLE
Make IndexHasChanged more resilient to Raft quirks

### DIFF
--- a/helper/blocking/blocking.go
+++ b/helper/blocking/blocking.go
@@ -2,4 +2,4 @@ package blocking
 
 // IndexHasChanged is used to check whether a returned blocking query has an
 // updated index, compared to a tracked value.
-func IndexHasChanged(new, old uint64) bool { return new > old }
+func IndexHasChanged(new, old uint64) bool { return new != old }

--- a/helper/blocking/blocking_test.go
+++ b/helper/blocking/blocking_test.go
@@ -25,7 +25,7 @@ func Test_indexHasChange(t *testing.T) {
 		{
 			newValue:       7,
 			oldValue:       13,
-			expectedReturn: false,
+			expectedReturn: true,
 		},
 	}
 


### PR DESCRIPTION
Per https://www.consul.io/api-docs/features/blocking#implementation-details the index can go backward, or even reset, and thus checking for equality will be more resilient for detecting changes

This will be even more relevant with Nomad supporting snapshot restore 