### PR TITLE
Add eval broker configuration and validate agent config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/agent/config"
@@ -74,7 +73,10 @@ func (a *Agent) Run() error {
 	go a.policyManager.Run(ctx, policyEvalCh)
 
 	// Launch eval broker and workers.
-	a.evalBroker = policyeval.NewBroker(a.logger.ResetNamed("policy_eval"), 5*time.Minute, 3)
+	a.evalBroker = policyeval.NewBroker(
+		a.logger.ResetNamed("policy_eval"),
+		a.config.PolicyWorkers.AckTimeout,
+		a.config.PolicyWorkers.DeliveryLimit)
 	a.initWorkers(ctx)
 
 	// Launch the eval handler.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -75,8 +75,8 @@ func (a *Agent) Run() error {
 	// Launch eval broker and workers.
 	a.evalBroker = policyeval.NewBroker(
 		a.logger.ResetNamed("policy_eval"),
-		a.config.PolicyWorkers.AckTimeout,
-		a.config.PolicyWorkers.DeliveryLimit)
+		a.config.PolicyEval.AckTimeout,
+		a.config.PolicyEval.DeliveryLimit)
 	a.initWorkers(ctx)
 
 	// Launch the eval handler.
@@ -102,13 +102,13 @@ func (a *Agent) runEvalHandler(ctx context.Context, evalCh chan *sdk.ScalingEval
 func (a *Agent) initWorkers(ctx context.Context) {
 	policyEvalLogger := a.logger.ResetNamed("policy_eval")
 
-	for i := 0; i < a.config.PolicyWorkers.Horizontal; i++ {
+	for i := 0; i < a.config.PolicyEval.Workers["horizontal"]; i++ {
 		w := policyeval.NewBaseWorker(
 			policyEvalLogger, a.pluginManager, a.policyManager, a.evalBroker, "horizontal")
 		go w.Run(ctx)
 	}
 
-	for i := 0; i < a.config.PolicyWorkers.Cluster; i++ {
+	for i := 0; i < a.config.PolicyEval.Workers["cluster"]; i++ {
 		w := policyeval.NewBaseWorker(
 			policyEvalLogger, a.pluginManager, a.policyManager, a.evalBroker, "cluster")
 		go w.Run(ctx)

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -24,6 +24,8 @@ func Test_Default(t *testing.T) {
 	assert.Equal(t, "127.0.0.1", def.HTTP.BindAddress)
 	assert.Equal(t, 8080, def.HTTP.BindPort)
 	assert.Equal(t, def.Policy.DefaultCooldown, 5*time.Minute)
+	assert.Equal(t, defaultPolicyWorkerDeliveryLimit, def.PolicyWorkers.DeliveryLimit)
+	assert.Equal(t, defaultPolicyWorkerAckTimeout, def.PolicyWorkers.AckTimeout)
 	assert.Equal(t, defaultClusterPolicyWorkers, def.PolicyWorkers.Cluster)
 	assert.Equal(t, defaultHorizontalPolicyWorkers, def.PolicyWorkers.Horizontal)
 	assert.Len(t, def.APMs, 1)
@@ -83,10 +85,13 @@ func TestAgent_Merge(t *testing.T) {
 			DefaultEvaluationInterval: 10 * time.Second,
 		},
 		PolicyWorkers: &PolicyWorkers{
-			ClusterPtr:    ptr.IntToPtr(8),
-			Cluster:       8,
-			HorizontalPtr: ptr.IntToPtr(7),
-			Horizontal:    7,
+			DeliveryLimitPtr: ptr.IntToPtr(10),
+			DeliveryLimit:    10,
+			AckTimeout:       3 * time.Minute,
+			ClusterPtr:       ptr.IntToPtr(8),
+			Cluster:          8,
+			HorizontalPtr:    ptr.IntToPtr(7),
+			Horizontal:       7,
 		},
 		Telemetry: &Telemetry{
 			StatsiteAddr:                       "some-address",
@@ -158,10 +163,13 @@ func TestAgent_Merge(t *testing.T) {
 			DefaultEvaluationInterval: 10 * time.Second,
 		},
 		PolicyWorkers: &PolicyWorkers{
-			Cluster:       8,
-			ClusterPtr:    ptr.IntToPtr(8),
-			Horizontal:    7,
-			HorizontalPtr: ptr.IntToPtr(7),
+			DeliveryLimitPtr: ptr.IntToPtr(10),
+			DeliveryLimit:    10,
+			AckTimeout:       3 * time.Minute,
+			Cluster:          8,
+			ClusterPtr:       ptr.IntToPtr(8),
+			Horizontal:       7,
+			HorizontalPtr:    ptr.IntToPtr(7),
 		},
 		Telemetry: &Telemetry{
 			StatsiteAddr:                       "some-address",


### PR DESCRIPTION
This PR allows for operators to configure the eval broker via the configuration file. It also renames some of the fields to better match their intended use:

```hcl
policy_eval {
  ack_timeout = "10m"
  delivery_limit = 3

  workers = {
    cluster    = 0
    horizontal = 2
  }
}
```

Docs and CLI flags will come in a separate PR.