### PR TITLE
deps: update Nomad dep to 0.12.0-rc1 to accommodate API changes.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-plugin v1.0.1
 	github.com/hashicorp/hcl/v2 v2.3.0
-	github.com/hashicorp/nomad/api v0.0.0-20200514223145-f2210cedd9d6
+	github.com/hashicorp/nomad/api v0.0.0-20200707021849-438fec972a84
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/cli v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggUE=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
-github.com/hashicorp/nomad/api v0.0.0-20200514223145-f2210cedd9d6 h1:Sp9lwJLD841yaXWQCHcYojb73jV/ktjX0vA4DxFJeSM=
-github.com/hashicorp/nomad/api v0.0.0-20200514223145-f2210cedd9d6/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=
+github.com/hashicorp/nomad/api v0.0.0-20200707021849-438fec972a84 h1:WNFpuAFOrk7WdEnipnUVPI6s9e1b5Nr5zLPuDrf68rs=
+github.com/hashicorp/nomad/api v0.0.0-20200707021849-438fec972a84/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -20,7 +20,7 @@ func parsePolicy(p *api.ScalingPolicy) policy.Policy {
 
 	to := policy.Policy{
 		ID:      p.ID,
-		Max:     p.Max,
+		Max:     *p.Max, // Nomad always ensures Max is populated.
 		Enabled: true,
 		Checks:  parseChecks(p.Policy[keyChecks]),
 	}

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -28,22 +28,25 @@ func validateScalingPolicy(policy *api.ScalingPolicy) error {
 	//   1. Min must not be nil.
 	//   2. Min must be positive.
 	//   3. Max must be positive.
-	//   4. Min must be smaller than Max.
+	//   4. Max must not be nil.
+	//   5. Min must be smaller than Max.
 	if policy.Min == nil {
 		result = multierror.Append(result, fmt.Errorf("scaling.min is missing"))
+	} else if policy.Max == nil {
+		result = multierror.Append(result, fmt.Errorf("scaling.max is missing"))
 	} else {
 		min := *policy.Min
 		if min < 0 {
 			result = multierror.Append(result, fmt.Errorf("scaling.min can't be negative"))
 		}
 
-		if min > policy.Max {
+		if min > *policy.Max {
 			result = multierror.Append(result, fmt.Errorf("scaling.min must be smaller than scaling.max"))
 		}
-	}
 
-	if policy.Max < 0 {
-		result = multierror.Append(result, fmt.Errorf("scaling.max can't be negative"))
+		if *policy.Max < 0 {
+			result = multierror.Append(result, fmt.Errorf("scaling.max can't be negative"))
+		}
 	}
 
 	// Validate Target.

--- a/policy/nomad/validate_test.go
+++ b/policy/nomad/validate_test.go
@@ -46,7 +46,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 					"key": "value",
 				},
 				Min: ptr.Int64ToPtr(1),
-				Max: 5,
+				Max: ptr.Int64ToPtr(5),
 				Policy: map[string]interface{}{
 					keyChecks: []interface{}{
 						map[string]interface{}{
@@ -76,7 +76,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 			input: &api.ScalingPolicy{
 				ID:  "id",
 				Min: ptr.Int64ToPtr(1),
-				Max: 5,
+				Max: ptr.Int64ToPtr(5),
 				Policy: map[string]interface{}{
 					keyChecks: []interface{}{
 						map[string]interface{}{
@@ -108,7 +108,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 				Target: map[string]string{
 					"key": "value",
 				},
-				Max: 5,
+				Max: ptr.Int64ToPtr(5),
 				Policy: map[string]interface{}{
 					keyChecks: []interface{}{
 						map[string]interface{}{
@@ -141,7 +141,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 					"key": "value",
 				},
 				Min: ptr.Int64ToPtr(-1),
-				Max: 5,
+				Max: ptr.Int64ToPtr(5),
 				Policy: map[string]interface{}{
 					keyChecks: []interface{}{
 						map[string]interface{}{
@@ -174,7 +174,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 					"key": "value",
 				},
 				Min: ptr.Int64ToPtr(1),
-				Max: -5,
+				Max: ptr.Int64ToPtr(-5),
 				Policy: map[string]interface{}{
 					keyChecks: []interface{}{
 						map[string]interface{}{
@@ -207,7 +207,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 					"key": "value",
 				},
 				Min: ptr.Int64ToPtr(2),
-				Max: 1,
+				Max: ptr.Int64ToPtr(1),
 				Policy: map[string]interface{}{
 					keyChecks: []interface{}{
 						map[string]interface{}{
@@ -270,7 +270,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 					"key": "value",
 				},
 				Min: ptr.Int64ToPtr(1),
-				Max: 5,
+				Max: ptr.Int64ToPtr(5),
 				Policy: map[string]interface{}{
 					keyChecks: []interface{}{
 						map[string]interface{}{
@@ -303,7 +303,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 					"key": "value",
 				},
 				Min: ptr.Int64ToPtr(1),
-				Max: 5,
+				Max: ptr.Int64ToPtr(5),
 				Policy: map[string]interface{}{
 					keyChecks: []interface{}{
 						map[string]interface{}{
@@ -347,7 +347,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 					"key": "value",
 				},
 				Min: ptr.Int64ToPtr(1),
-				Max: 5,
+				Max: ptr.Int64ToPtr(5),
 				Policy: map[string]interface{}{
 					keyTarget: []interface{}{
 						map[string]interface{}{
@@ -389,7 +389,7 @@ func Test_validateScalingPolicy(t *testing.T) {
 					"key": "value",
 				},
 				Min: ptr.Int64ToPtr(1),
-				Max: 5,
+				Max: ptr.Int64ToPtr(5),
 				Policy: map[string]interface{}{
 					keyTarget: []interface{}{
 						map[string]interface{}{


### PR DESCRIPTION
Nomad 0.12 makes a change to the scaling policy API response
object which results in a change to the Nomad policy parser.

The change moves the max param to a pointer and although Nomad
should never return a nil max value, the parser accommodates it
to be safe.