### PR TITLE
policy: validate key params of policy struct.

### DIFF
--- a/policy/file/parse_test.go
+++ b/policy/file/parse_test.go
@@ -62,6 +62,51 @@ func Test_decodeFile(t *testing.T) {
 			expectedOutputError: nil,
 			name:                "full parsable cluster scaling policy",
 		},
+		{
+			inputFile:   "./test-fixtures/full-task-group-policy.hcl",
+			inputPolicy: &policy.Policy{},
+			expectedOutputPolicy: &policy.Policy{
+				ID:                 "",
+				Enabled:            true,
+				Min:                1,
+				Max:                10,
+				Cooldown:           1 * time.Minute,
+				EvaluationInterval: 30 * time.Second,
+				Checks: []*policy.Check{
+					{
+						Name:   "cpu_nomad",
+						Source: "nomad_apm",
+						Query:  "avg_cpu",
+						Strategy: &policy.Strategy{
+							Name: "target-value",
+							Config: map[string]string{
+								"target": "80",
+							},
+						},
+					},
+					{
+						Name:   "memory_nomad",
+						Source: "nomad_apm",
+						Query:  "avg_memory",
+						Strategy: &policy.Strategy{
+							Name: "target-value",
+							Config: map[string]string{
+								"target": "80",
+							},
+						},
+					},
+				},
+				Target: &policy.Target{
+					Name: "nomad",
+					Config: map[string]string{
+						"Group": "cache",
+						"Job":   "example",
+					},
+				},
+			},
+			expectedOutputError: nil,
+			name:                "full parsable task group scaling policy",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/policy/file/test-fixtures/full-task-group-policy.hcl
+++ b/policy/file/test-fixtures/full-task-group-policy.hcl
@@ -1,0 +1,32 @@
+enabled = true
+min     = 1
+max     = 10
+
+policy {
+
+  cooldown            = "1m"
+  evaluation_interval = "30s"
+
+  check "cpu_nomad" {
+    source    = "nomad_apm"
+    query     = "avg_cpu"
+
+    strategy "target-value" {
+      target = "80"
+    }
+  }
+
+  check "memory_nomad" {
+    source    = "nomad_apm"
+    query     = "avg_memory"
+
+    strategy "target-value" {
+      target = "80"
+    }
+  }
+
+  target "nomad" {
+    Group = "cache"
+    Job   = "example"
+  }
+}

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -229,9 +229,6 @@ func canonicalizeCheck(c *policy.Check, t *policy.Target) {
 		c.Strategy.Config = make(map[string]string)
 	}
 
-	// Default source to the Nomad APM.
-	if c.Source == "" {
-		c.Source = plugins.InternalAPMNomad
-	}
-	c.CanonicalizeAPMQuery(t)
+	// Canonicalize the check.
+	c.Canonicalize(t)
 }


### PR DESCRIPTION
This adds a validate function to the Policy struct which allows
for the validation ensuring key params are not outside of the
expected.

Ideally both policy sources would use the same function, however,
the Nomad policy source performs validation on the Nomad API
policy struct so there is work to do if we wish to make the
change.