### PR TITLE
agent: allow capturing of SIGHUP to reload policy sources.

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"strings"
@@ -14,8 +13,6 @@ import (
 )
 
 type AgentCommand struct {
-	Ctx context.Context
-
 	args []string
 }
 
@@ -148,7 +145,7 @@ func (c *AgentCommand) Run(args []string) int {
 
 	// create and run agent
 	a := agent.NewAgent(parsedConfig, logger)
-	if err := a.Run(c.Ctx); err != nil {
+	if err := a.Run(); err != nil {
 		logger.Error("failed to start agent", "error", err)
 		return 1
 	}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/hashicorp/nomad-autoscaler/command"
 	"github.com/hashicorp/nomad-autoscaler/version"
@@ -13,25 +10,16 @@ import (
 )
 
 func main() {
-	// create context to handle signals
-	ctx, cancel := context.WithCancel(context.Background())
 
-	signalCn := make(chan os.Signal, 1)
-	signal.Notify(signalCn, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-signalCn
-		cancel()
-	}()
-
-	version := fmt.Sprintf("Nomad Autoscaler %s", version.GetHumanVersion())
-	c := cli.NewCLI("nomad-autoscaler", version)
+	versionString := fmt.Sprintf("Nomad Autoscaler %s", version.GetHumanVersion())
+	c := cli.NewCLI("nomad-autoscaler", versionString)
 	c.Args = os.Args[1:]
 	c.Commands = map[string]cli.CommandFactory{
 		"agent": func() (cli.Command, error) {
-			return &command.AgentCommand{Ctx: ctx}, nil
+			return &command.AgentCommand{}, nil
 		},
 		"version": func() (cli.Command, error) {
-			return &command.VersionCommand{Version: version}, nil
+			return &command.VersionCommand{Version: versionString}, nil
 		},
 	}
 

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -51,12 +51,20 @@ func (s *Source) Name() policy.SourceName {
 	return policy.SourceNameNomad
 }
 
+// ReloadIDsMonitor satisfies the ReloadIDsMonitor function of the
+// policy.Source interface.
+//
+// This currently does nothing but in the future will be useful to allow
+// reloading configuration options such as the Nomad client params or the log
+// level.
+func (s *Source) ReloadIDsMonitor() {}
+
 // MonitorIDs retrieves a list of policy IDs from a Nomad cluster and sends it
 // in the resultCh channel when change is detected. Errors are sent through the
 // errCh channel.
 //
 // This function blocks until the context is closed.
-func (s *Source) MonitorIDs(ctx context.Context, resultCh chan<- policy.IDMessage, errCh chan<- error) {
+func (s *Source) MonitorIDs(ctx context.Context, req policy.MonitorIDsReq) {
 	s.log.Debug("starting policy blocking query watcher")
 
 	q := &api.QueryOptions{WaitTime: 5 * time.Minute, WaitIndex: 1}
@@ -81,7 +89,7 @@ func (s *Source) MonitorIDs(ctx context.Context, resultCh chan<- policy.IDMessag
 			}
 
 			if err != nil {
-				errCh <- fmt.Errorf("failed to call the Nomad list policies API: %v", err)
+				req.ErrCh <- fmt.Errorf("failed to call the Nomad list policies API: %v", err)
 				time.Sleep(10 * time.Second)
 				continue
 			}
@@ -108,7 +116,7 @@ func (s *Source) MonitorIDs(ctx context.Context, resultCh chan<- policy.IDMessag
 			q.WaitIndex = meta.LastIndex
 
 			// Send new policy IDs in the channel.
-			resultCh <- policy.IDMessage{IDs: policyIDs, Source: s.Name()}
+			req.ResultCh <- policy.IDMessage{IDs: policyIDs, Source: s.Name()}
 		}
 	}
 }
@@ -117,12 +125,12 @@ func (s *Source) MonitorIDs(ctx context.Context, resultCh chan<- policy.IDMessag
 // when a change is detect. Errors are sent through the errCh channel.
 //
 // This function blocks until the context is closed.
-func (s *Source) MonitorPolicy(ctx context.Context, ID policy.PolicyID, resultCh chan<- policy.Policy, errCh chan<- error) {
-	log := s.log.With("policy_id", ID)
+func (s *Source) MonitorPolicy(ctx context.Context, req policy.MonitorPolicyReq) {
+	log := s.log.With("policy_id", req.ID)
 
 	// Close channels when done with the monitoring loop.
-	defer close(resultCh)
-	defer close(errCh)
+	defer close(req.ResultCh)
+	defer close(req.ErrCh)
 
 	log.Trace("starting policy blocking query watcher")
 
@@ -138,7 +146,7 @@ func (s *Source) MonitorPolicy(ctx context.Context, ID policy.PolicyID, resultCh
 			// sleep and try again.
 			//
 			// TODO(jrasell) in the future maybe use a better method than sleep.
-			p, meta, err := s.nomad.Scaling().GetPolicy(string(ID), q)
+			p, meta, err := s.nomad.Scaling().GetPolicy(string(req.ID), q)
 
 			// Return immediately if context is closed.
 			if ctx.Err() != nil {
@@ -147,7 +155,7 @@ func (s *Source) MonitorPolicy(ctx context.Context, ID policy.PolicyID, resultCh
 			}
 
 			if err != nil {
-				errCh <- fmt.Errorf("failed to get policy: %v", err)
+				req.ErrCh <- fmt.Errorf("failed to get policy: %v", err)
 				time.Sleep(10 * time.Second)
 				continue
 			}
@@ -172,14 +180,14 @@ func (s *Source) MonitorPolicy(ctx context.Context, ID policy.PolicyID, resultCh
 					err = fmt.Errorf("%s: %v", errMsg, err)
 				}
 
-				errCh <- err
+				req.ErrCh <- err
 				continue
 			}
 
 			autoPolicy := parsePolicy(p)
 			s.canonicalizePolicy(&autoPolicy)
 
-			resultCh <- autoPolicy
+			req.ResultCh <- autoPolicy
 		}
 	}
 }

--- a/policy/source.go
+++ b/policy/source.go
@@ -11,15 +11,32 @@ type ConfigDefaults struct {
 	DefaultCooldown           time.Duration
 }
 
+type MonitorIDsReq struct {
+	ErrCh    chan<- error
+	ResultCh chan<- IDMessage
+}
+
+type MonitorPolicyReq struct {
+	ID       PolicyID
+	ErrCh    chan<- error
+	ReloadCh <-chan struct{}
+	ResultCh chan<- Policy
+}
+
 // Source is the interface that must be implemented by backends which provide
 // the canonical source for scaling policies.
 type Source interface {
-	MonitorIDs(ctx context.Context, resultCh chan<- IDMessage, errCh chan<- error)
-	MonitorPolicy(ctx context.Context, ID PolicyID, resultCh chan<- Policy, errCh chan<- error)
+	MonitorIDs(ctx context.Context, monitorIDsReq MonitorIDsReq)
+	MonitorPolicy(ctx context.Context, monitorPolicyReq MonitorPolicyReq)
 
 	// Name returns the SourceName for the implementation. This helps handlers
 	// identify the source implementation which is responsible for policies.
 	Name() SourceName
+
+	// ReloadIDsMonitor is used to trigger a reload of the MonitorIDs routine
+	// so that config items can be reloaded gracefully without restarting the
+	// agent.
+	ReloadIDsMonitor()
 }
 
 type PolicyID string


### PR DESCRIPTION
The file source in particular benefits greatly from being able
to perform reloads. This allows the source to re-read and decode
files which may have changed as well as process new or delete
scaling policies. In order to keep the behaviour as consistent as
possible across all sources the interface has been modified with
this new functionality. The Nomad source noops a reload, but in
the future we may want to use this to reload Nomad client config
params, in particular ACL tokens.

closes #166 