### PR TITLE
docs: revert change in requirement matrix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The compatibility requirements are as follows:
 | [0.0.1-techpreview2](https://releases.hashicorp.com/nomad-autoscaler/0.0.1-techpreview2/) |    0.11.0     |
 | [0.0.2](https://releases.hashicorp.com/nomad-autoscaler/0.0.2/)                           |    0.11.2     |
 | [0.1.0](https://releases.hashicorp.com/nomad-autoscaler/0.1.0/)                           |    0.12.0     |
-| [0.1.1](https://releases.hashicorp.com/nomad-autoscaler/0.1.1/)                           |    0.12.4     |
-| [nightly](https://github.com/hashicorp/nomad-autoscaler/releases/tag/nightly)             |    0.12.4     |
+| [0.1.1](https://releases.hashicorp.com/nomad-autoscaler/0.1.1/)                           |    0.12.0     |
+| [nightly](https://github.com/hashicorp/nomad-autoscaler/releases/tag/nightly)             |    0.12.0     |
 
 ## Documentation
 


### PR DESCRIPTION
0.1.1 only required the Nomad dep upgrdae. The remote agent does
not need 0.12.4 running.