### PR TITLE
policy: fix issue when parsing non-default source name Nomad query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+BUG FIXES:
+ * policy: fix an issue where the Nomad Autoscaler would fail to canonicalize Nomad APM queries with non-default plugin name [[GH-216](https://github.com/hashicorp/nomad-autoscaler/issues/216)]
+
 ## 0.1.0 (July 09, 2020)
 
 __BACKWARDS INCOMPATIBILITIES:__

--- a/agent/plugins.go
+++ b/agent/plugins.go
@@ -78,3 +78,13 @@ func (a *Agent) setupPluginConfig(cfg map[string]string) {
 		nomadHelper.MergeMapWithAgentConfig(cfg, a.config.Nomad)
 	}
 }
+
+func (a *Agent) getNomadAPMNames() []string {
+	var names []string
+	for _, apm := range a.config.APMs {
+		if apm.Driver == plugins.InternalAPMNomad {
+			names = append(names, apm.Name)
+		}
+	}
+	return names
+}

--- a/agent/plugins_test.go
+++ b/agent/plugins_test.go
@@ -151,3 +151,52 @@ func TestAgent_setupPluginConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestAgent_getNomadAPMNames(t *testing.T) {
+	testCases := []struct {
+		inputAgent     *Agent
+		expectedOutput []string
+		name           string
+	}{
+		{
+			inputAgent: &Agent{
+				config: &config.Agent{
+					APMs: []*config.Plugin{},
+				},
+			},
+			expectedOutput: nil,
+			name:           "no Nomad APMs configured",
+		},
+		{
+			inputAgent: &Agent{
+				config: &config.Agent{
+					APMs: []*config.Plugin{
+						{Name: "nomad-apm", Driver: "nomad-apm"},
+					},
+				},
+			},
+			expectedOutput: []string{"nomad-apm"},
+			name:           "default Nomad APM configured",
+		},
+		{
+			inputAgent: &Agent{
+				config: &config.Agent{
+					APMs: []*config.Plugin{
+						{Name: "nomad-platform-apm", Driver: "nomad-apm"},
+						{Name: "nomad-qa-apm", Driver: "nomad-apm"},
+						{Name: "nomad-operations-apm", Driver: "nomad-apm"},
+					},
+				},
+			},
+			expectedOutput: []string{"nomad-platform-apm", "nomad-qa-apm", "nomad-operations-apm"},
+			name:           "default Nomad APM configured",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOuput := tc.inputAgent.getNomadAPMNames()
+			assert.Equal(t, tc.expectedOutput, actualOuput, tc.name)
+		})
+	}
+}

--- a/policy/nomad/testing.go
+++ b/policy/nomad/testing.go
@@ -34,7 +34,10 @@ func TestNomadSource(t *testing.T, cb func(*api.Config, *policy.ConfigDefaults))
 	log := hclog.New(&hclog.LoggerOptions{
 		Level: hclog.Trace,
 	})
-	return NewNomadSource(log, nomad, sourceConfig)
+
+	pr := policy.NewProcessor(sourceConfig, []string{"nomad-apm"})
+
+	return NewNomadSource(log, nomad, pr)
 }
 
 // TestParseJob parses a file into an *api.Job object.


### PR DESCRIPTION
When converting a Nomad APM short query to its long form, there
was an assumption that the plugin was named in its default manner
which caused problems where operators used their own naming
convention.

This change fixes that issue by passing the Nomad APM names to
the function which performs the query transformation. In addition
to simply fixing the issue, this change adds a new policy
processor that can be used to perform validation, canonicalization
and default setting work. I opted for this as it reduced the need
to duplicate work in the two sources. In this case I would have
had to add the APM name list to each source which seems silly and
continues to become annoying in the event we have other
functionality to add to policy parsing and such.

closes #216 