### PR TITLE
agent: move and fix default eval interval param to policy block.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -86,7 +86,7 @@ func (a *Agent) runEvalHandler(ctx context.Context, evalCh chan *policy.Evaluati
 func (a *Agent) setupPolicyManager() chan *policy.Evaluation {
 	sourceConfig := &policy.ConfigDefaults{
 		DefaultCooldown:           a.config.Policy.DefaultCooldown,
-		DefaultEvaluationInterval: a.config.DefaultEvaluationInterval,
+		DefaultEvaluationInterval: a.config.Policy.DefaultEvaluationInterval,
 	}
 
 	// Setup our initial default policy source which is Nomad.

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -72,7 +72,7 @@ func TestAgent_Merge(t *testing.T) {
 		Policy: &Policy{
 			Dir:                       "/etc/scaling/policies",
 			DefaultCooldown:           20 * time.Minute,
-			DefaultEvaluationInterval: 10000000000,
+			DefaultEvaluationInterval: 10 * time.Second,
 		},
 		APMs: []*Plugin{
 			{

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -18,7 +18,7 @@ func Test_Default(t *testing.T) {
 	assert.False(t, def.LogJson)
 	assert.Equal(t, def.LogLevel, "info")
 	assert.True(t, strings.HasSuffix(def.PluginDir, "/plugins"))
-	assert.Equal(t, def.Policy.DefaultEvaluationInterval, time.Duration(10000000000))
+	assert.Equal(t, def.Policy.DefaultEvaluationInterval, 10 * time.Second)
 	assert.Equal(t, def.Nomad.Address, "http://127.0.0.1:4646")
 	assert.Equal(t, "127.0.0.1", def.HTTP.BindAddress)
 	assert.Equal(t, 8080, def.HTTP.BindPort)

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -118,7 +118,7 @@ func TestAgent_Merge(t *testing.T) {
 		Policy: &Policy{
 			Dir:                       "/etc/scaling/policies",
 			DefaultCooldown:           20 * time.Minute,
-			DefaultEvaluationInterval: 10000000000,
+			DefaultEvaluationInterval: 10 * time.Second,
 		},
 		APMs: []*Plugin{
 			{

--- a/command/agent.go
+++ b/command/agent.go
@@ -110,6 +110,10 @@ Policy Options:
   -policy-default-cooldown=<dur>
     The default cooldown that will be applied to all scaling policies which do
     not specify a cooldown period.
+
+  -policy-default-evaluation-interval=<dur>
+    The default evaluation interval that will be applied to all scaling policies
+    which do not specify an evaluation interval.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -170,10 +174,6 @@ func (c *AgentCommand) readConfig() *config.Agent {
 	flags.StringVar(&cmdConfig.LogLevel, "log-level", "", "")
 	flags.BoolVar(&cmdConfig.LogJson, "log-json", false, "")
 	flags.StringVar(&cmdConfig.PluginDir, "plugin-dir", "", "")
-	flags.Var((flaghelper.FuncDurationVar)(func(d time.Duration) error {
-		cmdConfig.DefaultEvaluationInterval = d
-		return nil
-	}), "scan-interval", "")
 
 	// Specify our HTTP bind flags.
 	flags.StringVar(&cmdConfig.HTTP.BindAddress, "http-bind-address", "", "")
@@ -198,6 +198,10 @@ func (c *AgentCommand) readConfig() *config.Agent {
 		cmdConfig.Policy.DefaultCooldown = d
 		return nil
 	}), "policy-default-cooldown", "")
+	flags.Var((flaghelper.FuncDurationVar)(func(d time.Duration) error {
+		cmdConfig.Policy.DefaultEvaluationInterval = d
+		return nil
+	}), "policy-default-evaluation-interval", "")
 
 	if err := flags.Parse(c.args); err != nil {
 		return nil


### PR DESCRIPTION
The addition of a policy config block allows us to move and
evaluation interval parameter to this section. The param is only
used for policies and so makes sense in this section. A result of
this move fixes an incorrect detailing of the CLI flag which
referenced its old name.