### PR TITLE
Fix version geneartion logic with GitDescribe

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -30,33 +30,34 @@ var (
 // for displaying to humans.
 func GetHumanVersion() string {
 	version := Version
+	release := VersionPrerelease
+
 	if GitDescribe != "" {
 		version = GitDescribe
+	} else {
+		if release == "" {
+			release = "dev"
+		}
+
+		if release != "" && !strings.HasSuffix(version, "-"+release) {
+			// if we tagged a prerelease version then the release is in the version
+			// already.
+			version += fmt.Sprintf("-%s", release)
+		}
+
+		if VersionMetadata != "" {
+			version += fmt.Sprintf("+%s", VersionMetadata)
+		}
+	}
+
+	// Add the commit hash at the very end of the version.
+	if GitCommit != "" {
+		version += fmt.Sprintf(" (%s)", GitCommit)
 	}
 
 	// Add v as prefix if not present
 	if !strings.HasPrefix(version, "v") {
 		version = fmt.Sprintf("v%s", version)
-	}
-
-	release := VersionPrerelease
-	if GitDescribe == "" && release == "" {
-		release = "dev"
-	}
-
-	if release != "" && !strings.HasSuffix(version, "-"+release) {
-		// if we tagged a prerelease version then the release is in the version
-		// already.
-		version += fmt.Sprintf("-%s", release)
-	}
-
-	if VersionMetadata != "" {
-		version += fmt.Sprintf("+%s", VersionMetadata)
-	}
-
-	// Add the commit hash at the very end of the version.
-	if release != "" && GitCommit != "" {
-		version += fmt.Sprintf(" (%s)", GitCommit)
 	}
 
 	// Strip off any single quotes added by the git information.

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -37,15 +37,23 @@ func Test_GetHumanVersion(t *testing.T) {
 			inputVersion:         "1.0.0",
 			inputPrerelease:      "",
 			inputVersionMetadata: "",
-			expectedOutput:       "v1.0.0",
+			expectedOutput:       "v1.0.0 (440bca3)",
 		},
 		{
-			inputCommit:          "440bca3",
-			inputDescribe:        "v1.0.0",
+			inputCommit:          "",
+			inputDescribe:        "",
 			inputVersion:         "1.0.0",
 			inputPrerelease:      "",
 			inputVersionMetadata: "special",
-			expectedOutput:       "v1.0.0+special",
+			expectedOutput:       "v1.0.0-dev+special",
+		},
+		{
+			inputCommit:          "440bca3",
+			inputDescribe:        "v1.0.0+special",
+			inputVersion:         "1.0.0",
+			inputPrerelease:      "",
+			inputVersionMetadata: "special",
+			expectedOutput:       "v1.0.0+special (440bca3)",
 		},
 	}
 


### PR DESCRIPTION
When the CI pipeline builds the final binary, `GitDescribe` is define with all segments already, so the CLI shouldn't add any extra info (apart from the commit hash).