### PR TITLE
policy: namespace cluster target config params.

### DIFF
--- a/plugins/builtin/target/aws-asg/plugin/aws.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/hashicorp/nomad-autoscaler/helper/scaleutils"
+	"github.com/hashicorp/nomad-autoscaler/plugins/target"
 )
 
 const (
@@ -145,16 +146,16 @@ func (t *TargetPlugin) generateScaleReq(num int64, config map[string]string) (*s
 
 	// Pull the class key from the config mapping. This is a required value and
 	// we cannot scale without this.
-	class, ok := config[configKeyClass]
+	class, ok := config[target.ConfigKeyClass]
 	if !ok {
-		return nil, fmt.Errorf("required config param %q not found", configKeyClass)
+		return nil, fmt.Errorf("required config param %q not found", target.ConfigKeyClass)
 	}
 
 	// The drain_deadline is an optional parameter so define out default and
 	// then attempt to find an operator specified value.
 	drain := scaleutils.DefaultDrainDeadline
 
-	if drainString, ok := config[configKeyDrainDeadline]; ok {
+	if drainString, ok := config[target.ConfigKeyDrainDeadline]; ok {
 		d, err := time.ParseDuration(drainString)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse %q as time duration", drainString)

--- a/plugins/builtin/target/aws-asg/plugin/aws_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws_test.go
@@ -20,8 +20,8 @@ func TestTargetPlugin_generateScaleReq(t *testing.T) {
 		{
 			inputNum: 2,
 			inputConfig: map[string]string{
-				"class":          "high-memory",
-				"drain_deadline": "5m",
+				"node_class":          "high-memory",
+				"node_drain_deadline": "5m",
 			},
 			expectedOutputReq: &scaleutils.ScaleInReq{
 				Num:           2,
@@ -40,13 +40,13 @@ func TestTargetPlugin_generateScaleReq(t *testing.T) {
 			inputNum:            2,
 			inputConfig:         map[string]string{},
 			expectedOutputReq:   nil,
-			expectedOutputError: errors.New("required config param \"class\" not found"),
+			expectedOutputError: errors.New("required config param \"node_class\" not found"),
 			name:                "no class key found in config",
 		},
 		{
 			inputNum: 2,
 			inputConfig: map[string]string{
-				"class": "high-memory",
+				"node_class": "high-memory",
 			},
 			expectedOutputReq: &scaleutils.ScaleInReq{
 				Num:           2,
@@ -64,8 +64,8 @@ func TestTargetPlugin_generateScaleReq(t *testing.T) {
 		{
 			inputNum: 2,
 			inputConfig: map[string]string{
-				"class":          "high-memory",
-				"drain_deadline": "time to make a cuppa",
+				"node_class":          "high-memory",
+				"node_drain_deadline": "time to make a cuppa",
 			},
 			expectedOutputReq:   nil,
 			expectedOutputError: errors.New("failed to parse \"time to make a cuppa\" as time duration"),

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -22,13 +22,11 @@ const (
 
 	// configKeys represents the known configuration parameters required at
 	// varying points throughout the plugins lifecycle.
-	configKeyRegion        = "aws_region"
-	configKeyAccessID      = "aws_access_key_id"
-	configKeySecretKey     = "aws_secret_access_key"
-	configKeySessionToken  = "session_token"
-	configKeyASGName       = "asg_name"
-	configKeyClass         = "class"
-	configKeyDrainDeadline = "drain_deadline"
+	configKeyRegion       = "aws_region"
+	configKeyAccessID     = "aws_access_key_id"
+	configKeySecretKey    = "aws_secret_access_key"
+	configKeySessionToken = "aws_session_token"
+	configKeyASGName      = "aws_asg_name"
 
 	// configValues are the default values used when a configuration key is not
 	// supplied by the operator that are specific to the plugin.

--- a/plugins/target/target.go
+++ b/plugins/target/target.go
@@ -30,9 +30,10 @@ const MetaKeyLastEvent = "nomad_autoscaler.last_event"
 const (
 	// ConfigKeys are the various target config map keys that can be used to
 	// identify a target.
-	ConfigKeyJob       = "Job"
-	ConfigKeyTaskGroup = "Group"
-	ConfigKeyClass     = "class"
+	ConfigKeyJob           = "Job"
+	ConfigKeyTaskGroup     = "Group"
+	ConfigKeyClass         = "node_class"
+	ConfigKeyDrainDeadline = "node_drain_deadline"
 )
 
 // RPC is a plugin implementation that talks over net/rpc

--- a/policy/file/parse_test.go
+++ b/policy/file/parse_test.go
@@ -53,9 +53,9 @@ func Test_decodeFile(t *testing.T) {
 				Target: &policy.Target{
 					Name: "aws-asg",
 					Config: map[string]string{
-						"asg_name":       "my-target-asg",
-						"class":          "high-memory",
-						"drain_deadline": "15m",
+						"aws_asg_name":        "my-target-asg",
+						"node_class":          "high-memory",
+						"node_drain_deadline": "15m",
 					},
 				},
 			},

--- a/policy/file/test-fixtures/full-cluster-policy.hcl
+++ b/policy/file/test-fixtures/full-cluster-policy.hcl
@@ -26,8 +26,8 @@ policy {
   }
 
   target "aws-asg" {
-      asg_name       = "my-target-asg"
-      class          = "high-memory"
-      drain_deadline = "15m"
+      aws_asg_name        = "my-target-asg"
+      node_class          = "high-memory"
+      node_drain_deadline = "15m"
   }
 }

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -79,7 +79,7 @@ func TestCheck_CanonicalizeAPMQuery(t *testing.T) {
 				Query:  "percentage-allocated_memory",
 			},
 			inputTarget: &Target{
-				Config: map[string]string{"class": "hashistack"},
+				Config: map[string]string{"node_class": "hashistack"},
 			},
 			expectedOutputCheck: &Check{
 				Name:   "random-check",


### PR DESCRIPTION
Namespacing the general cluster target params such as node_class
allows easier adoption of future pool identifier such as node
attributes. It also means these will be easier to understand when
namespaced such as "node_attr_random" rather than "attr_random".

Namespacing the AWS specific config params brings consistency to
the plugin. It also means any future plugins that use similar
terminology will have clear differentiators.