### PR TITLE
demo/remote: add Nomad requirement to doc and remove Consul output

### DIFF
--- a/demo/remote/README.md
+++ b/demo/remote/README.md
@@ -9,6 +9,7 @@ production use***
 
 ### Requirements
 In order to build and run the demo, the following applications are required locally:
+ * HashiCorp Nomad [0.12.0](https://releases.hashicorp.com/nomad/0.12.0/)
  * HashiCorp Packer [1.5.6](https://releases.hashicorp.com/packer/1.5.6/)
  * HashiCorp Terraform [0.12.23](https://releases.hashicorp.com/terraform/0.12.23/)
  * rakyll/hey [latest](https://github.com/rakyll/hey#installation)

--- a/demo/remote/terraform/env/aws/outputs.tf
+++ b/demo/remote/terraform/env/aws/outputs.tf
@@ -22,7 +22,6 @@ Webapp can be accessed at http://${module.hashistack_cluster.client_elb_dns}:80
 CLI environment variables:
 export NOMAD_CLIENT_DNS=http://${module.hashistack_cluster.client_elb_dns}
 export NOMAD_ADDR=${module.hashistack_cluster.nomad_addr}
-export CONSUL_HTTP_ADDR=${module.hashistack_cluster.consul_addr}
 
 CONFIGURATION
 }


### PR DESCRIPTION
Removed the Consul output as the demo doesn't make any calls using
the Consul CLI.

closes #227 