### PR TITLE
scaleutils: add post scale in task to optionally purge nodes.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-plugin v1.0.1
 	github.com/hashicorp/hcl/v2 v2.3.0
-	github.com/hashicorp/nomad/api v0.0.0-20200812215312-956c3a426dbc
+	github.com/hashicorp/nomad/api v0.0.0-20200904210342-cfe4f8314ff7
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/cli v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCO
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggUE=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
-github.com/hashicorp/nomad/api v0.0.0-20200812215312-956c3a426dbc h1:b3Q1n+vuKmCLOa1H6cuet8xJT5LDaMiGJet55KnxW6w=
-github.com/hashicorp/nomad/api v0.0.0-20200812215312-956c3a426dbc/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=
+github.com/hashicorp/nomad/api v0.0.0-20200904210342-cfe4f8314ff7 h1:xVUfoEZ6PAu+NZPZY/aRlG5FG/VosFS6kw1FjjEy30A=
+github.com/hashicorp/nomad/api v0.0.0-20200904210342-cfe4f8314ff7/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=

--- a/plugins/builtin/target/aws-asg/plugin/aws.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws.go
@@ -100,7 +100,7 @@ func (t *TargetPlugin) scaleIn(ctx context.Context, asg *autoscaling.AutoScaling
 
 	ids, err := t.scaleInUtils.RunPreScaleInTasks(ctx, scaleReq)
 	if err != nil {
-		return fmt.Errorf("failed to perform Nomad scale in tasks: %v", err)
+		return fmt.Errorf("failed to perform pre-scale Nomad scale in tasks: %v", err)
 	}
 
 	// Grab the instanceIDs once as it is used multiple times throughout the
@@ -138,6 +138,11 @@ func (t *TargetPlugin) scaleIn(ctx context.Context, asg *autoscaling.AutoScaling
 	}
 	log.Info("successfully terminated EC2 instances")
 	eWriter.write(ctx, scalingEventTerminate)
+
+	// Run any post scale in tasks that are desired.
+	if err := t.scaleInUtils.RunPostScaleInTasks(config, ids); err != nil {
+		return fmt.Errorf("failed to perform post-scale Nomad scale in tasks: %v", err)
+	}
 
 	return nil
 }

--- a/plugins/target/target.go
+++ b/plugins/target/target.go
@@ -34,6 +34,7 @@ const (
 	ConfigKeyTaskGroup     = "Group"
 	ConfigKeyClass         = "node_class"
 	ConfigKeyDrainDeadline = "node_drain_deadline"
+	ConfigKeyNodePurge     = "node_purge"
 )
 
 // RPC is a plugin implementation that talks over net/rpc


### PR DESCRIPTION
When performing cluster scaling and removing nodes from the pool
of compute, an operator may optionally wish to have the terminated
node removed from the Nomad node list. This can be performed by
using the node purge API call and is now included as part of the
scaleutils scale in post tasks run.

The default behaviour is that the purge is not run. The operator
can change this by adding a config option "node_purge" to the
target config mapping. The RunPostScaleInTasks func handles
checking the target configuration, so that this work does not need
to be repeated across all cluster scaling plugins.

closes #257 