### PR TITLE
plugins: allow all plugins to inherit agents Nomad config.

### DIFF
--- a/agent/plugins.go
+++ b/agent/plugins.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"strconv"
+
 	"github.com/hashicorp/nomad-autoscaler/agent/config"
 	nomadHelper "github.com/hashicorp/nomad-autoscaler/helper/nomad"
 	"github.com/hashicorp/nomad-autoscaler/plugins"
@@ -11,7 +13,7 @@ import (
 // and forks the configured plugins for use.
 func (a *Agent) setupPlugins() error {
 
-	a.pluginManager = manager.NewPluginManager(a.logger, a.config.PluginDir, a.setupPluginConfig())
+	a.pluginManager = manager.NewPluginManager(a.logger, a.config.PluginDir, a.setupPluginsConfig())
 
 	// Trigger the loading of the plugins which will be available to the agent.
 	// Any errors here will cause the agent to fail, but will include wrapped
@@ -19,9 +21,9 @@ func (a *Agent) setupPlugins() error {
 	return a.pluginManager.Load()
 }
 
-// setupPluginConfig builds a map which is used by the plugin manager to load
+// setupPluginsConfig builds a map which is used by the plugin manager to load
 // all the configured plugins.
-func (a *Agent) setupPluginConfig() map[string][]*config.Plugin {
+func (a *Agent) setupPluginsConfig() map[string][]*config.Plugin {
 
 	cfg := map[string][]*config.Plugin{}
 
@@ -35,17 +37,44 @@ func (a *Agent) setupPluginConfig() map[string][]*config.Plugin {
 		cfg[plugins.PluginTypeTarget] = a.config.Targets
 	}
 
-	// Iterate the configurations to match any nomad plugins. If these plugins
-	// have an empty config map, update this with the agents top level Nomad
-	// config. This helps stop the need for repeating the same params over and
-	// over.
+	// Iterate the configs and perform the config setup on each. If the
+	// operator did not specify any config, it will be nil so make sure we
+	// initialise the map.
 	for _, cfgs := range cfg {
 		for _, c := range cfgs {
-			if (c.Name == plugins.InternalAPMNomad || c.Name == plugins.InternalTargetNomad) && len(c.Config) == 0 {
-				c.Config = nomadHelper.ConfigToMap(a.config.Nomad)
+			if c.Config == nil {
+				c.Config = make(map[string]string)
 			}
+			a.setupPluginConfig(c.Config)
 		}
 	}
 
 	return cfg
+}
+
+// setupPluginConfig takes the individual plugin configuration and merges in
+// namespaced Nomad configuration unless the user has disabled this
+// functionality.
+func (a *Agent) setupPluginConfig(cfg map[string]string) {
+
+	// Look for the config flag that users can supply to toggle inheriting the
+	// Nomad config from the agent. If we do not find it, opt-in by default.
+	val, ok := cfg[plugins.ConfigKeyNomadConfigInherit]
+	if !ok {
+		nomadHelper.MergeMapWithAgentConfig(cfg, a.config.Nomad)
+		return
+	}
+
+	// Attempt to convert the string. If the operator made an effort to
+	// configure the key but got the value wrong, log the error and do not
+	// perform the merge. The operator can fix the error and we do not make an
+	// assumption.
+	boolVal, err := strconv.ParseBool(val)
+	if err != nil {
+		a.logger.Error("failed to convert config value to bool", "error", err)
+		return
+	}
+	if boolVal {
+		nomadHelper.MergeMapWithAgentConfig(cfg, a.config.Nomad)
+	}
 }

--- a/agent/plugins_test.go
+++ b/agent/plugins_test.go
@@ -9,34 +9,145 @@ import (
 )
 
 func TestAgent_setupPluginConfig(t *testing.T) {
-	c, err := config.Default()
-	assert.Nil(t, err)
-
-	a := NewAgent(c, hclog.NewNullLogger())
-
-	expectedOutput := map[string][]*config.Plugin{
-		"target": {
-			{
-				Name:   "nomad-target",
-				Driver: "nomad-target",
-				Config: map[string]string{"address": "http://127.0.0.1:4646", "region": "global"},
+	testCases := []struct {
+		inputCfg          map[string]string
+		inputAgent        *Agent
+		expectedOutputCfg map[string]string
+		name              string
+	}{
+		{
+			inputCfg: map[string]string{
+				"nomad_config_inherit": "false",
 			},
+			inputAgent: &Agent{
+				logger: hclog.NewNullLogger(),
+				config: &config.Agent{
+					Nomad: &config.Nomad{
+						Address:       "test",
+						Region:        "test",
+						Namespace:     "test",
+						Token:         "test",
+						HTTPAuth:      "test",
+						CACert:        "test",
+						CAPath:        "test",
+						ClientCert:    "test",
+						ClientKey:     "test",
+						TLSServerName: "test",
+						SkipVerify:    true,
+					},
+				},
+			},
+			expectedOutputCfg: map[string]string{
+				"nomad_config_inherit": "false",
+			},
+			name: "Nomad config merging disabled ",
 		},
-		"apm": {
-			{
-				Name:   "nomad-apm",
-				Driver: "nomad-apm",
-				Config: map[string]string{"address": "http://127.0.0.1:4646", "region": "global"},
+		{
+			inputCfg: map[string]string{
+				"nomad_config_inherit": "falso",
 			},
+			inputAgent: &Agent{
+				logger: hclog.NewNullLogger(),
+				config: &config.Agent{
+					Nomad: &config.Nomad{
+						Address:       "test",
+						Region:        "test",
+						Namespace:     "test",
+						Token:         "test",
+						HTTPAuth:      "test",
+						CACert:        "test",
+						CAPath:        "test",
+						ClientCert:    "test",
+						ClientKey:     "test",
+						TLSServerName: "test",
+						SkipVerify:    true,
+					},
+				},
+			},
+			expectedOutputCfg: map[string]string{
+				"nomad_config_inherit": "falso",
+			},
+			name: "Nomad config merging key set but value not parsable",
 		},
-		"strategy": {
-			{
-				Name:   "target-value",
-				Driver: "target-value",
-				Config: nil,
+		{
+			inputCfg: map[string]string{
+				"nomad_config_inherit": "true",
 			},
+			inputAgent: &Agent{
+				logger: hclog.NewNullLogger(),
+				config: &config.Agent{
+					Nomad: &config.Nomad{
+						Address:       "test",
+						Region:        "test",
+						Namespace:     "test",
+						Token:         "test",
+						HTTPAuth:      "test",
+						CACert:        "test",
+						CAPath:        "test",
+						ClientCert:    "test",
+						ClientKey:     "test",
+						TLSServerName: "test",
+						SkipVerify:    true,
+					},
+				},
+			},
+			expectedOutputCfg: map[string]string{
+				"nomad_config_inherit":  "true",
+				"nomad_address":         "test",
+				"nomad_region":          "test",
+				"nomad_namespace":       "test",
+				"nomad_token":           "test",
+				"nomad_http-auth":       "test",
+				"nomad_ca-cert":         "test",
+				"nomad_ca-path":         "test",
+				"nomad_client-cert":     "test",
+				"nomad_client-key":      "test",
+				"nomad_tls-server-name": "test",
+				"nomad_skip-verify":     "true",
+			},
+			name: "Nomad config merging key set to true",
+		},
+		{
+			inputCfg: map[string]string{},
+			inputAgent: &Agent{
+				logger: hclog.NewNullLogger(),
+				config: &config.Agent{
+					Nomad: &config.Nomad{
+						Address:       "test",
+						Region:        "test",
+						Namespace:     "test",
+						Token:         "test",
+						HTTPAuth:      "test",
+						CACert:        "test",
+						CAPath:        "test",
+						ClientCert:    "test",
+						ClientKey:     "test",
+						TLSServerName: "test",
+						SkipVerify:    true,
+					},
+				},
+			},
+			expectedOutputCfg: map[string]string{
+				"nomad_address":         "test",
+				"nomad_region":          "test",
+				"nomad_namespace":       "test",
+				"nomad_token":           "test",
+				"nomad_http-auth":       "test",
+				"nomad_ca-cert":         "test",
+				"nomad_ca-path":         "test",
+				"nomad_client-cert":     "test",
+				"nomad_client-key":      "test",
+				"nomad_tls-server-name": "test",
+				"nomad_skip-verify":     "true",
+			},
+			name: "Nomad config merging key not set",
 		},
 	}
 
-	assert.Equal(t, expectedOutput, a.setupPluginConfig())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.inputAgent.setupPluginConfig(tc.inputCfg)
+			assert.Equal(t, tc.expectedOutputCfg, tc.inputCfg, tc.name)
+		})
+	}
 }

--- a/helper/nomad/config_test.go
+++ b/helper/nomad/config_test.go
@@ -8,65 +8,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_ConfigToMap(t *testing.T) {
-	testCases := []struct {
-		inputCfg       *config.Nomad
-		expectedOutput map[string]string
-	}{
-		{
-			inputCfg: &config.Nomad{
-				Address:       "vlc.nomad",
-				Region:        "espana",
-				Namespace:     "picassent",
-				Token:         "my-precious",
-				HTTPAuth:      "username:password",
-				CACert:        "/etc/nomad.d/ca.crt",
-				CAPath:        "/etc/nomad.d/",
-				ClientCert:    "/etc/nomad.d/client.crt",
-				ClientKey:     "/etc/nomad.d/client.key",
-				TLSServerName: "lord-of-the-servers",
-				SkipVerify:    true,
-			},
-			expectedOutput: map[string]string{
-				"address":         "vlc.nomad",
-				"region":          "espana",
-				"namespace":       "picassent",
-				"token":           "my-precious",
-				"http-auth":       "username:password",
-				"ca-cert":         "/etc/nomad.d/ca.crt",
-				"ca-path":         "/etc/nomad.d/",
-				"client-cert":     "/etc/nomad.d/client.crt",
-				"client-key":      "/etc/nomad.d/client.key",
-				"tls-server-name": "lord-of-the-servers",
-				"skip-verify":     "true",
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		actualOutput := ConfigToMap(tc.inputCfg)
-		assert.Equal(t, tc.expectedOutput, actualOutput)
-	}
-}
-
-func Test_ConfigFromMap(t *testing.T) {
+func Test_ConfigFromNamespacedMap(t *testing.T) {
 	testCases := []struct {
 		inputCfg       map[string]string
 		expectedOutput *api.Config
 	}{
 		{
 			inputCfg: map[string]string{
-				"address":         "vlc.nomad",
-				"region":          "espana",
-				"namespace":       "picassent",
-				"token":           "my-precious",
-				"http-auth":       "username:password",
-				"ca-cert":         "/etc/nomad.d/ca.crt",
-				"ca-path":         "/etc/nomad.d/",
-				"client-cert":     "/etc/nomad.d/client.crt",
-				"client-key":      "/etc/nomad.d/client.key",
-				"tls-server-name": "lord-of-the-servers",
-				"skip-verify":     "true",
+				"nomad_address":         "vlc.nomad",
+				"nomad_region":          "espana",
+				"nomad_namespace":       "picassent",
+				"nomad_token":           "my-precious",
+				"nomad_http-auth":       "username:password",
+				"nomad_ca-cert":         "/etc/nomad.d/ca.crt",
+				"nomad_ca-path":         "/etc/nomad.d/",
+				"nomad_client-cert":     "/etc/nomad.d/client.crt",
+				"nomad_client-key":      "/etc/nomad.d/client.key",
+				"nomad_tls-server-name": "lord-of-the-servers",
+				"nomad_skip-verify":     "true",
 			},
 			expectedOutput: &api.Config{
 				Address:   "vlc.nomad",
@@ -90,7 +49,7 @@ func Test_ConfigFromMap(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actualOutput := ConfigFromMap(tc.inputCfg)
+		actualOutput := ConfigFromNamespacedMap(tc.inputCfg)
 		assert.Equal(t, tc.expectedOutput, actualOutput)
 	}
 }
@@ -117,5 +76,95 @@ func Test_HTTPAuthFromString(t *testing.T) {
 	for _, tc := range testCases {
 		actualOutput := HTTPAuthFromString(tc.inputAuth)
 		assert.Equal(t, tc.expectedOutput, actualOutput)
+	}
+}
+
+func Test_MergeMapWithAgentConfig(t *testing.T) {
+	testCases := []struct {
+		inputMap          map[string]string
+		inputAgentConfig  *config.Nomad
+		expectedOutputMap map[string]string
+		name              string
+	}{
+		{
+			inputMap: map[string]string{},
+			inputAgentConfig: &config.Nomad{
+				Address:       "test",
+				Region:        "test",
+				Namespace:     "test",
+				Token:         "test",
+				HTTPAuth:      "test",
+				CACert:        "test",
+				CAPath:        "test",
+				ClientCert:    "test",
+				ClientKey:     "test",
+				TLSServerName: "test",
+				SkipVerify:    true,
+			},
+			expectedOutputMap: map[string]string{
+				"nomad_address":         "test",
+				"nomad_region":          "test",
+				"nomad_namespace":       "test",
+				"nomad_token":           "test",
+				"nomad_http-auth":       "test",
+				"nomad_ca-cert":         "test",
+				"nomad_ca-path":         "test",
+				"nomad_client-cert":     "test",
+				"nomad_client-key":      "test",
+				"nomad_tls-server-name": "test",
+				"nomad_skip-verify":     "true",
+			},
+			name: "empty input map",
+		},
+
+		{
+			inputMap: map[string]string{
+				"nomad_address":         "test",
+				"nomad_region":          "test",
+				"nomad_namespace":       "test",
+				"nomad_token":           "test",
+				"nomad_http-auth":       "test",
+				"nomad_ca-cert":         "test",
+				"nomad_ca-path":         "test",
+				"nomad_client-cert":     "test",
+				"nomad_client-key":      "test",
+				"nomad_tls-server-name": "test",
+				"nomad_skip-verify":     "true",
+			},
+			inputAgentConfig: &config.Nomad{
+				Address:       "test-new",
+				Region:        "test-new",
+				Namespace:     "test-new",
+				Token:         "test-new",
+				HTTPAuth:      "test-new",
+				CACert:        "test-new",
+				CAPath:        "test-new",
+				ClientCert:    "test-new",
+				ClientKey:     "test-new",
+				TLSServerName: "test-new",
+				SkipVerify:    false,
+			},
+			expectedOutputMap: map[string]string{
+				"nomad_address":         "test",
+				"nomad_region":          "test",
+				"nomad_namespace":       "test",
+				"nomad_token":           "test",
+				"nomad_http-auth":       "test",
+				"nomad_ca-cert":         "test",
+				"nomad_ca-path":         "test",
+				"nomad_client-cert":     "test",
+				"nomad_client-key":      "test",
+				"nomad_tls-server-name": "test",
+				"nomad_skip-verify":     "true",
+			},
+			name: "fully populated input map and input agent config",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			MergeMapWithAgentConfig(tc.inputMap, tc.inputAgentConfig)
+			assert.Equal(t, tc.expectedOutputMap, tc.inputMap, tc.name)
+		})
 	}
 }

--- a/plugins/builtin/apm/nomad/plugin/plugin.go
+++ b/plugins/builtin/apm/nomad/plugin/plugin.go
@@ -45,7 +45,7 @@ func NewNomadPlugin(log hclog.Logger) apm.APM {
 
 func (a *APMPlugin) SetConfig(config map[string]string) error {
 
-	cfg := nomadHelper.ConfigFromMap(config)
+	cfg := nomadHelper.ConfigFromNamespacedMap(config)
 
 	client, err := api.NewClient(cfg)
 	if err != nil {

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -75,7 +75,7 @@ func (t *TargetPlugin) SetConfig(config map[string]string) error {
 		return err
 	}
 
-	utils, err := scaleutils.NewScaleInUtils(nomad.ConfigFromMap(config), t.logger)
+	utils, err := scaleutils.NewScaleInUtils(nomad.ConfigFromNamespacedMap(config), t.logger)
 	if err != nil {
 		return err
 	}

--- a/plugins/builtin/target/nomad/plugin/plugin.go
+++ b/plugins/builtin/target/nomad/plugin/plugin.go
@@ -83,7 +83,7 @@ func (t *TargetPlugin) SetConfig(config map[string]string) error {
 		go t.garbageCollectionLoop()
 	}
 
-	cfg := nomadHelper.ConfigFromMap(config)
+	cfg := nomadHelper.ConfigFromNamespacedMap(config)
 
 	client, err := api.NewClient(cfg)
 	if err != nil {

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -41,6 +41,12 @@ const (
 	InternalTargetAWSASG = "aws-asg"
 )
 
+// ConfigKeyNomadConfigInherit is a generic plugin config map key that supports
+// a boolean value. It indicates whether or not the plugin config should be
+// merged with the agent's Nomad config. This provides an easy simple way in
+// which plugins can have their Nomad client configured without extra hassle.
+const ConfigKeyNomadConfigInherit = "nomad_config_inherit"
+
 var (
 	// Handshake is used to do a basic handshake between a plugin and host. If
 	// the handshake fails, a user friendly error is shown. This prevents users


### PR DESCRIPTION
Plugins such as the AWS ASG target plugin setup a Nomad client in
order to provide scaleutil help. If the operator is using a Nomad
cluster which requires non-default config options, it would be
preferable that they do not have to supply them twice, once to the
agent and again to the plugin.

This changes makes it so that plugin inherit the agents Nomad
configuration by default, reducing the overhead on operators. When
merging config options within the plugin config will take
preference. This allows the operator to provide a subset of params
which are considered specific to the plugin such as ACL token, but
inherit the generic options such as address.

The generic plugin config key "nomad_config_inherit" allows
operators to override default behaviour via a boolean value.

closes #189 