### PR TITLE
agent: fix lint failure within agent config defaults.

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -259,7 +259,7 @@ const (
 	defaultHTTPBindPort = 8080
 
 	// defaultEvaluationInterval is the default value for the interval between evaluations
-	defaultEvaluationInterval = time.Second*10
+	defaultEvaluationInterval = time.Second * 10
 
 	// defaultPluginDirSuffix is the suffix appended to the PWD when building
 	// the PluginDir default value.


### PR DESCRIPTION
When merging the PR the checks showed green so I had assumed the
assosiated lint, test and build phase had also been run. It seems
Circle didn't run the CI phase for the PR so the lint failure was
not caught.

The CircleCI project is configured to build forked pull requests
so I am not sure what happened here. CircleCI status does not
show any issues over the weekend either so probably worth keeping
an eye on this in the future.

Related - https://github.com/hashicorp/nomad-autoscaler/pull/251