### PR TITLE
plugin/manager: ensure plugins are killed  during manager tests.

### DIFF
--- a/plugins/manager/manager_test.go
+++ b/plugins/manager/manager_test.go
@@ -94,6 +94,7 @@ func TestLoad(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pm := NewPluginManager(logger, tc.pluginDir, tc.cfg)
 			err := pm.Load()
+			defer pm.KillPlugins()
 
 			if tc.expectError {
 				assert.Error(t, err)


### PR DESCRIPTION
When performing tests on the plugin manager, the launched plugins
were not being killed meaning the process were left orphaned on
the host machine.