### PR TITLE
version: allow setting custom metadata on version output.

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -21,6 +21,9 @@ var (
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
 	VersionPrerelease = "dev"
+
+	// VersionMetadata is metadata further describing the build type.
+	VersionMetadata = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable
@@ -41,14 +44,19 @@ func GetHumanVersion() string {
 		release = "dev"
 	}
 
-	if release != "" {
-		if !strings.HasSuffix(version, "-"+release) {
-			// if we tagged a prerelease version then the release is in the version already
-			version += fmt.Sprintf("-%s", release)
-		}
-		if GitCommit != "" {
-			version += fmt.Sprintf(" (%s)", GitCommit)
-		}
+	if release != "" && !strings.HasSuffix(version, "-"+release) {
+		// if we tagged a prerelease version then the release is in the version
+		// already.
+		version += fmt.Sprintf("-%s", release)
+	}
+
+	if VersionMetadata != "" {
+		version += fmt.Sprintf("+%s", VersionMetadata)
+	}
+
+	// Add the commit hash at the very end of the version.
+	if release != "" && GitCommit != "" {
+		version += fmt.Sprintf(" (%s)", GitCommit)
 	}
 
 	// Strip off any single quotes added by the git information.

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -8,32 +8,44 @@ import (
 
 func Test_GetHumanVersion(t *testing.T) {
 	testCases := []struct {
-		inputCommit     string
-		inputDescribe   string
-		inputVersion    string
-		inputPrerelease string
-		expectedOutput  string
+		inputCommit          string
+		inputDescribe        string
+		inputVersion         string
+		inputPrerelease      string
+		inputVersionMetadata string
+		expectedOutput       string
 	}{
 		{
-			inputCommit:     "440bca3+CHANGES",
-			inputDescribe:   "",
-			inputVersion:    "0.1.3",
-			inputPrerelease: "dev",
-			expectedOutput:  "v0.1.3-dev (440bca3+CHANGES)",
+			inputCommit:          "440bca3+CHANGES",
+			inputDescribe:        "",
+			inputVersion:         "0.1.3",
+			inputPrerelease:      "dev",
+			inputVersionMetadata: "",
+			expectedOutput:       "v0.1.3-dev (440bca3+CHANGES)",
 		},
 		{
-			inputCommit:     "440bca3",
-			inputDescribe:   "",
-			inputVersion:    "0.6.0",
-			inputPrerelease: "beta1",
-			expectedOutput:  "v0.6.0-beta1 (440bca3)",
+			inputCommit:          "440bca3",
+			inputDescribe:        "",
+			inputVersion:         "0.6.0",
+			inputPrerelease:      "beta1",
+			inputVersionMetadata: "",
+			expectedOutput:       "v0.6.0-beta1 (440bca3)",
 		},
 		{
-			inputCommit:     "440bca3",
-			inputDescribe:   "v1.0.0",
-			inputVersion:    "1.0.0",
-			inputPrerelease: "",
-			expectedOutput:  "v1.0.0",
+			inputCommit:          "440bca3",
+			inputDescribe:        "v1.0.0",
+			inputVersion:         "1.0.0",
+			inputPrerelease:      "",
+			inputVersionMetadata: "",
+			expectedOutput:       "v1.0.0",
+		},
+		{
+			inputCommit:          "440bca3",
+			inputDescribe:        "v1.0.0",
+			inputVersion:         "1.0.0",
+			inputPrerelease:      "",
+			inputVersionMetadata: "special",
+			expectedOutput:       "v1.0.0+special",
 		},
 	}
 
@@ -42,6 +54,7 @@ func Test_GetHumanVersion(t *testing.T) {
 		GitDescribe = tc.inputDescribe
 		Version = tc.inputVersion
 		VersionPrerelease = tc.inputPrerelease
+		VersionMetadata = tc.inputVersionMetadata
 		assert.Equal(t, tc.expectedOutput, GetHumanVersion())
 	}
 }


### PR DESCRIPTION
Brings the autoscaler inline with HashiCorp products and expected
version formatting.