### PR TITLE
plugin/apm/nomad: support obtaining cluster usage metrics.

### DIFF
--- a/plugins/builtin/apm/nomad/plugin/job.go
+++ b/plugins/builtin/apm/nomad/plugin/job.go
@@ -1,0 +1,179 @@
+package plugin
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+// taskGroupQuery is the plugins internal representation of a query and
+// contains all the information needed to perform a Nomad APM query for a task
+// group.
+type taskGroupQuery struct {
+	metric    string
+	job       string
+	group     string
+	operation string
+}
+
+func (a *APMPlugin) queryTaskGroup(q string) (float64, error) {
+
+	// Parse the query ensuring we have all information available to make all
+	// subsequent calls.
+	query, err := parseTaskGroupQuery(q)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse query: %v", err)
+	}
+	a.logger.Debug("expanded query", "from", q, "to", fmt.Sprintf("%# v", query))
+
+	metrics, err := a.getTaskGroupResourceUsage(query)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(metrics) == 0 {
+		return 0, fmt.Errorf("metric not found: %s", q)
+	}
+	a.logger.Debug("metrics found", "num_data_points", len(metrics), "query", q)
+
+	return calculateTaskGroupResult(query.operation, metrics), nil
+}
+
+// getTaskGroupResourceUsage iterates the allocations within a job and
+// identifies those which meet the criteria for being part of the calculation.
+func (a *APMPlugin) getTaskGroupResourceUsage(query *taskGroupQuery) ([]float64, error) {
+
+	// Grab the list of allocations assigned to the job in question.
+	allocs, _, err := a.client.Jobs().Allocations(query.job, false, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get alloc listing for job: %v", err)
+	}
+
+	// The response is a list of data points from each allocation running in
+	// the task group.
+	var resp []float64
+
+	// Define a function that manages updating our response.
+	metricFunc := func(m *[]float64, ru *api.ResourceUsage) {}
+
+	// Depending on the desired metric, the function will append different data
+	// to the response. Using a function means we only have to perform the
+	// switch a single time, rather than on a per allocation basis.
+	switch query.metric {
+	case queryMetricCPU:
+		metricFunc = func(m *[]float64, ru *api.ResourceUsage) {
+			*m = append(*m, ru.CpuStats.Percent)
+		}
+	case queryMetricMem:
+		metricFunc = func(m *[]float64, ru *api.ResourceUsage) {
+			*m = append(*m, float64(ru.MemoryStats.Usage))
+		}
+	}
+
+	for _, alloc := range allocs {
+
+		// If the allocation is not running, or is not part of the target task
+		// group then we should skip and move onto the next allocation.
+		if alloc.ClientStatus != api.AllocClientStatusRunning || alloc.TaskGroup != query.group {
+			continue
+		}
+
+		// Obtains the statistics for the task group allocation. If we get a
+		// single error during the iteration, we cannot reliably make a scaling
+		// calculation.
+		//
+		// When calling Stats an entire Allocation object is needed, but only
+		// the ID is used within the call. Further details:
+		// https://github.com/hashicorp/nomad/issues/7955
+		allocStats, err := a.client.Allocations().Stats(&api.Allocation{ID: alloc.ID}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get alloc stats: %v", err)
+		}
+
+		// Be safe, be sensible.
+		if allocStats == nil {
+			continue
+		}
+
+		// Call the metric function to append the allocation resource metric to
+		// the response.
+		metricFunc(&resp, allocStats.ResourceUsage)
+	}
+
+	return resp, nil
+}
+
+// calculateTaskGroupResult determines the query result based on the metrics
+// and operation to perform.
+func calculateTaskGroupResult(op string, metrics []float64) float64 {
+
+	var result float64
+
+	switch op {
+	case queryOpSum:
+		for _, m := range metrics {
+			result += m
+		}
+	case queryOpAvg:
+		for _, m := range metrics {
+			result += m
+		}
+		result /= float64(len(metrics))
+	case queryOpMax:
+		result = math.SmallestNonzeroFloat64
+		for _, m := range metrics {
+			if m > result {
+				result = m
+			}
+		}
+	case queryOpMin:
+		result = math.MaxFloat64
+		for _, m := range metrics {
+			if m < result {
+				result = m
+			}
+		}
+	}
+	return result
+}
+
+// parseTaskGroupQuery takes the query string and transforms it into our
+// internal query representation. Parsing validates that the returned query is
+// usable by all subsequent calls but cannot ensure the job or group will
+// actually be found on the cluster.
+func parseTaskGroupQuery(q string) (*taskGroupQuery, error) {
+	mainParts := strings.SplitN(q, "/", 3)
+	if len(mainParts) != 3 {
+		return nil, fmt.Errorf("expected <query>/<group>/<job>, received %s", q)
+	}
+
+	query := &taskGroupQuery{
+		group: mainParts[1],
+		job:   mainParts[2],
+	}
+
+	opMetricParts := strings.SplitN(mainParts[0], "_", 3)
+	if len(opMetricParts) != 3 {
+		return nil, fmt.Errorf(`expected taskgroup_<operation>_<metric>, received "%s"`, mainParts[0])
+	}
+
+	op := opMetricParts[1]
+	metric := opMetricParts[2]
+
+	if err := validateMetric(metric); err != nil {
+		return nil, err
+	}
+	query.metric = metric
+
+	switch op {
+	case queryOpSum, queryOpAvg, queryOpMin, queryOpMax:
+		query.operation = op
+	default:
+		return nil, fmt.Errorf(`invalid operation %q, allowed values are %s, %s, %s or %s`,
+			op, queryOpSum, queryOpAvg, queryOpMin, queryOpMax)
+	}
+
+	return query, nil
+}

--- a/plugins/builtin/apm/nomad/plugin/job_test.go
+++ b/plugins/builtin/apm/nomad/plugin/job_test.go
@@ -1,0 +1,135 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_calculateTaskGroupResult(t *testing.T) {
+	testCases := []struct {
+		inputOp        string
+		inputMetrics   []float64
+		expectedOutput float64
+		name           string
+	}{
+		{
+			inputOp:        queryOpSum,
+			inputMetrics:   []float64{76.34, 13.13, 24.50},
+			expectedOutput: 113.97,
+			name:           "sum operation",
+		},
+		{
+			inputOp:        queryOpAvg,
+			inputMetrics:   []float64{76.34, 13.13, 24.50},
+			expectedOutput: 37.99,
+			name:           "avg operation",
+		},
+		{
+			inputOp:        queryOpMax,
+			inputMetrics:   []float64{76.34, 13.13, 24.50, 76.33},
+			expectedOutput: 76.34,
+			name:           "max operation",
+		},
+		{
+			inputOp:        queryOpMin,
+			inputMetrics:   []float64{76.34, 13.13, 24.50, 13.14},
+			expectedOutput: 13.13,
+			name:           "min operation",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := calculateTaskGroupResult(tc.inputOp, tc.inputMetrics)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}
+
+func Test_parseTaskGroupQuery(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expected    *taskGroupQuery
+		expectError bool
+	}{
+		{
+			name:  "avg_cpu",
+			input: "taskgroup_avg_cpu/group/job",
+			expected: &taskGroupQuery{
+				metric:    "cpu",
+				job:       "job",
+				group:     "group",
+				operation: "avg",
+			},
+			expectError: false,
+		},
+		{
+			name:  "avg_memory",
+			input: "taskgroup_avg_memory/group/job",
+			expected: &taskGroupQuery{
+				metric:    "memory",
+				job:       "job",
+				group:     "group",
+				operation: "avg",
+			},
+			expectError: false,
+		},
+		{
+			name:  "job with fwd slashes",
+			input: "taskgroup_avg_cpu/group/my/super/job//",
+			expected: &taskGroupQuery{
+				metric:    "cpu",
+				job:       "my/super/job//",
+				group:     "group",
+				operation: "avg",
+			},
+			expectError: false,
+		},
+		{
+			name:        "empty query",
+			input:       "",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid query format",
+			input:       "invalid",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "missing job",
+			input:       "avg_cpu/group",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid op_metric format",
+			input:       "taskgroup_invalid/groups/job",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid operation",
+			input:       "taskgroup_op_invalid/group/job",
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := parseTaskGroupQuery(tc.input)
+
+			assert.Equal(t, tc.expected, actual)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/plugins/builtin/apm/nomad/plugin/metrics.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics.go
@@ -2,192 +2,58 @@ package plugin
 
 import (
 	"fmt"
-	"math"
 	"strings"
-
-	"github.com/hashicorp/nomad/api"
 )
 
-// query is the plugins internal representation of a query and contains all the
-// information needed to perform a Nomad APM query.
-type query struct {
-	metric    string
-	job       string
-	group     string
-	operation string
-}
-
 const (
-	// queryOps are the supported operators.
+	// queryTypes are the types of query the Nomad APM plugin can handle. Each
+	// one has its own path to discovering the correct data and so its
+	// important this is included and validated on every query request.
+	QueryTypeTaskGroup = "taskgroup"
+	QueryTypeNode      = "node"
+
+	// queryOps below are the supported operators for task group queries.
 	queryOpSum = "sum"
 	queryOpAvg = "avg"
 	queryOpMax = "max"
 	queryOpMin = "min"
+
+	// queryOps below are the supported operators for node pool queries.
+	queryOpPercentageAllocated = "percentage-allocated"
 
 	// queryMetrics are the supported resources for querying.
 	queryMetricCPU = "cpu"
 	queryMetricMem = "memory"
 )
 
+// Query satisfies the Query function on the apm.APM interface.
 func (a *APMPlugin) Query(q string) (float64, error) {
 
-	// Parse the query ensuring we have all information available to make all
-	// subsequent calls.
-	query, err := parseQuery(q)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse query: %v", err)
-	}
-	a.logger.Debug("expanded query", "from", q, "to", fmt.Sprintf("%# v", query))
+	// Split the input query so we can understand which query type we are
+	// dealing with.
+	querySplit := strings.Split(q, "_")
 
-	metrics, err := a.getTaskGroupResourceUsage(query)
-	if err != nil {
-		return 0, err
+	switch querySplit[0] {
+	case QueryTypeTaskGroup:
+		return a.queryTaskGroup(q)
+	case QueryTypeNode:
+		return a.queryNodePool(q)
+	default:
+		return 0, fmt.Errorf("unsupported query type %q", querySplit[0])
 	}
-
-	if len(metrics) == 0 {
-		return 0, fmt.Errorf("metric not found: %s", q)
-	}
-	a.logger.Debug("metrics found", "num_data_points", len(metrics), "query", q)
-
-	return calculateResult(query.operation, metrics), nil
 }
 
-// getTaskGroupResourceUsage iterates the allocations within a job and
-// identifies those which meet the criteria for being part of the calculation.
-func (a *APMPlugin) getTaskGroupResourceUsage(query *query) ([]float64, error) {
+// validateMetric helps ensure the desired metric within the query is able to
+// be handled by the plugin.
+func validateMetric(metric string) error {
 
-	// Grab the list of allocations assigned to the job in question.
-	allocs, _, err := a.client.Jobs().Allocations(query.job, false, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get alloc listing for job: %v", err)
-	}
-
-	// The response is a list of data points from each allocation running in
-	// the task group.
-	var resp []float64
-
-	// Define a function that manages updating our response.
-	metricFunc := func(m *[]float64, ru *api.ResourceUsage) {}
-
-	// Depending on the desired metric, the function will append different data
-	// to the response. Using a function means we only have to perform the
-	// switch a single time, rather than on a per allocation basis.
-	switch query.metric {
-	case queryMetricCPU:
-		metricFunc = func(m *[]float64, ru *api.ResourceUsage) {
-			*m = append(*m, ru.CpuStats.Percent)
-		}
-	case queryMetricMem:
-		metricFunc = func(m *[]float64, ru *api.ResourceUsage) {
-			*m = append(*m, float64(ru.MemoryStats.Usage))
-		}
-	}
-
-	for _, alloc := range allocs {
-
-		// If the allocation is not running, or is not part of the target task
-		// group then we should skip and move onto the next allocation.
-		if alloc.ClientStatus != api.AllocClientStatusRunning || alloc.TaskGroup != query.group {
-			continue
-		}
-
-		// Obtains the statistics for the task group allocation. If we get a
-		// single error during the iteration, we cannot reliably make a scaling
-		// calculation.
-		//
-		// When calling Stats an entire Allocation object is needed, but only
-		// the ID is used within the call. Further details:
-		// https://github.com/hashicorp/nomad/issues/7955
-		allocStats, err := a.client.Allocations().Stats(&api.Allocation{ID: alloc.ID}, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get alloc stats: %v", err)
-		}
-
-		// Be safe, be sensible.
-		if allocStats == nil {
-			continue
-		}
-
-		// Call the metric function to append the allocation resource metric to
-		// the response.
-		metricFunc(&resp, allocStats.ResourceUsage)
-	}
-
-	return resp, nil
-}
-
-// calculateResult determines the query result based on the metrics and
-// operation to perform.
-func calculateResult(op string, metrics []float64) float64 {
-
-	var result float64
-
-	switch op {
-	case queryOpSum:
-		for _, m := range metrics {
-			result += m
-		}
-	case queryOpAvg:
-		for _, m := range metrics {
-			result += m
-		}
-		result /= float64(len(metrics))
-	case queryOpMax:
-		result = math.SmallestNonzeroFloat64
-		for _, m := range metrics {
-			if m > result {
-				result = m
-			}
-		}
-	case queryOpMin:
-		result = math.MaxFloat64
-		for _, m := range metrics {
-			if m < result {
-				result = m
-			}
-		}
-	}
-	return result
-}
-
-// parseQuery takes the query string and transforms it into our internal query
-// representation. Parsing validates that the returned query is usable by all
-// subsequent calls but cannot ensure the job or group will actually be found
-// on the cluster.
-func parseQuery(q string) (*query, error) {
-	mainParts := strings.SplitN(q, "/", 3)
-	if len(mainParts) != 3 {
-		return nil, fmt.Errorf("expected <query>/<job>/group>, received %s", q)
-	}
-
-	query := &query{
-		group: mainParts[1],
-		job:   mainParts[2],
-	}
-
-	opMetricParts := strings.SplitN(mainParts[0], "_", 2)
-	if len(opMetricParts) != 2 {
-		return nil, fmt.Errorf(`expected <operation>_<metric>, received "%s"`, mainParts[0])
-	}
-
-	op := opMetricParts[0]
-	metric := opMetricParts[1]
+	var err error
 
 	switch metric {
 	case queryMetricCPU, queryMetricMem:
-		query.metric = metric
 	default:
-		return nil, fmt.Errorf(`invalid metric %q, allowed values are %s or %s`,
+		err = fmt.Errorf(`invalid metric %q, allowed values are %s or %s`,
 			metric, queryMetricCPU, queryMetricMem)
 	}
-
-	switch op {
-	case queryOpSum, queryOpAvg, queryOpMin, queryOpMax:
-		query.operation = op
-	default:
-		return nil, fmt.Errorf(`invalid operation %q, allowed values are %s, %s, %s or %s`,
-			op, queryOpSum, queryOpAvg, queryOpMin, queryOpMax)
-	}
-
-	return query, nil
+	return err
 }

--- a/plugins/builtin/apm/nomad/plugin/metrics_test.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics_test.go
@@ -1,135 +1,39 @@
 package plugin
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_calculateResult(t *testing.T) {
+func Test_validateMetric(t *testing.T) {
 	testCases := []struct {
-		inputOp        string
-		inputMetrics   []float64
-		expectedOutput float64
+		inputMetric    string
+		expectedOutput error
 		name           string
 	}{
 		{
-			inputOp:        queryOpSum,
-			inputMetrics:   []float64{76.34, 13.13, 24.50},
-			expectedOutput: 113.97,
-			name:           "sum operation",
+			inputMetric:    "memory",
+			expectedOutput: nil,
+			name:           "memory metric",
 		},
 		{
-			inputOp:        queryOpAvg,
-			inputMetrics:   []float64{76.34, 13.13, 24.50},
-			expectedOutput: 37.99,
-			name:           "avg operation",
+			inputMetric:    "cpu",
+			expectedOutput: nil,
+			name:           "cpu metric",
 		},
 		{
-			inputOp:        queryOpMax,
-			inputMetrics:   []float64{76.34, 13.13, 24.50, 76.33},
-			expectedOutput: 76.34,
-			name:           "max operation",
-		},
-		{
-			inputOp:        queryOpMin,
-			inputMetrics:   []float64{76.34, 13.13, 24.50, 13.14},
-			expectedOutput: 13.13,
-			name:           "min operation",
+			inputMetric:    "cost-of-server",
+			expectedOutput: errors.New("invalid metric \"cost-of-server\", allowed values are cpu or memory"),
+			name:           "invalid metric",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualOutput := calculateResult(tc.inputOp, tc.inputMetrics)
+			actualOutput := validateMetric(tc.inputMetric)
 			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
-		})
-	}
-}
-
-func Test_parseQuery(t *testing.T) {
-	testCases := []struct {
-		name        string
-		input       string
-		expected    *query
-		expectError bool
-	}{
-		{
-			name:  "avg_cpu",
-			input: "avg_cpu/group/job",
-			expected: &query{
-				metric:    "cpu",
-				job:       "job",
-				group:     "group",
-				operation: "avg",
-			},
-			expectError: false,
-		},
-		{
-			name:  "avg_memory",
-			input: "avg_memory/group/job",
-			expected: &query{
-				metric:    "memory",
-				job:       "job",
-				group:     "group",
-				operation: "avg",
-			},
-			expectError: false,
-		},
-		{
-			name:  "job with fwd slashes",
-			input: "avg_cpu/group/my/super/job//",
-			expected: &query{
-				metric:    "cpu",
-				job:       "my/super/job//",
-				group:     "group",
-				operation: "avg",
-			},
-			expectError: false,
-		},
-		{
-			name:        "empty query",
-			input:       "",
-			expected:    nil,
-			expectError: true,
-		},
-		{
-			name:        "invalid query format",
-			input:       "invalid",
-			expected:    nil,
-			expectError: true,
-		},
-		{
-			name:        "missing job",
-			input:       "avg_cpu/group",
-			expected:    nil,
-			expectError: true,
-		},
-		{
-			name:        "invalid op_metric format",
-			input:       "invalid/groups/job",
-			expected:    nil,
-			expectError: true,
-		},
-		{
-			name:        "invalid operation",
-			input:       "op_invalid/group/job",
-			expected:    nil,
-			expectError: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual, err := parseQuery(tc.input)
-
-			assert.Equal(t, tc.expected, actual)
-
-			if tc.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
 		})
 	}
 }

--- a/plugins/builtin/apm/nomad/plugin/node.go
+++ b/plugins/builtin/apm/nomad/plugin/node.go
@@ -1,0 +1,215 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad-autoscaler/helper/scaleutils"
+	"github.com/hashicorp/nomad/api"
+)
+
+// nodePoolQuery is the plugins internal representation of a query and contains
+// all the information needed to perform a Nomad APM query for a node pool.
+type nodePoolQuery struct {
+	metric         string
+	poolIdentifier *scaleutils.PoolIdentifier
+	operation      string
+}
+
+type nodePoolResources struct {
+	allocatable *poolResources
+	allocated   *poolResources
+}
+
+type poolResources struct {
+	cpu int64
+	mem int64
+}
+
+// queryNodePool is the main entry point when performing a Nomad node pool APM
+// query.
+func (a *APMPlugin) queryNodePool(q string) (float64, error) {
+
+	// Parse our query to ensure we have all the information required to
+	// continue.
+	query, err := parseNodePoolQuery(q)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse query: %v", err)
+	}
+	a.logger.Debug("performing node pool APM query", "query", q)
+
+	// Identify the resource available and consumed within the target pool.
+	resources, err := a.getPoolResources(query.poolIdentifier)
+	if err != nil {
+		return 0, err
+	}
+	a.logger.Debug("collected node pool resource data",
+		"allocated_cpu", resources.allocated.cpu, "allocated_memory", resources.allocated.mem,
+		"allocatable_cpu", resources.allocatable.cpu, "allocatable_memory", resources.allocatable.mem)
+
+	var result float64
+
+	// There is no need for a default catch all here as the metric has been
+	// validated during the query parsing.
+	switch query.metric {
+	case queryMetricMem:
+		if resources.allocatable.mem == 0 {
+			return 0, errors.New("zero allocatable memory found in pool")
+		}
+		result = calculateNodePoolResult(float64(resources.allocated.mem), float64(resources.allocatable.mem))
+	case queryMetricCPU:
+		if resources.allocatable.cpu == 0 {
+			return 0, errors.New("zero allocatable cpu found in pool")
+		}
+		result = calculateNodePoolResult(float64(resources.allocated.cpu), float64(resources.allocatable.cpu))
+	}
+
+	return result, nil
+}
+
+// getPoolResources gathers the allocatable and allocated resources for the
+// specified node pool. Any error in calling the Nomad API for details will
+// result in an error. This is because with missing data, we cannot reliably
+// make calculations.
+func (a *APMPlugin) getPoolResources(id *scaleutils.PoolIdentifier) (*nodePoolResources, error) {
+
+	nodes, _, err := a.client.Nodes().List(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Nomad nodes: %v", err)
+	}
+
+	// Perform our node filtering so we are left with a list of nodes that form
+	// our pool and that are in the correct state.
+	nodePoolList, err := id.IdentifyNodes(nodes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to identify nodes within pool")
+	}
+	if len(nodePoolList) == 0 {
+		return nil, errors.New("no nodes identified within pool")
+	}
+
+	// Ensure we instantiate the whole object.
+	resp := nodePoolResources{
+		allocatable: &poolResources{},
+		allocated:   &poolResources{},
+	}
+
+	// Loop here so we only need to iterate the list of nodes once.
+	for _, node := range nodePoolList {
+
+		// If we get a single error when performing the following lookups we
+		// cannot reliably make calculations.
+		if err := a.getNodeAllocatableResources(node.ID, resp.allocatable); err != nil {
+			return nil, fmt.Errorf("failed to get allocatable resources on node %s: %v", node.ID, err)
+		}
+		if err := a.getNodeAllocatedResources(node.ID, resp.allocated); err != nil {
+			return nil, fmt.Errorf("failed to get allocated resources on node %s: %v", node.ID, err)
+		}
+	}
+
+	return &resp, nil
+}
+
+// getNodeAllocatableResources updates the poolResources tracking with the
+// allocatable resources on the node.
+func (a *APMPlugin) getNodeAllocatableResources(nodeID string, pool *poolResources) error {
+
+	nodeInfo, _, err := a.client.Nodes().Info(nodeID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to read Nomad node info: %v", err)
+	}
+
+	// Update our tracking, making sure to account for reserved resources
+	// on the node.
+	pool.cpu += nodeInfo.NodeResources.Cpu.CpuShares - int64(nodeInfo.ReservedResources.Cpu.CpuShares)
+	pool.mem += nodeInfo.NodeResources.Memory.MemoryMB - int64(nodeInfo.ReservedResources.Memory.MemoryMB)
+
+	return nil
+}
+
+// getNodeAllocatedResources updates the poolResources tracking with the
+// allocated resources on the node.
+func (a *APMPlugin) getNodeAllocatedResources(nodeID string, pool *poolResources) error {
+
+	nodeAllocs, _, err := a.client.Nodes().Allocations(nodeID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to read Nomad node allocs : %v", err)
+	}
+
+	for _, alloc := range nodeAllocs {
+
+		// Do not use the allocations stats if it is in a terminal status.
+		if isServerTerminalStatus(alloc) || isClientTerminalStatus(alloc) {
+			continue
+		}
+
+		// Update our tracking with the resources of the allocation.
+		pool.cpu += int64(*alloc.Resources.CPU)
+		pool.mem += int64(*alloc.Resources.MemoryMB)
+	}
+
+	return nil
+}
+
+func parseNodePoolQuery(q string) (*nodePoolQuery, error) {
+
+	mainParts := strings.SplitN(q, "/", 3)
+	if len(mainParts) != 3 {
+		return nil, fmt.Errorf("expected <query>/<pool_identifier_value>/<pool_identifier_key>, received %s", q)
+	}
+
+	query := nodePoolQuery{
+		poolIdentifier: &scaleutils.PoolIdentifier{
+			IdentifierKey: scaleutils.IdentifierKey(mainParts[2]),
+			Value:         mainParts[1],
+		},
+	}
+
+	opMetricParts := strings.SplitN(mainParts[0], "_", 3)
+	if len(opMetricParts) != 3 {
+		return nil, fmt.Errorf("expected node_<operation>_<metric>, received %s", mainParts[0])
+	}
+
+	if err := validateMetric(opMetricParts[2]); err != nil {
+		return nil, err
+	}
+	query.metric = opMetricParts[2]
+
+	switch opMetricParts[1] {
+	case queryOpPercentageAllocated:
+		query.operation = opMetricParts[1]
+	default:
+		return nil, fmt.Errorf("invalid operation %q, allowed value is %s",
+			opMetricParts[1], queryOpPercentageAllocated)
+	}
+	return &query, nil
+}
+
+// calculateNodePoolResult returns the current usage percentage of the node
+// pool.
+func calculateNodePoolResult(allocated, allocatable float64) float64 {
+	return allocated * 100 / allocatable
+}
+
+// isServerTerminalStatus returns true if the desired state of the allocation
+// is terminal.
+func isServerTerminalStatus(alloc *api.Allocation) bool {
+	switch alloc.DesiredStatus {
+	case api.AllocDesiredStatusRun:
+		return false
+	default:
+		return true
+	}
+}
+
+// isClientTerminalStatus returns true if the desired state of the allocation
+// is terminal.
+func isClientTerminalStatus(alloc *api.Allocation) bool {
+	switch alloc.ClientStatus {
+	case api.AllocClientStatusComplete, api.AllocClientStatusFailed, api.AllocClientStatusLost:
+		return true
+	default:
+		return false
+	}
+}

--- a/plugins/builtin/apm/nomad/plugin/node_test.go
+++ b/plugins/builtin/apm/nomad/plugin/node_test.go
@@ -1,0 +1,192 @@
+package plugin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/nomad-autoscaler/helper/scaleutils"
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseNodePoolQuery(t *testing.T) {
+	testCases := []struct {
+		inputQuery          string
+		expectedOutputQuery *nodePoolQuery
+		expectError         error
+		name                string
+	}{
+		{
+			inputQuery: "node_percentage-allocated_memory/high-memory/class",
+			expectedOutputQuery: &nodePoolQuery{
+				metric: "memory",
+				poolIdentifier: &scaleutils.PoolIdentifier{
+					IdentifierKey: "class",
+					Value:         "high-memory",
+				},
+				operation: "percentage-allocated",
+			},
+			expectError: nil,
+			name:        "node percentage-allocated memory",
+		},
+		{
+			inputQuery: "node_percentage-allocated_cpu/high-compute/class",
+			expectedOutputQuery: &nodePoolQuery{
+				metric: "cpu",
+				poolIdentifier: &scaleutils.PoolIdentifier{
+					IdentifierKey: "class",
+					Value:         "high-compute",
+				},
+				operation: "percentage-allocated",
+			},
+			expectError: nil,
+			name:        "node percentage-allocated cpu",
+		},
+
+		{
+			inputQuery:          "",
+			expectedOutputQuery: nil,
+			expectError:         errors.New("expected <query>/<pool_identifier_value>/<pool_identifier_key>, received "),
+			name:                "empty input query",
+		},
+		{
+			inputQuery:          "invalid",
+			expectedOutputQuery: nil,
+			expectError:         errors.New("expected <query>/<pool_identifier_value>/<pool_identifier_key>, received invalid"),
+			name:                "invalid input query format",
+		},
+		{
+			inputQuery:          "node_percentage-allocated_cpu/class",
+			expectedOutputQuery: nil,
+			expectError:         errors.New("expected <query>/<pool_identifier_value>/<pool_identifier_key>, received node_percentage-allocated_cpu/class"),
+			name:                "missing node pool identifier value",
+		},
+		{
+			inputQuery:          "node_percentage-allocated_invalid/class/high-compute",
+			expectedOutputQuery: nil,
+			expectError:         errors.New("invalid metric \"invalid\", allowed values are cpu or memory"),
+			name:                "invalid metric",
+		},
+		{
+			inputQuery:          "node_invalid_cpu/class/high-compute",
+			expectedOutputQuery: nil,
+			expectError:         errors.New("invalid operation \"invalid\", allowed value is percentage-allocated"),
+			name:                "invalid operation",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualQuery, actualError := parseNodePoolQuery(tc.inputQuery)
+			assert.Equal(t, tc.expectedOutputQuery, actualQuery, tc.name)
+			assert.Equal(t, tc.expectError, actualError, tc.name)
+		})
+	}
+}
+
+func Test_calculateNodePoolResult(t *testing.T) {
+	testCases := []struct {
+		inputAllocated   float64
+		inputAllocatable float64
+		expectedOutput   float64
+		name             string
+	}{
+		{
+			inputAllocated:   1000,
+			inputAllocatable: 38400,
+			expectedOutput:   2.6041666666666665,
+			name:             "general example calculation 1",
+		},
+		{
+			inputAllocated:   512,
+			inputAllocatable: 16384,
+			expectedOutput:   3.125,
+			name:             "general example calculation 2",
+		},
+		{
+			inputAllocated:   0,
+			inputAllocatable: 16384,
+			expectedOutput:   0,
+			name:             "zero allocated",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := calculateNodePoolResult(tc.inputAllocated, tc.inputAllocatable)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}
+
+func Test_isServerTerminalStatus(t *testing.T) {
+	testCases := []struct {
+		inputAlloc     *api.Allocation
+		expectedOutput bool
+		name           string
+	}{
+		{
+			inputAlloc:     &api.Allocation{DesiredStatus: "run"},
+			expectedOutput: false,
+			name:           "desired status run",
+		},
+		{
+			inputAlloc:     &api.Allocation{DesiredStatus: "stop"},
+			expectedOutput: true,
+			name:           "desired status stop",
+		},
+		{
+			inputAlloc:     &api.Allocation{DesiredStatus: "evict"},
+			expectedOutput: true,
+			name:           "desired status evict",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := isServerTerminalStatus(tc.inputAlloc)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}
+
+func Test_isClientTerminalStatus(t *testing.T) {
+	testCases := []struct {
+		inputAlloc     *api.Allocation
+		expectedOutput bool
+		name           string
+	}{
+		{
+			inputAlloc:     &api.Allocation{ClientStatus: "pending"},
+			expectedOutput: false,
+			name:           "client status pending",
+		},
+		{
+			inputAlloc:     &api.Allocation{ClientStatus: "running"},
+			expectedOutput: false,
+			name:           "client status running",
+		},
+		{
+			inputAlloc:     &api.Allocation{ClientStatus: "complete"},
+			expectedOutput: true,
+			name:           "client status complete",
+		},
+		{
+			inputAlloc:     &api.Allocation{ClientStatus: "failed"},
+			expectedOutput: true,
+			name:           "client status failed",
+		},
+		{
+			inputAlloc:     &api.Allocation{ClientStatus: "lost"},
+			expectedOutput: true,
+			name:           "client status lost",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := isClientTerminalStatus(tc.inputAlloc)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}

--- a/plugins/target/target.go
+++ b/plugins/target/target.go
@@ -27,6 +27,14 @@ type Status struct {
 // out-of-band scaling activities have been triggered.
 const MetaKeyLastEvent = "nomad_autoscaler.last_event"
 
+const (
+	// ConfigKeys are the various target config map keys that can be used to
+	// identify a target.
+	ConfigKeyJob       = "Job"
+	ConfigKeyTaskGroup = "Group"
+	ConfigKeyClass     = "class"
+)
+
 // RPC is a plugin implementation that talks over net/rpc
 type RPC struct {
 	client *rpc.Client

--- a/policy/file/source.go
+++ b/policy/file/source.go
@@ -181,6 +181,10 @@ func (s *Source) handlerPolicyReload(ID policy.PolicyID) (*policy.Policy, error)
 	newPolicy.ID = ID.String()
 	newPolicy.ApplyDefaults(s.config)
 
+	for _, c := range newPolicy.Checks {
+		c.CanonicalizeAPMQuery(newPolicy.Target)
+	}
+
 	// Check the new policy against the stored. If they are the same, and
 	// therefore the policy has not changed indicate that to the caller.
 	if md5Sum(newPolicy) == md5Sum(val) {
@@ -246,6 +250,10 @@ func (s *Source) handleDir() ([]policy.PolicyID, error) {
 		}
 
 		scalingPolicy.ApplyDefaults(s.config)
+
+		for _, c := range scalingPolicy.Checks {
+			c.CanonicalizeAPMQuery(scalingPolicy.Target)
+		}
 
 		// We have had to decode the file, so store the information. This makes
 		// the MonitorPolicy function simpler as we have an easy mapping of the

--- a/policy/file/source.go
+++ b/policy/file/source.go
@@ -194,7 +194,7 @@ func (s *Source) handleIndividualPolicyRead(ID policy.PolicyID, path string) (*p
 
 	for _, c := range newPolicy.Checks {
 		c.CanonicalizeAPMQuery(newPolicy.Target)
-  }
+	}
 
 	val, ok := s.policyMap[ID]
 	if !ok || val.policy == nil {

--- a/policy/nomad/source_test.go
+++ b/policy/nomad/source_test.go
@@ -123,7 +123,7 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Checks: []*policy.Check{
 					{
 						Source: plugins.InternalAPMNomad,
-						Query:  "avg_cpu/group/job",
+						Query:  "taskgroup_avg_cpu/group/job",
 						Strategy: &policy.Strategy{
 							Config: map[string]string{},
 						},
@@ -159,7 +159,7 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Checks: []*policy.Check{
 					{
 						Source: plugins.InternalAPMNomad,
-						Query:  "avg_cpu/group/job",
+						Query:  "taskgroup_avg_cpu/group/job",
 						Strategy: &policy.Strategy{
 							Config: map[string]string{},
 						},
@@ -194,7 +194,7 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Checks: []*policy.Check{
 					{
 						Source: plugins.InternalAPMNomad,
-						Query:  "avg_cpu/my_group/my_job",
+						Query:  "taskgroup_avg_cpu/my_group/my_job",
 						Strategy: &policy.Strategy{
 							Config: map[string]string{},
 						},


### PR DESCRIPTION
Operators may wish to use the Nomad APM in order to obtain cluster
resource metrics. In order to enhance the Nomad APM changes have
been made to the query formatting allowing for distinction between
taskgroup and node queries. Each has a very seperate path.

The initial implementation does not use blocking queries meaning
performance is suboptimal. A follow up issue will be used to track
this future work.

closes #155 