### PR TITLE
Fix Vagrant demo for Nomad 0.12

### DIFF
--- a/demo/vagrant/files/nomad.hcl
+++ b/demo/vagrant/files/nomad.hcl
@@ -15,6 +15,14 @@ client {
   }
 }
 
+plugin "docker" {
+  config {
+    volumes {
+      enabled = true
+    }
+  }
+}
+
 telemetry {
   publish_allocation_metrics = true
   publish_node_metrics       = true


### PR DESCRIPTION
Nomad 0.12 has a breaking change that requires a flag to enable absolute path Docker volumes, which we use to load the local Grafana dashboard file.