### PR TITLE
plugin/target/aws-asg: fix panic when parsing last ASG activity.

### DIFF
--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -152,19 +152,17 @@ func (t *TargetPlugin) Status(config map[string]string) (*target.Status, error) 
 		return nil, fmt.Errorf("failed to describe AWS Autoscaling Group activities: %v", err)
 	}
 
+	// Set our initial status. The asg.Status field is only set when the ASG is
+	// being deleted.
 	resp := target.Status{
 		Ready: asg.Status == nil,
 		Count: *asg.DesiredCapacity,
+		Meta:  make(map[string]string),
 	}
 
-	// If the ASG has scaling activities listed ensure the status takes into
-	// account the most recent activity. Most importantly if the last event has
-	// not finished, the ASG is not ready for scaling.
+	// If we have previous activities then process the last.
 	if events != nil && len(events) > 0 {
-		resp.Ready = resp.Ready || *events[0].Progress == 100
-		resp.Meta = map[string]string{
-			target.MetaKeyLastEvent: strconv.FormatInt(events[0].EndTime.UnixNano(), 10),
-		}
+		processLastActivity(events[0], &resp)
 	}
 
 	return &resp, nil
@@ -179,4 +177,22 @@ func (t *TargetPlugin) calculateDirection(asgDesired, strategyDesired int64) (in
 		return strategyDesired, "out"
 	}
 	return 0, ""
+}
+
+// processLastActivity updates the status object based on the details within
+// the last scaling activity.
+func processLastActivity(activity autoscaling.Activity, status *target.Status) {
+
+	// If the last activities progress is not nil then check whether this
+	// finished or not. In the event there is a current activity in progress
+	// set ready to false so the autoscaler will not perform any actions.
+	if activity.Progress != nil && *activity.Progress != 100 {
+		status.Ready = false
+	}
+
+	// EndTime isn't always populated, especially if the activity has not yet
+	// finished :).
+	if activity.EndTime != nil {
+		status.Meta[target.MetaKeyLastEvent] = strconv.FormatInt(activity.EndTime.UnixNano(), 10)
+	}
 }

--- a/plugins/builtin/target/aws-asg/plugin/plugin_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin_test.go
@@ -2,7 +2,10 @@ package plugin
 
 import (
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/hashicorp/nomad-autoscaler/plugins/target"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,4 +49,77 @@ func TestTargetPlugin_calculateDirection(t *testing.T) {
 			assert.Equal(t, tc.expectedOutputString, actualString, tc.name)
 		})
 	}
+}
+
+func Test_processLastActivity(t *testing.T) {
+
+	testTime := time.Date(2020, time.April, 13, 8, 4, 0, 0, time.UTC)
+
+	testCases := []struct {
+		inputActivity  autoscaling.Activity
+		inputStatus    *target.Status
+		expectedStatus *target.Status
+		name           string
+	}{
+		{
+			inputActivity: autoscaling.Activity{
+				Progress: int64ToPtr(75),
+			},
+			inputStatus: &target.Status{
+				Ready: true,
+				Count: 1,
+				Meta:  map[string]string{},
+			},
+			expectedStatus: &target.Status{
+				Ready: false,
+				Count: 1,
+				Meta:  map[string]string{},
+			},
+			name: "latest activity still in progress",
+		},
+		{
+			inputActivity: autoscaling.Activity{
+				Progress: int64ToPtr(100),
+				EndTime:  &testTime,
+			},
+			inputStatus: &target.Status{
+				Ready: true,
+				Count: 1,
+				Meta:  map[string]string{},
+			},
+			expectedStatus: &target.Status{
+				Ready: true,
+				Count: 1,
+				Meta: map[string]string{
+					"nomad_autoscaler.last_event": "1586765040000000000",
+				},
+			},
+			name: "latest activity completed",
+		},
+		{
+			inputActivity: autoscaling.Activity{},
+			inputStatus: &target.Status{
+				Ready: true,
+				Count: 1,
+				Meta:  map[string]string{},
+			},
+			expectedStatus: &target.Status{
+				Ready: true,
+				Count: 1,
+				Meta:  map[string]string{},
+			},
+			name: "latest activity all nils",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			processLastActivity(tc.inputActivity, tc.inputStatus)
+			assert.Equal(t, tc.expectedStatus, tc.inputStatus, tc.name)
+		})
+	}
+}
+
+func int64ToPtr(v int64) *int64 {
+	return &v
 }


### PR DESCRIPTION
If the target is queried for status while a scaling activity is
in-progress the EndTime will not be populated. The parsing should
therefore protect against this, otherwise the plugin will panic
which is less than ideal, especially during a demo.