### PR TITLE
target/nomad: support for namespaced jobs in scale and status RPC.

### DIFF
--- a/plugins/builtin/target/nomad/plugin/state_test.go
+++ b/plugins/builtin/target/nomad/plugin/state_test.go
@@ -17,7 +17,7 @@ func Test_newJobStateHandler(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Create the new handler and perform assertions.
-	jsh := newJobScaleStatusHandler(c, "test", hclog.NewNullLogger())
+	jsh := newJobScaleStatusHandler(c, "default", "test", hclog.NewNullLogger())
 	assert.NotNil(t, jsh.client)
 	assert.Equal(t, "test", jsh.jobID)
 	assert.NotNil(t, jsh.initialDone)


### PR DESCRIPTION
Tested locally via vagrant demo with success.

closes #276 