### PR TITLE
helper/ptr: add string to pointer method.

### DIFF
--- a/helper/ptr/ptr.go
+++ b/helper/ptr/ptr.go
@@ -11,3 +11,7 @@ func IntToPtr(i int) *int {
 func Int64ToPtr(i int64) *int64 {
 	return &i
 }
+
+func StringToPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
This is useful for testing Nomad API JobSpec objects which use
string pointers in many places.