### PR TITLE
Remove -scan-interval from help msg, not used anymore

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -258,9 +258,8 @@ const (
 	// defaultHTTPBindPort is the default port used for the HTTP health server.
 	defaultHTTPBindPort = 8080
 
-	// defaultEvaluationInterval is the default value for the
-	// DefaultEvaluationInterval in nano seconds.
-	defaultEvaluationInterval = time.Duration(10000000000)
+	// defaultEvaluationInterval is the default value for the interval between evaluations
+	defaultEvaluationInterval = time.Second*10
 
 	// defaultPluginDirSuffix is the suffix appended to the PWD when building
 	// the PluginDir default value.

--- a/command/agent.go
+++ b/command/agent.go
@@ -48,9 +48,6 @@ Options:
     specified, the plugin directory defaults to be that of
     <current-dir>/plugins/.
 
-  -scan-interval=<dur>
-    The time to wait between Nomad Autoscaler evaluations.
-
 HTTP Options:
 
   -http-bind-address=<addr>


### PR DESCRIPTION
removed in: https://github.com/hashicorp/nomad-autoscaler/pull/197