### PR TITLE
demo/remote: remove use of custom node_class param.

### DIFF
--- a/demo/remote/terraform/modules/aws-hashistack/templates.tf
+++ b/demo/remote/terraform/modules/aws-hashistack/templates.tf
@@ -18,6 +18,6 @@ data "template_file" "user_data_client" {
     retry_join    = var.retry_join
     consul_binary = var.consul_binary
     nomad_binary  = var.nomad_binary
-    node_class    = var.client_node_class
+    node_class    = "hashistack"
   }
 }

--- a/demo/remote/terraform/modules/aws-hashistack/variables.tf
+++ b/demo/remote/terraform/modules/aws-hashistack/variables.tf
@@ -65,12 +65,6 @@ variable "client_count" {
   default     = 1
 }
 
-variable "client_node_class" {
-  description = "The Nomad client class to configure."
-  type        = string
-  default     = "hashistack"
-}
-
 variable "root_block_device_size" {
   description = "The number of GB to assign as a block device on instances."
   type        = number


### PR DESCRIPTION
When running the demo with a modified node_class, the autoscaler
job and grafana dashboard require modification. To allow custom
classes would require templating of the dashboard and autoscaler
Nomad job even though using a hardcoded class param would not
cause any conflicts or issues within environments.

This change therefore removes the node_class terraform variable
in favour of a simpler hardcoded one.

closes #234 