### PR TITLE
Update APM interface to allow time range queries

### DIFF
--- a/plugins/builtin/apm/datadog/plugin/plugin.go
+++ b/plugins/builtin/apm/datadog/plugin/plugin.go
@@ -143,9 +143,15 @@ func (a *APMPlugin) Query(q string, r sdk.TimeRange) (sdk.TimestampedMetrics, er
 
 	// pl is [[timestamp, value]...] array
 	for _, p := range *pl {
+		if len(p) != 2 {
+			continue
+		}
+
+		ts := int64(p[0]) / 1e3
+		value := p[1]
 		tm := sdk.TimestampedMetric{
-			Timestamp: time.Unix(int64(p[0]), 0),
-			Value:     p[1],
+			Timestamp: time.Unix(ts, 0),
+			Value:     value,
 		}
 		result = append(result, tm)
 	}

--- a/plugins/builtin/apm/datadog/plugin/plugin.go
+++ b/plugins/builtin/apm/datadog/plugin/plugin.go
@@ -26,12 +26,6 @@ const (
 	envKeyClientAPIKey = "DD_API_KEY"
 	envKeyClientAPPKey = "DD_APP_KEY"
 
-	// Example string: FROM=1m;TO=0m;QUERY=<datadog_query>
-	queryFromToken = "FROM="
-	queryToToken   = "TO="
-	queryToken     = "QUERY="
-	queryDelim     = ";"
-
 	datadogAuthAPIKey = "apiKeyAuth"
 	datadogAuthAPPKey = "appKeyAuth"
 

--- a/plugins/builtin/apm/datadog/plugin/plugin_test.go
+++ b/plugins/builtin/apm/datadog/plugin/plugin_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 	hclog "github.com/hashicorp/go-hclog"
@@ -128,86 +127,6 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				assert.Nil(t, apmPlugin.clientCtx, tc.name)
 				assert.Nil(t, apmPlugin.client, tc.name)
 			}
-		})
-	}
-}
-
-func Test_parseDatadogRawQuery(t *testing.T) {
-	testCases := []struct {
-		name               string
-		rawQuery           string
-		expectedQuery      string
-		expectedTimeWindow time.Duration
-		expectError        bool
-	}{
-		{
-			name:               "simple query",
-			rawQuery:           "FROM=1m;TO=0m;QUERY=foo",
-			expectedQuery:      "foo",
-			expectedTimeWindow: time.Minute,
-			expectError:        false,
-		},
-		{
-			name:               "change order of components",
-			rawQuery:           "TO=0m;QUERY=foo;FROM=1m",
-			expectedQuery:      "foo",
-			expectedTimeWindow: time.Minute,
-			expectError:        false,
-		},
-		{
-			name:               "error: trailing delimiter",
-			rawQuery:           "FROM=1m;TO=0m;QUERY=foo;;",
-			expectedQuery:      "foo",
-			expectedTimeWindow: time.Minute,
-			expectError:        true,
-		},
-		{
-			name:               "error: from after to",
-			rawQuery:           "FROM=1m;TO=3m;QUERY=foo",
-			expectedQuery:      "foo",
-			expectedTimeWindow: time.Minute,
-			expectError:        true,
-		},
-		{
-			name:               "error: empty query",
-			rawQuery:           "FROM=1m;TO=3m;QUERY=",
-			expectedQuery:      "",
-			expectedTimeWindow: time.Minute,
-			expectError:        true,
-		},
-		{
-			name:               "error: missing query",
-			rawQuery:           "FROM=1m;TO=3m",
-			expectedQuery:      "",
-			expectedTimeWindow: time.Minute,
-			expectError:        true,
-		},
-		{
-			name:               "error: missing from",
-			rawQuery:           "TO=3m;QUERY=foo",
-			expectedQuery:      "",
-			expectedTimeWindow: time.Minute,
-			expectError:        true,
-		},
-		{
-			name:               "error: missing from and to",
-			rawQuery:           "QUERY=foo",
-			expectedQuery:      "",
-			expectedTimeWindow: time.Minute,
-			expectError:        true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actualOutput, err := parseRawQuery(tc.rawQuery)
-			if tc.expectError {
-				assert.NotNil(t, err, tc.rawQuery, tc.name)
-				return
-			}
-			assert.Nil(t, err, tc.name)
-			assert.Equal(t, tc.expectedQuery, actualOutput.query, tc.name)
-			assert.Equal(t, tc.expectedTimeWindow, actualOutput.to.Sub(actualOutput.from), tc.name)
 		})
 	}
 }

--- a/plugins/builtin/apm/nomad/plugin/job_test.go
+++ b/plugins/builtin/apm/nomad/plugin/job_test.go
@@ -42,7 +42,7 @@ func Test_calculateTaskGroupResult(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualOutput := calculateTaskGroupResult(tc.inputOp, tc.inputMetrics)
-			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+			assert.Equal(t, tc.expectedOutput, actualOutput[0].Value, tc.name)
 		})
 	}
 }

--- a/plugins/builtin/apm/nomad/plugin/metrics.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/nomad-autoscaler/sdk"
 )
 
 const (
@@ -27,7 +29,7 @@ const (
 )
 
 // Query satisfies the Query function on the apm.APM interface.
-func (a *APMPlugin) Query(q string) (float64, error) {
+func (a *APMPlugin) Query(q string, _ sdk.TimeRange) (sdk.TimestampedMetrics, error) {
 
 	// Split the input query so we can understand which query type we are
 	// dealing with.
@@ -39,7 +41,7 @@ func (a *APMPlugin) Query(q string) (float64, error) {
 	case QueryTypeNode:
 		return a.queryNodePool(q)
 	default:
-		return 0, fmt.Errorf("unsupported query type %q", querySplit[0])
+		return nil, fmt.Errorf("unsupported query type %q", querySplit[0])
 	}
 }
 

--- a/plugins/builtin/apm/nomad/plugin/metrics.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics.go
@@ -29,10 +29,9 @@ const (
 )
 
 // Query satisfies the Query function on the apm.APM interface.
+// The Nomad Metrics API doesn't provide historical data, so time range
+// for the query is not used.
 func (a *APMPlugin) Query(q string, _ sdk.TimeRange) (sdk.TimestampedMetrics, error) {
-	// The Nomad Metrics API doesn't provide historical data, so time range
-	// for the query is not used.
-
 	// Split the input query so we can understand which query type we are
 	// dealing with.
 	querySplit := strings.Split(q, "_")

--- a/plugins/builtin/apm/nomad/plugin/metrics.go
+++ b/plugins/builtin/apm/nomad/plugin/metrics.go
@@ -30,6 +30,8 @@ const (
 
 // Query satisfies the Query function on the apm.APM interface.
 func (a *APMPlugin) Query(q string, _ sdk.TimeRange) (sdk.TimestampedMetrics, error) {
+	// The Nomad Metrics API doesn't provide historical data, so time range
+	// for the query is not used.
 
 	// Split the input query so we can understand which query type we are
 	// dealing with.

--- a/plugins/builtin/strategy/target-value/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/plugins/base"
@@ -37,8 +38,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
 				Check: &sdk.ScalingPolicyCheck{
-					Strategy: &sdk.ScalingPolicyStrategy{
-					},
+					Strategy: &sdk.ScalingPolicyStrategy{},
 				},
 			},
 			expectedResp:  nil,
@@ -71,7 +71,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
-				Metric: 13,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 13}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "13"},
@@ -81,7 +81,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			inputCount: 2,
 			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metric: 13,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 13}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "13"},
@@ -96,7 +96,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
-				Metric: 26,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 26}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "13"},
@@ -106,7 +106,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			inputCount: 2,
 			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metric: 26,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 26}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "13"},
@@ -123,7 +123,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
-				Metric: 20,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 20}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "10"},
@@ -133,7 +133,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			inputCount: 0,
 			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metric: 20,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 20}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "10"},
@@ -150,7 +150,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
-				Metric: 9,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 9}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "10"},
@@ -160,7 +160,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			inputCount: 1,
 			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metric: 9,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 9}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "10"},
@@ -175,7 +175,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
-				Metric: 1,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 1}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "10"},
@@ -185,7 +185,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			inputCount: 0,
 			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metric: 1,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 1}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "10"},
@@ -202,7 +202,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
-				Metric: 0,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 0}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "0"},
@@ -212,7 +212,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			inputCount: 5,
 			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metric: 0,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 0}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "0"},
@@ -229,7 +229,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
-				Metric: 5.00001,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 5.00001}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "5"},
@@ -239,7 +239,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			inputCount: 8,
 			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metric: 5.00001,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 5.00001}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "5"},
@@ -254,7 +254,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
-				Metric: 5.00001,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 5.00001}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "5", "threshold": "0.000001"},
@@ -264,7 +264,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			inputCount: 8,
 			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metric: 5.00001,
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 5.00001}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "5", "threshold": "0.000001"},
@@ -278,6 +278,41 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			},
 			expectedError: nil,
 			name:          "scale up on small changes if threshold is small",
+		},
+		{
+			inputEval: &sdk.ScalingCheckEvaluation{
+				Metrics: sdk.TimestampedMetrics{
+					sdk.TimestampedMetric{Value: 13, Timestamp: time.Unix(1600000000, 0)},
+					sdk.TimestampedMetric{Value: 14, Timestamp: time.Unix(1600000001, 0)},
+					sdk.TimestampedMetric{Value: 15, Timestamp: time.Unix(1600000002, 0)},
+					sdk.TimestampedMetric{Value: 16, Timestamp: time.Unix(1600000003, 0)},
+				},
+				Check: &sdk.ScalingPolicyCheck{
+					Strategy: &sdk.ScalingPolicyStrategy{
+						Config: map[string]string{"target": "16"},
+					},
+				},
+				Action: &sdk.ScalingAction{},
+			},
+			inputCount: 2,
+			expectedResp: &sdk.ScalingCheckEvaluation{
+				Metrics: sdk.TimestampedMetrics{
+					sdk.TimestampedMetric{Value: 13, Timestamp: time.Unix(1600000000, 0)},
+					sdk.TimestampedMetric{Value: 14, Timestamp: time.Unix(1600000001, 0)},
+					sdk.TimestampedMetric{Value: 15, Timestamp: time.Unix(1600000002, 0)},
+					sdk.TimestampedMetric{Value: 16, Timestamp: time.Unix(1600000003, 0)},
+				},
+				Check: &sdk.ScalingPolicyCheck{
+					Strategy: &sdk.ScalingPolicyStrategy{
+						Config: map[string]string{"target": "16"},
+					},
+				},
+				Action: &sdk.ScalingAction{
+					Direction: sdk.ScaleDirectionNone,
+				},
+			},
+			expectedError: nil,
+			name:          "properly handle multiple input",
 		},
 	}
 

--- a/policy/file/parse.go
+++ b/policy/file/parse.go
@@ -31,6 +31,17 @@ func decodeFile(file string, p *sdk.ScalingPolicy) error {
 		decodePolicy.Doc.EvaluationInterval = d
 	}
 
+	// Parse query window for each check.
+	for i := 0; i < len(decodePolicy.Doc.Checks); i++ {
+		check := decodePolicy.Doc.Checks[i]
+		w, err := time.ParseDuration(check.QueryWindowHCL)
+		if err != nil {
+			return err
+		}
+
+		decodePolicy.Doc.Checks[i].QueryWindow = w
+	}
+
 	// Translate from our intermediate struct, to our internal flattened
 	// policy.
 	decodePolicy.Translate(p)

--- a/policy/file/parse.go
+++ b/policy/file/parse.go
@@ -34,11 +34,16 @@ func decodeFile(file string, p *sdk.ScalingPolicy) error {
 	// Parse query window for each check.
 	for i := 0; i < len(decodePolicy.Doc.Checks); i++ {
 		check := decodePolicy.Doc.Checks[i]
+
+		// Skip parsing if query_window not set.
+		if check.QueryWindowHCL == "" {
+			continue
+		}
+
 		w, err := time.ParseDuration(check.QueryWindowHCL)
 		if err != nil {
 			return err
 		}
-
 		decodePolicy.Doc.Checks[i].QueryWindow = w
 	}
 

--- a/policy/file/parse_test.go
+++ b/policy/file/parse_test.go
@@ -28,9 +28,10 @@ func Test_decodeFile(t *testing.T) {
 				EvaluationInterval: 1 * time.Minute,
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Name:   "cpu_nomad",
-						Source: "nomad_apm",
-						Query:  "cpu_high-memory",
+						Name:        "cpu_nomad",
+						Source:      "nomad_apm",
+						Query:       "cpu_high-memory",
+						QueryWindow: time.Minute,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Name: "target-value",
 							Config: map[string]string{
@@ -114,6 +115,11 @@ func Test_decodeFile(t *testing.T) {
 			actualError := decodeFile(tc.inputFile, tc.inputPolicy)
 			assert.Equal(t, tc.expectedOutputPolicy, tc.inputPolicy, tc.name)
 			assert.Equal(t, tc.expectedOutputError, actualError, tc.name)
+
+			// Print unexpected errors.
+			if actualError != nil && tc.expectedOutputError == nil {
+				t.Logf("%s", actualError)
+			}
 		})
 	}
 }

--- a/policy/file/test-fixtures/full-cluster-policy.hcl
+++ b/policy/file/test-fixtures/full-cluster-policy.hcl
@@ -8,8 +8,9 @@ policy {
   evaluation_interval = "1m"
 
   check "cpu_nomad" {
-    source    = "nomad_apm"
-    query     = "cpu_high-memory"
+    source       = "nomad_apm"
+    query        = "cpu_high-memory"
+    query_window = "1m"
 
     strategy "target-value" {
       target = "80"

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -106,6 +106,7 @@ func parseChecks(cs interface{}) []*sdk.ScalingPolicyCheck {
 //    | check "name" {                 |
 //    |   source = "source"            |
 //    |   query = "query"              |
+//    |   query_window = "5m"          |
 //    |   strategy "strategy" { ... }  |
 //    | }                              |
 //    +--------------------------------+
@@ -136,10 +137,17 @@ func parseCheck(c interface{}) *sdk.ScalingPolicyCheck {
 	query, _ := checkMap[keyQuery].(string)
 	source, _ := checkMap[keySource].(string)
 
+	// Parse query_window ignoring errors since we assume policy has been validated.
+	var queryWindow time.Duration
+	if queryWindowStr, ok := checkMap[keyQueryWindow].(string); ok {
+		queryWindow, _ = time.ParseDuration(queryWindowStr)
+	}
+
 	return &sdk.ScalingPolicyCheck{
-		Query:    query,
-		Source:   source,
-		Strategy: strategy,
+		Query:       query,
+		QueryWindow: queryWindow,
+		Source:      source,
+		Strategy:    strategy,
 	}
 }
 

--- a/policy/nomad/parser_test.go
+++ b/policy/nomad/parser_test.go
@@ -39,9 +39,10 @@ func Test_parsePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Name:   "check-1",
-						Source: "source-1",
-						Query:  "query-1",
+						Name:        "check-1",
+						Source:      "source-1",
+						Query:       "query-1",
+						QueryWindow: time.Minute,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Name: "strategy-1",
 							Config: map[string]string{

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -19,6 +19,7 @@ import (
 const (
 	keySource             = "source"
 	keyQuery              = "query"
+	keyQueryWindow        = "query_window"
 	keyEvaluationInterval = "evaluation_interval"
 	keyTarget             = "target"
 	keyChecks             = "check"

--- a/policy/nomad/source_test.go
+++ b/policy/nomad/source_test.go
@@ -37,9 +37,10 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Name:   "check",
-						Source: "source",
-						Query:  "query",
+						Name:        "check",
+						Source:      "source",
+						Query:       "query",
+						QueryWindow: 5 * time.Minute,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Name: "strategy",
 							Config: map[string]string{
@@ -67,9 +68,10 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Name:   "check",
-						Source: "source",
-						Query:  "query",
+						Name:        "check",
+						Source:      "source",
+						Query:       "query",
+						QueryWindow: 5 * time.Minute,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Name: "strategy",
 							Config: map[string]string{
@@ -123,8 +125,9 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Source: plugins.InternalAPMNomad,
-						Query:  "taskgroup_avg_cpu/group/job",
+						Source:      plugins.InternalAPMNomad,
+						Query:       "taskgroup_avg_cpu/group/job",
+						QueryWindow: policy.DefaultQueryWindow,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Config: map[string]string{},
 						},
@@ -159,8 +162,9 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Source: plugins.InternalAPMNomad,
-						Query:  "taskgroup_avg_cpu/group/job",
+						Source:      plugins.InternalAPMNomad,
+						Query:       "taskgroup_avg_cpu/group/job",
+						QueryWindow: policy.DefaultQueryWindow,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Config: map[string]string{},
 						},
@@ -194,8 +198,9 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Source: plugins.InternalAPMNomad,
-						Query:  "taskgroup_avg_cpu/my_group/my_job",
+						Source:      plugins.InternalAPMNomad,
+						Query:       "taskgroup_avg_cpu/my_group/my_job",
+						QueryWindow: policy.DefaultQueryWindow,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Config: map[string]string{},
 						},
@@ -230,8 +235,9 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Source: "not_nomad",
-						Query:  "avg_cpu",
+						Source:      "not_nomad",
+						Query:       "avg_cpu",
+						QueryWindow: policy.DefaultQueryWindow,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Config: map[string]string{},
 						},
@@ -265,8 +271,9 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Source: plugins.InternalAPMNomad,
-						Query:  "avg_cpu/my_group/my_job",
+						Source:      plugins.InternalAPMNomad,
+						Query:       "avg_cpu/my_group/my_job",
+						QueryWindow: policy.DefaultQueryWindow,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Config: map[string]string{},
 						},

--- a/policy/nomad/test-fixtures/full-scaling.json.golden
+++ b/policy/nomad/test-fixtures/full-scaling.json.golden
@@ -4,18 +4,20 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulToken": "",
-    "CreateIndex": 935,
+    "CreateIndex": 10,
     "Datacenters": [
       "dc1"
     ],
     "Dispatched": false,
     "ID": "full-scaling",
-    "JobModifyIndex": 935,
+    "JobModifyIndex": 10,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 964,
+    "ModifyIndex": 13,
+    "Multiregion": null,
     "Name": "full-scaling",
     "Namespace": "default",
+    "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
     "Payload": null,
@@ -28,7 +30,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1591924316308770000,
+    "SubmitTime": 1600298684068791000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -58,12 +60,12 @@
           "Mode": "fail"
         },
         "Scaling": {
-          "CreateIndex": 935,
+          "CreateIndex": 10,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 2,
-          "ModifyIndex": 935,
+          "ModifyIndex": 10,
           "Namespace": "",
           "Policy": {
             "cooldown": "5m",
@@ -72,9 +74,9 @@
               {
                 "target": [
                   {
-                    "str_config": "str",
                     "bool_config": true,
-                    "int_config": 2
+                    "int_config": 2,
+                    "str_config": "str"
                   }
                 ]
               }
@@ -83,19 +85,20 @@
               {
                 "check-1": [
                   {
-                    "query": "query-1",
+                    "query_window": "1m",
                     "source": "source-1",
                     "strategy": [
                       {
                         "strategy-1": [
                           {
+                            "int_config": 2,
                             "str_config": "str",
-                            "bool_config": true,
-                            "int_config": 2
+                            "bool_config": true
                           }
                         ]
                       }
-                    ]
+                    ],
+                    "query": "query-1"
                   }
                 ]
               },
@@ -121,9 +124,9 @@
             ]
           },
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "full-scaling"
+            "Job": "full-scaling",
+            "Group": "test"
           }
         },
         "Services": null,

--- a/policy/nomad/test-fixtures/invalid-query-window1.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query-window1.json.golden
@@ -1,0 +1,169 @@
+{
+  "Job": {
+    "Affinities": null,
+    "AllAtOnce": false,
+    "Constraints": null,
+    "ConsulToken": "",
+    "CreateIndex": 36,
+    "Datacenters": [
+      "dc1"
+    ],
+    "Dispatched": false,
+    "ID": "invalid-query-window1",
+    "JobModifyIndex": 36,
+    "Meta": null,
+    "Migrate": null,
+    "ModifyIndex": 39,
+    "Multiregion": null,
+    "Name": "invalid-query-window1",
+    "Namespace": "default",
+    "NomadTokenID": "",
+    "ParameterizedJob": null,
+    "ParentID": "",
+    "Payload": null,
+    "Periodic": null,
+    "Priority": 50,
+    "Region": "global",
+    "Reschedule": null,
+    "Spreads": null,
+    "Stable": false,
+    "Status": "dead",
+    "StatusDescription": "",
+    "Stop": false,
+    "SubmitTime": 1600299182059182000,
+    "TaskGroups": [
+      {
+        "Affinities": null,
+        "Constraints": null,
+        "Count": 1,
+        "EphemeralDisk": {
+          "Migrate": false,
+          "SizeMB": 300,
+          "Sticky": false
+        },
+        "Meta": null,
+        "Migrate": null,
+        "Name": "test",
+        "Networks": null,
+        "ReschedulePolicy": {
+          "Attempts": 1,
+          "Delay": 5000000000,
+          "DelayFunction": "constant",
+          "Interval": 86400000000000,
+          "MaxDelay": 0,
+          "Unlimited": false
+        },
+        "RestartPolicy": {
+          "Attempts": 3,
+          "Delay": 15000000000,
+          "Interval": 86400000000000,
+          "Mode": "fail"
+        },
+        "Scaling": {
+          "CreateIndex": 36,
+          "Enabled": true,
+          "ID": "id",
+          "Max": 10,
+          "Min": 1,
+          "ModifyIndex": 36,
+          "Namespace": "",
+          "Policy": {
+            "check": [
+              {
+                "check": [
+                  {
+                    "query_window": 5,
+                    "strategy": [
+                      {
+                        "strategy": [
+                          {
+                            "str_config": "str",
+                            "bool_config": true,
+                            "int_config": 2
+                          }
+                        ]
+                      }
+                    ],
+                    "query": "query"
+                  }
+                ]
+              }
+            ]
+          },
+          "Target": {
+            "Group": "test",
+            "Namespace": "default",
+            "Job": "invalid-query-window1"
+          }
+        },
+        "Services": null,
+        "ShutdownDelay": null,
+        "Spreads": null,
+        "StopAfterClientDisconnect": null,
+        "Tasks": [
+          {
+            "Affinities": null,
+            "Artifacts": null,
+            "Config": {
+              "command": "echo",
+              "args": [
+                "hi"
+              ]
+            },
+            "Constraints": null,
+            "DispatchPayload": null,
+            "Driver": "raw_exec",
+            "Env": null,
+            "KillSignal": "",
+            "KillTimeout": 5000000000,
+            "Kind": "",
+            "Leader": false,
+            "Lifecycle": null,
+            "LogConfig": {
+              "MaxFileSizeMB": 10,
+              "MaxFiles": 10
+            },
+            "Meta": null,
+            "Name": "echo",
+            "Resources": {
+              "CPU": 100,
+              "Devices": null,
+              "DiskMB": 0,
+              "IOPS": 0,
+              "MemoryMB": 300,
+              "Networks": null
+            },
+            "RestartPolicy": {
+              "Attempts": 3,
+              "Delay": 15000000000,
+              "Interval": 86400000000000,
+              "Mode": "fail"
+            },
+            "Services": null,
+            "ShutdownDelay": 0,
+            "Templates": null,
+            "User": "",
+            "Vault": null,
+            "VolumeMounts": null
+          }
+        ],
+        "Update": null,
+        "Volumes": null
+      }
+    ],
+    "Type": "batch",
+    "Update": {
+      "AutoPromote": false,
+      "AutoRevert": false,
+      "Canary": 0,
+      "HealthCheck": "",
+      "HealthyDeadline": 0,
+      "MaxParallel": 0,
+      "MinHealthyTime": 0,
+      "ProgressDeadline": 0,
+      "Stagger": 0
+    },
+    "VaultToken": "",
+    "Version": 0
+  }
+}

--- a/policy/nomad/test-fixtures/invalid-query-window2.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query-window2.json.golden
@@ -1,0 +1,169 @@
+{
+  "Job": {
+    "Affinities": null,
+    "AllAtOnce": false,
+    "Constraints": null,
+    "ConsulToken": "",
+    "CreateIndex": 42,
+    "Datacenters": [
+      "dc1"
+    ],
+    "Dispatched": false,
+    "ID": "invalid-query-window2",
+    "JobModifyIndex": 42,
+    "Meta": null,
+    "Migrate": null,
+    "ModifyIndex": 43,
+    "Multiregion": null,
+    "Name": "invalid-query-window2",
+    "Namespace": "default",
+    "NomadTokenID": "",
+    "ParameterizedJob": null,
+    "ParentID": "",
+    "Payload": null,
+    "Periodic": null,
+    "Priority": 50,
+    "Region": "global",
+    "Reschedule": null,
+    "Spreads": null,
+    "Stable": false,
+    "Status": "running",
+    "StatusDescription": "",
+    "Stop": false,
+    "SubmitTime": 1600299193558569000,
+    "TaskGroups": [
+      {
+        "Affinities": null,
+        "Constraints": null,
+        "Count": 1,
+        "EphemeralDisk": {
+          "Migrate": false,
+          "SizeMB": 300,
+          "Sticky": false
+        },
+        "Meta": null,
+        "Migrate": null,
+        "Name": "test",
+        "Networks": null,
+        "ReschedulePolicy": {
+          "Attempts": 1,
+          "Delay": 5000000000,
+          "DelayFunction": "constant",
+          "Interval": 86400000000000,
+          "MaxDelay": 0,
+          "Unlimited": false
+        },
+        "RestartPolicy": {
+          "Attempts": 3,
+          "Delay": 15000000000,
+          "Interval": 86400000000000,
+          "Mode": "fail"
+        },
+        "Scaling": {
+          "CreateIndex": 42,
+          "Enabled": true,
+          "ID": "id",
+          "Max": 10,
+          "Min": 1,
+          "ModifyIndex": 42,
+          "Namespace": "",
+          "Policy": {
+            "check": [
+              {
+                "check": [
+                  {
+                    "query_window": "not quite right",
+                    "strategy": [
+                      {
+                        "strategy": [
+                          {
+                            "bool_config": true,
+                            "int_config": 2,
+                            "str_config": "str"
+                          }
+                        ]
+                      }
+                    ],
+                    "query": "query"
+                  }
+                ]
+              }
+            ]
+          },
+          "Target": {
+            "Group": "test",
+            "Namespace": "default",
+            "Job": "invalid-query-window2"
+          }
+        },
+        "Services": null,
+        "ShutdownDelay": null,
+        "Spreads": null,
+        "StopAfterClientDisconnect": null,
+        "Tasks": [
+          {
+            "Affinities": null,
+            "Artifacts": null,
+            "Config": {
+              "args": [
+                "hi"
+              ],
+              "command": "echo"
+            },
+            "Constraints": null,
+            "DispatchPayload": null,
+            "Driver": "raw_exec",
+            "Env": null,
+            "KillSignal": "",
+            "KillTimeout": 5000000000,
+            "Kind": "",
+            "Leader": false,
+            "Lifecycle": null,
+            "LogConfig": {
+              "MaxFileSizeMB": 10,
+              "MaxFiles": 10
+            },
+            "Meta": null,
+            "Name": "echo",
+            "Resources": {
+              "CPU": 100,
+              "Devices": null,
+              "DiskMB": 0,
+              "IOPS": 0,
+              "MemoryMB": 300,
+              "Networks": null
+            },
+            "RestartPolicy": {
+              "Attempts": 3,
+              "Delay": 15000000000,
+              "Interval": 86400000000000,
+              "Mode": "fail"
+            },
+            "Services": null,
+            "ShutdownDelay": 0,
+            "Templates": null,
+            "User": "",
+            "Vault": null,
+            "VolumeMounts": null
+          }
+        ],
+        "Update": null,
+        "Volumes": null
+      }
+    ],
+    "Type": "batch",
+    "Update": {
+      "AutoPromote": false,
+      "AutoRevert": false,
+      "Canary": 0,
+      "HealthCheck": "",
+      "HealthyDeadline": 0,
+      "MaxParallel": 0,
+      "MinHealthyTime": 0,
+      "ProgressDeadline": 0,
+      "Stagger": 0
+    },
+    "VaultToken": "",
+    "Version": 0
+  }
+}

--- a/policy/nomad/test-fixtures/src/full-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/full-scaling.hcl
@@ -19,8 +19,9 @@ job "full-scaling" {
         }
 
         check "check-1" {
-          source = "source-1"
-          query  = "query-1"
+          source       = "source-1"
+          query        = "query-1"
+          query_window = "1m"
 
           strategy "strategy-1" {
             int_config  = 2

--- a/policy/nomad/test-fixtures/src/invalid-query-window1.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-query-window1.hcl
@@ -1,0 +1,31 @@
+job "invalid-query-window1" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  group "test" {
+    scaling {
+      max = 10
+
+      policy {
+        check "check" {
+          query        = "query"
+          query_window = 5
+
+          strategy "strategy" {
+            int_config  = 2
+            bool_config = true
+            str_config  = "str"
+          }
+        }
+      }
+    }
+
+    task "echo" {
+      driver = "raw_exec"
+      config {
+        command = "echo"
+        args    = ["hi"]
+      }
+    }
+  }
+}

--- a/policy/nomad/test-fixtures/src/invalid-query-window2.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-query-window2.hcl
@@ -1,0 +1,31 @@
+job "invalid-query-window2" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  group "test" {
+    scaling {
+      max = 10
+
+      policy {
+        check "check" {
+          query        = "query"
+          query_window = "not quite right"
+
+          strategy "strategy" {
+            int_config  = 2
+            bool_config = true
+            str_config  = "str"
+          }
+        }
+      }
+    }
+
+    task "echo" {
+      driver = "raw_exec"
+      config {
+        command = "echo"
+        args    = ["hi"]
+      }
+    }
+  }
+}

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -205,6 +205,15 @@ func validateCheck(c map[string]interface{}, path string) error {
 		}
 	}
 
+	// Validate QueryWindow, if present.
+	//   1. QueryWindow should be a valid time duration.
+	queryWindow, ok := c[keyQueryWindow]
+	if ok {
+		if err := validateDuration(queryWindow, path+"."+keyQueryWindow); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
 	// Validate Strategy.
 	//   1. Strategy key must exist.
 	//   2. Strategy must be a valid block.

--- a/policy/nomad/validate_test.go
+++ b/policy/nomad/validate_test.go
@@ -253,6 +253,16 @@ func Test_validateScalingPolicy(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:        "policy.check.query_window is not a string",
+			inputFile:   "invalid-query-window1",
+			expectError: true,
+		},
+		{
+			name:        "policy.check.query_window is not a duration",
+			inputFile:   "invalid-query-window2",
+			expectError: true,
+		},
+		{
 			name:        "policy.check.query is empty",
 			inputFile:   "invalid-empty-query",
 			expectError: true,

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -35,6 +35,13 @@ func (pr *Processor) ApplyPolicyDefaults(p *sdk.ScalingPolicy) {
 	if p.EvaluationInterval == 0 {
 		p.EvaluationInterval = pr.defaults.DefaultEvaluationInterval
 	}
+
+	for i := 0; i < len(p.Checks); i++ {
+		c := p.Checks[i]
+		if c.QueryWindow == 0 {
+			c.QueryWindow = DefaultQueryWindow
+		}
+	}
 }
 
 // ValidatePolicy performs validation of the policy document returning a list

--- a/policy/source.go
+++ b/policy/source.go
@@ -8,6 +8,10 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/sdk"
 )
 
+// DefaultQueryWindow is the value used if `query_window` is not specified in
+// a policy check.
+const DefaultQueryWindow = time.Minute
+
 // ConfigDefaults holds default configuration for unspecified values.
 type ConfigDefaults struct {
 	DefaultEvaluationInterval time.Duration

--- a/sdk/apm.go
+++ b/sdk/apm.go
@@ -1,0 +1,29 @@
+package sdk
+
+import "time"
+
+// TimestampedMetric contains a single metric Value along with its associated
+// Timestamp.
+type TimestampedMetric struct {
+	Timestamp time.Time
+	Value     float64
+}
+
+// TimestampedMetrics is an array of timestamped metric values. This type is
+// used so we can sort metrics based on the timestamp.
+type TimestampedMetrics []TimestampedMetric
+
+// Len satisfies the Len function of the sort.Interface interface.
+func (t TimestampedMetrics) Len() int { return len(t) }
+
+// Less satisfies the Less function of the sort.Interface interface.
+func (t TimestampedMetrics) Less(i, j int) bool { return t[i].Timestamp.Before(t[j].Timestamp) }
+
+// Swap satisfies the Swap function of the sort.Interface interface.
+func (t TimestampedMetrics) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+
+// TimeRange defines a range of time.
+type TimeRange struct {
+	From time.Time
+	To   time.Time
+}

--- a/sdk/eval.go
+++ b/sdk/eval.go
@@ -18,7 +18,7 @@ type ScalingCheckEvaluation struct {
 	Check *ScalingPolicyCheck
 
 	// Metric is the metric resulting from querying the APM.
-	Metric float64
+	Metrics TimestampedMetrics
 
 	// Action is the calculated desired state and is populated by strategy.Run.
 	Action *ScalingAction

--- a/sdk/eval_test.go
+++ b/sdk/eval_test.go
@@ -101,7 +101,7 @@ func TestNewScalingEvaluation(t *testing.T) {
 								Config: map[string]string{"target": "10"},
 							},
 						},
-						Metric: 0,
+						Metrics: nil,
 						Action: &ScalingAction{
 							Meta: make(map[string]interface{}),
 						},
@@ -116,7 +116,7 @@ func TestNewScalingEvaluation(t *testing.T) {
 								Config: map[string]string{"target": "100"},
 							},
 						},
-						Metric: 0,
+						Metrics: nil,
 						Action: &ScalingAction{
 							Meta: make(map[string]interface{}),
 						},

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -153,7 +153,7 @@ func (fpd *FileDecodeScalingPolicy) Translate(p *ScalingPolicy) {
 func (fpd *FileDecodeScalingPolicy) translateChecks(p *ScalingPolicy) {
 	var checks []*ScalingPolicyCheck
 	for _, c := range fpd.Doc.Checks {
-		var check *ScalingPolicyCheck
+		check := &ScalingPolicyCheck{}
 		c.Translate(check)
 		checks = append(checks, check)
 	}

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -49,18 +49,22 @@ type ScalingPolicyCheck struct {
 
 	// Name is a human readable name for this check and allows operators to
 	// create clearly identified policy checks.
-	Name string `hcl:"name,label"`
+	Name string
 
 	// Source is the APM plugin that should be used to perform the query and
 	// obtain the metric that will be used to perform a calculation.
-	Source string `hcl:"source,optional"`
+	Source string
 
 	// Query is run against the Source in order to receive a metric response.
-	Query string `hcl:"query"`
+	Query string
+
+	// QueryWindow is used to define how further back in time to query for
+	// metrics.
+	QueryWindow time.Duration
 
 	// Strategy is the ScalingPolicyStrategy to use when performing the
 	// ScalingPolicyCheck evaluation.
-	Strategy *ScalingPolicyStrategy `hcl:"strategy,block"`
+	Strategy *ScalingPolicyStrategy
 }
 
 // ScalingPolicyStrategy contains the plugin and configuration details for
@@ -119,9 +123,18 @@ type FileDecodePolicyDoc struct {
 	Cooldown              time.Duration
 	CooldownHCL           string `hcl:"cooldown,optional"`
 	EvaluationInterval    time.Duration
-	EvaluationIntervalHCL string                `hcl:"evaluation_interval,optional"`
-	Checks                []*ScalingPolicyCheck `hcl:"check,block"`
-	Target                *ScalingPolicyTarget  `hcl:"target,block"`
+	EvaluationIntervalHCL string                      `hcl:"evaluation_interval,optional"`
+	Checks                []*FileDecodePolicyCheckDoc `hcl:"check,block"`
+	Target                *ScalingPolicyTarget        `hcl:"target,block"`
+}
+
+type FileDecodePolicyCheckDoc struct {
+	Name           string `hcl:"name,label"`
+	Source         string `hcl:"source,optional"`
+	Query          string `hcl:"query"`
+	QueryWindow    time.Duration
+	QueryWindowHCL string                 `hcl:"query_window"`
+	Strategy       *ScalingPolicyStrategy `hcl:"strategy,block"`
 }
 
 // Translate all values from the decoded policy file into our internal policy
@@ -132,6 +145,28 @@ func (fpd *FileDecodeScalingPolicy) Translate(p *ScalingPolicy) {
 	p.Enabled = fpd.Enabled
 	p.Cooldown = fpd.Doc.Cooldown
 	p.EvaluationInterval = fpd.Doc.EvaluationInterval
-	p.Checks = fpd.Doc.Checks
 	p.Target = fpd.Doc.Target
+
+	fpd.translateChecks(p)
+}
+
+func (fpd *FileDecodeScalingPolicy) translateChecks(p *ScalingPolicy) {
+	var checks []*ScalingPolicyCheck
+	for _, c := range fpd.Doc.Checks {
+		var check *ScalingPolicyCheck
+		c.Translate(check)
+		checks = append(checks, check)
+	}
+
+	p.Checks = checks
+}
+
+// Translate all values from the decoded policy check into our internal policy
+// check object.
+func (fdc *FileDecodePolicyCheckDoc) Translate(c *ScalingPolicyCheck) {
+	c.Name = fdc.Name
+	c.Source = fdc.Source
+	c.Query = fdc.Query
+	c.QueryWindow = fdc.QueryWindow
+	c.Strategy = fdc.Strategy
 }

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -133,7 +133,7 @@ type FileDecodePolicyCheckDoc struct {
 	Source         string `hcl:"source,optional"`
 	Query          string `hcl:"query"`
 	QueryWindow    time.Duration
-	QueryWindowHCL string                 `hcl:"query_window"`
+	QueryWindowHCL string                 `hcl:"query_window,optional"`
 	Strategy       *ScalingPolicyStrategy `hcl:"strategy,block"`
 }
 

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -24,11 +24,13 @@ func TestFileDecodePolicy_Translate(t *testing.T) {
 					CooldownHCL:           "10ms",
 					EvaluationInterval:    10 * time.Nanosecond,
 					EvaluationIntervalHCL: "10ns",
-					Checks: []*ScalingPolicyCheck{
+					Checks: []*FileDecodePolicyCheckDoc{
 						{
-							Name:   "approach-speed",
-							Source: "front-sensor",
-							Query:  "how-fast-am-i-going",
+							Name:           "approach-speed",
+							Source:         "front-sensor",
+							Query:          "how-fast-am-i-going",
+							QueryWindow:    time.Minute,
+							QueryWindowHCL: "1m",
 							Strategy: &ScalingPolicyStrategy{
 								Name: "approach-velocity",
 								Config: map[string]string{
@@ -55,9 +57,10 @@ func TestFileDecodePolicy_Translate(t *testing.T) {
 				EvaluationInterval: 10 * time.Nanosecond,
 				Checks: []*ScalingPolicyCheck{
 					{
-						Name:   "approach-speed",
-						Source: "front-sensor",
-						Query:  "how-fast-am-i-going",
+						Name:        "approach-speed",
+						Source:      "front-sensor",
+						Query:       "how-fast-am-i-going",
+						QueryWindow: time.Minute,
 						Strategy: &ScalingPolicyStrategy{
 							Name: "approach-velocity",
 							Config: map[string]string{


### PR DESCRIPTION
This PR updates the APM interface to allow plugins to query multiple results for a give time window. 

It adds a new optional attribute to `check` called `query_window` that takes a string in the Go `time.Duration` format. This value is used to query the APM from the current time the check is evaluated and back a window period.

Example:

```diff
 check "avg_instance_sessions" {
   source       = "prometheus"
   query        = "avg((haproxy_server_current_sessions{backend=\"http_back\"}) and (haproxy_server_up{backend=\"http_back\"} == 1))"
+  query_window = "5m"
  ...
}

```

It also updates the current builtin plugins. For the target strategy, only the latest value is currently being used.