### PR TITLE
demo: add Azure remote demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ pkg/
 # Terraform state files.
 *.tfstate
 *.tfstate.backup
+*.tfstate.*.backup
 .terraform.tfstate.lock.info
 
 # Terraform module and provider directory.

--- a/demo/remote/README.md
+++ b/demo/remote/README.md
@@ -18,6 +18,7 @@ In order to build and run the demo, the following applications are required loca
 There are specific steps to build the infrastructure depending on which provider you wish to use.
 Please navigate to the appropriate section below.
  * [Amazon Web Services](./aws.md)
+ * [Microsoft Azure](./azure/README.md)
 
 ## The Demo
 The steps below this point are generic across providers and form the main part of this demo. Enjoy.

--- a/demo/remote/azure/README.md
+++ b/demo/remote/azure/README.md
@@ -1,0 +1,134 @@
+### Microsoft Azure
+Some of the steps below will require that you have the
+[Azure CLI installed](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+in your machine.
+
+### Environment setup
+The first step is to login using the CLI:
+
+```shellsession
+$ az login
+[
+  {
+    "cloudName": "AzureCloud",
+    "id": "<SUBSCRIPTION_ID>",
+    "isDefault": true,
+    "name": "Free Trial",
+    "state": "Enabled",
+    "tenantId": "<TENANT_ID>",
+    "user": {
+      "name": "user@example.com",
+      "type": "user"
+    }
+  }
+```
+
+Take a note of the values for `<SUBSCRIPTION_ID>` and `<TENANT_ID>` end export
+them as environment variables:
+
+```shellsession
+$ export ARM_SUBSCRIPTION_ID=<SUBSCRIPTION_ID>
+$ export ARM_TENENT_ID=<TENANT_ID>
+```
+
+Next, create an application ID and password that will be used to run Terraform:
+
+```shellsession
+$ az ad sp create-for-rbac --role="Owner" --scopes="/subscriptions/$ARM_SUBSCRIPTION_ID"
+{
+  "appId": "<CLIENT_ID>",
+  "displayName": "azure-cli-...",
+  "name": "http://azure-cli-...",
+  "password": "<CLIENT_SECRET>",
+  "tenant": "<TENANT_ID>"
+}
+```
+
+Export the values for `<CLIENT_ID>` and `<CLIENT_SECRET>` as environment
+variables as well:
+
+```shellsession
+$ export ARM_CLIENT_ID=<CLIENT_ID>
+$ export ARM_CLIENT_SECRET=<CLIENT_SECRET>
+```
+
+# Running Terraform
+Navigate to the Terraform control folder and execute the Terraform
+configuration to deploy the demo infrastructure:
+
+```shellsession
+$ cd ./terraform/control
+$ terraform init
+$ terraform plan
+$ terraform apply --auto-approve
+```
+
+Once the Terraform apply finishes, a number of useful pieces of information
+should be output to your console. These include URLs to deployed resources as
+well as a semi-populated Nomad Autoscaler config.
+
+```
+ip_addresses =
+Server IPs:
+ * instance server-1 - Public: 52.188.111.20, Private: 10.0.2.4
+
+
+To connect, add your private key and SSH into any client or server with
+`ssh -i azure-hashistack.pem -o IdentitiesOnly=yes ubuntu@PUBLIC_IP`.
+You can test the integrity of the cluster by running:
+
+  $ consul members
+  $ nomad server members
+  $ nomad node status
+
+The Nomad UI can be accessed at http://52.249.185.10:4646/ui
+The Consul UI can be accessed at http://52.249.185.10:8500/ui
+Grafana dashbaord can be accessed at http://52.249.187.190:3000/d/AQphTqmMk/demo?orgId=1&refresh=5s
+Traefik can be accessed at http://52.249.187.190:8081
+Prometheus can be accessed at http://52.249.187.190:9090
+Webapp can be accessed at http://52.249.187.190:80
+
+CLI environment variables:
+export NOMAD_CLIENT_DNS=http://52.249.187.190
+export NOMAD_ADDR=http://52.249.185.10:4646
+```
+
+You can visit the URLs and explore what has been created. This will include
+registration of a number of Nomad jobs which provide metrics and dashboarding
+as well as a demo application and routing provided by Traefik. It may take a
+few seconds for all the applications to start, so if any of the URLs doesn't
+load the first time, wait a little bit and give it a try again.
+
+Please also copy the export commands and run these in the terminal where the
+rest of the demo will be run.
+
+The application is pre-configured with a scaling policy, you can view this by
+opening the job file or calling the Nomad API. The application scales based on
+the average number of active connections, and we are targeting an average of 10
+per instance of our app.
+```
+curl $NOMAD_ADDR/v1/scaling/policies
+```
+
+## Run the Autoscaler
+The Autoscaler is not triggered automatically. This provides the opportunity to
+look through the jobfile to understand it better before deploying. The most
+important parts of the `azure_autoscaler.nomad` file are the template sections.
+The first defines our agent config where we configure the `prometheus`,
+`azure-vmss` and `target-value` plugins. The second is where we define our
+cluster scaling policy and write this to a local directory for reading. Once
+you have an understanding of the job file, submit it to the Nomad cluster
+ensuring the `NOMAD_ADDR` env var has been exported.
+
+```shellsession
+$ nomad run azure_autoscaler.nomad
+```
+
+If you wish, in another terminal window you can export the `NOMAD_ADDR` env var
+and then follow the Nomad Autoscaler logs.
+
+```
+$ nomad logs -stderr -f <alloc-id>
+```
+
+You can now return to the [demo instrunctions](../README.md#the-demo).

--- a/demo/remote/azure/packer/azure-packer.pkr.hcl
+++ b/demo/remote/azure/packer/azure-packer.pkr.hcl
@@ -1,0 +1,45 @@
+variable "client_id" {}
+variable "client_secret" {}
+variable "resource_group" {}
+variable "subscription_id" {}
+variable "location" { default = "East US" }
+variable "image_name" { default = "hashistack" }
+
+source "azure-arm" "hashistack" {
+  azure_tags = {
+    Product = "Hashistack"
+  }
+  client_id                         = "${var.client_id}"
+  client_secret                     = "${var.client_secret}"
+  image_offer                       = "UbuntuServer"
+  image_publisher                   = "Canonical"
+  image_sku                         = "18.04-LTS"
+  location                          = "${var.location}"
+  managed_image_name                = "${var.image_name}"
+  managed_image_resource_group_name = "${var.resource_group}"
+  os_type                           = "Linux"
+  ssh_username                      = "packer"
+  subscription_id                   = "${var.subscription_id}"
+}
+
+build {
+  sources = [
+    "source.azure-arm.hashistack"
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "sudo mkdir -p /ops",
+      "sudo chmod 777 /ops"
+    ]
+  }
+
+  provisioner "file" {
+    source      = "../../shared/packer/"
+    destination = "/ops"
+  }
+
+  provisioner "shell" {
+    script = "../../shared/packer/scripts/setup.sh"
+  }
+}

--- a/demo/remote/azure/terraform/.gitignore
+++ b/demo/remote/azure/terraform/.gitignore
@@ -1,0 +1,2 @@
+azure-hashistack.pem
+azure_autoscaler.nomad

--- a/demo/remote/azure/terraform/control/main.tf
+++ b/demo/remote/azure/terraform/control/main.tf
@@ -1,0 +1,17 @@
+module "my_ip_address" {
+  source = "matti/resource/shell"
+
+  command = "curl https://ipinfo.io/ip"
+}
+
+module "hashistack_cluster" {
+  source = "../modules/azure-hashistack"
+
+  allowlist_ip = ["${module.my_ip_address.stdout}/32"]
+}
+
+module "hashistack_jobs" {
+  source = "../../../terraform/modules/shared-nomad-jobs"
+
+  nomad_addr = module.hashistack_cluster.nomad_addr
+}

--- a/demo/remote/azure/terraform/control/outputs.tf
+++ b/demo/remote/azure/terraform/control/outputs.tf
@@ -1,0 +1,28 @@
+output "ip_addresses" {
+  value = <<CONFIGURATION
+
+Server IPs:
+${module.hashistack_cluster.server_addresses}
+
+
+To connect, add your private key and SSH into any client or server with
+`ssh -i azure-hashistack.pem -o IdentitiesOnly=yes ubuntu@PUBLIC_IP`.
+You can test the integrity of the cluster by running:
+
+  $ consul members
+  $ nomad server members
+  $ nomad node status
+
+The Nomad UI can be accessed at ${module.hashistack_cluster.nomad_addr}/ui
+The Consul UI can be accessed at ${module.hashistack_cluster.consul_addr}/ui
+Grafana dashbaord can be accessed at http://${module.hashistack_cluster.clients_lb_public_ip}:3000/d/AQphTqmMk/demo?orgId=1&refresh=5s
+Traefik can be accessed at http://${module.hashistack_cluster.clients_lb_public_ip}:8081
+Prometheus can be accessed at http://${module.hashistack_cluster.clients_lb_public_ip}:9090
+Webapp can be accessed at http://${module.hashistack_cluster.clients_lb_public_ip}:80
+
+CLI environment variables:
+export NOMAD_CLIENT_DNS=http://${module.hashistack_cluster.clients_lb_public_ip}
+export NOMAD_ADDR=${module.hashistack_cluster.nomad_addr}
+
+CONFIGURATION
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/clients.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/clients.tf
@@ -1,0 +1,54 @@
+resource "azurerm_linux_virtual_machine_scale_set" "clients" {
+  name                = "clients"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+  sku                 = var.client_vm_size
+  source_image_id     = data.azurerm_image.hashistack.id
+  custom_data         = base64encode(data.template_file.user_data_client.rendered)
+  instances           = var.client_count
+  admin_username      = "ubuntu"
+
+  network_interface {
+    name                      = "client-vmss-ni"
+    primary                   = true
+    network_security_group_id = azurerm_network_security_group.nomad_clients.id
+
+    ip_configuration {
+      name                                   = "PrivateIPConfiguration"
+      primary                                = true
+      subnet_id                              = azurerm_subnet.primary.id
+      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.clients_lb.id]
+      public_ip_address {
+        name = "client-vmss-public-ip"
+      }
+    }
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  admin_ssh_key {
+    username   = "ubuntu"
+    public_key = tls_private_key.main.public_key_openssh
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.clients_vmss.id]
+  }
+}
+
+# Managed identity
+resource "azurerm_user_assigned_identity" "clients_vmss" {
+  name                = "clients-vmss"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  location            = azurerm_resource_group.hashistack.location
+}
+
+resource "azurerm_role_assignment" "clients_vmss" {
+  scope                = data.azurerm_subscription.main.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.clients_vmss.principal_id
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/clients_lb.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/clients_lb.tf
@@ -1,0 +1,143 @@
+resource "azurerm_public_ip" "clients_lb" {
+  name                = "clients-lb-ip"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+  allocation_method   = "Static"
+}
+
+resource "azurerm_lb" "clients" {
+  name                = "clients-lb"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+
+  frontend_ip_configuration {
+    name                 = "PublicIPAddress"
+    public_ip_address_id = azurerm_public_ip.clients_lb.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "clients_lb" {
+  name                = "clients-lb-backend"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.clients.id
+}
+
+# Nomad rule
+resource "azurerm_lb_probe" "clients_nomad" {
+  name                = "clients-nomad-lb-probe"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.clients.id
+  port                = 4646
+}
+
+resource "azurerm_lb_rule" "clients_nomad" {
+  name                           = "clients-nomad-lb-rule"
+  resource_group_name            = azurerm_resource_group.hashistack.name
+  loadbalancer_id                = azurerm_lb.clients.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.clients_lb.id
+  probe_id                       = azurerm_lb_probe.clients_nomad.id
+  protocol                       = "Tcp"
+  frontend_port                  = 4646
+  backend_port                   = 4646
+  frontend_ip_configuration_name = "PublicIPAddress"
+}
+
+# Consul rule
+resource "azurerm_lb_probe" "clients_consul" {
+  name                = "clients-consul-lb-probe"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.clients.id
+  port                = 8500
+}
+
+resource "azurerm_lb_rule" "clients_consul" {
+  name                           = "clients-consul-lb-rule"
+  resource_group_name            = azurerm_resource_group.hashistack.name
+  loadbalancer_id                = azurerm_lb.clients.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.clients_lb.id
+  probe_id                       = azurerm_lb_probe.clients_consul.id
+  protocol                       = "Tcp"
+  frontend_port                  = 8500
+  backend_port                   = 8500
+  frontend_ip_configuration_name = "PublicIPAddress"
+}
+
+# Grafana rule
+resource "azurerm_lb_probe" "clients_grafana" {
+  name                = "clients-grafana-lb-probe"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.clients.id
+  port                = 3000
+}
+
+resource "azurerm_lb_rule" "clients_grafana" {
+  name                           = "clients-grafana-lb-rule"
+  resource_group_name            = azurerm_resource_group.hashistack.name
+  loadbalancer_id                = azurerm_lb.clients.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.clients_lb.id
+  probe_id                       = azurerm_lb_probe.clients_grafana.id
+  protocol                       = "Tcp"
+  frontend_port                  = 3000
+  backend_port                   = 3000
+  frontend_ip_configuration_name = "PublicIPAddress"
+}
+
+# Prometheus rule
+resource "azurerm_lb_probe" "clients_prometheus" {
+  name                = "clients-prometheus-lb-probe"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.clients.id
+  port                = 9090
+}
+
+resource "azurerm_lb_rule" "clients_prometheus" {
+  name                           = "clients-prometheus-lb-rule"
+  resource_group_name            = azurerm_resource_group.hashistack.name
+  loadbalancer_id                = azurerm_lb.clients.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.clients_lb.id
+  probe_id                       = azurerm_lb_probe.clients_prometheus.id
+  protocol                       = "Tcp"
+  frontend_port                  = 9090
+  backend_port                   = 9090
+  frontend_ip_configuration_name = "PublicIPAddress"
+}
+
+# Traefik rule
+resource "azurerm_lb_probe" "clients_traefik" {
+  name                = "clients-traefik-lb-probe"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.clients.id
+  port                = 8081
+}
+
+resource "azurerm_lb_rule" "clients_traefik" {
+  name                           = "clients-traefik-lb-rule"
+  resource_group_name            = azurerm_resource_group.hashistack.name
+  loadbalancer_id                = azurerm_lb.clients.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.clients_lb.id
+  probe_id                       = azurerm_lb_probe.clients_traefik.id
+  protocol                       = "Tcp"
+  frontend_port                  = 8081
+  backend_port                   = 8081
+  frontend_ip_configuration_name = "PublicIPAddress"
+}
+
+# HTTP rule
+resource "azurerm_lb_probe" "clients_http" {
+  name                = "clients-http-lb-probe"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.clients.id
+  port                = 80
+}
+
+resource "azurerm_lb_rule" "clients_http" {
+  name                           = "clients-http-lb-rule"
+  resource_group_name            = azurerm_resource_group.hashistack.name
+  loadbalancer_id                = azurerm_lb.clients.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.clients_lb.id
+  probe_id                       = azurerm_lb_probe.clients_http.id
+  protocol                       = "Tcp"
+  frontend_port                  = 80
+  backend_port                   = 80
+  frontend_ip_configuration_name = "PublicIPAddress"
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/image.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/image.tf
@@ -1,0 +1,24 @@
+resource "null_resource" "packer_build" {
+  depends_on = [azurerm_resource_group.hashistack]
+
+  provisioner "local-exec" {
+    command = <<EOF
+cd ../../packer && \
+  packer build -force \
+    -var "client_id=$ARM_CLIENT_ID" \
+    -var "client_secret=$ARM_CLIENT_SECRET" \
+    -var "resource_group=${azurerm_resource_group.hashistack.name}" \
+    -var "subscription_id=$ARM_SUBSCRIPTION_ID" \
+    -var "location=${azurerm_resource_group.hashistack.location}" \
+    -var "image_name=hashistack" \
+    azure-packer.pkr.hcl
+EOF
+  }
+}
+
+data "azurerm_image" "hashistack" {
+  depends_on = [null_resource.packer_build]
+
+  name                = "hashistack"
+  resource_group_name = azurerm_resource_group.hashistack.name
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/network.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/network.tf
@@ -1,0 +1,13 @@
+resource "azurerm_virtual_network" "primary" {
+  name                = "virtual-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+}
+
+resource "azurerm_subnet" "primary" {
+  name                 = "subnet"
+  resource_group_name  = azurerm_resource_group.hashistack.name
+  virtual_network_name = azurerm_virtual_network.primary.name
+  address_prefixes     = ["10.0.2.0/24"]
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/outputs.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/outputs.tf
@@ -1,0 +1,58 @@
+output "server_public_ips" {
+  value = azurerm_linux_virtual_machine.servers.*.public_ip_address
+}
+
+output "server_private_ips" {
+  value = azurerm_linux_virtual_machine.servers.*.private_ip_address
+}
+
+output "server_addresses" {
+  value = join("\n", formatlist(
+    " * instance %v - Public: %v, Private: %v",
+    azurerm_linux_virtual_machine.servers.*.name,
+    azurerm_linux_virtual_machine.servers.*.public_ip_address,
+    azurerm_linux_virtual_machine.servers.*.private_ip_address
+  ))
+}
+
+output "server_lb_id" {
+  value = azurerm_lb.servers.id
+}
+
+output "server_lb_public_ip" {
+  value = azurerm_public_ip.servers_lb.ip_address
+}
+
+output "clients_lb_id" {
+  value = azurerm_lb.clients.id
+}
+
+output "clients_lb_public_ip" {
+  value = azurerm_public_ip.clients_lb.ip_address
+}
+
+output "nomad_addr" {
+  value = "http://${azurerm_public_ip.servers_lb.ip_address}:4646"
+
+  depends_on = [
+    azurerm_linux_virtual_machine.servers,
+    azurerm_linux_virtual_machine_scale_set.clients,
+  ]
+}
+
+output "consul_addr" {
+  value = "http://${azurerm_public_ip.servers_lb.ip_address}:8500"
+
+  depends_on = [
+    azurerm_linux_virtual_machine.servers,
+    azurerm_linux_virtual_machine_scale_set.clients,
+  ]
+}
+
+output "client_vmss_id" {
+  value = azurerm_linux_virtual_machine_scale_set.clients.id
+}
+
+output "client_vmss_name" {
+  value = azurerm_linux_virtual_machine_scale_set.clients.name
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/provider.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "azurerm" {
+  version = "=2.32.0"
+  features {}
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/rg.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/rg.tf
@@ -1,0 +1,6 @@
+resource "random_pet" "server" {}
+
+resource "azurerm_resource_group" "hashistack" {
+  name     = "hashistack-${random_pet.server.id}"
+  location = var.location
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/servers.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/servers.tf
@@ -1,0 +1,84 @@
+resource "azurerm_linux_virtual_machine" "servers" {
+  count               = var.server_count
+  name                = "server-${count.index + 1}"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+  size                = var.server_vm_size
+  source_image_id     = data.azurerm_image.hashistack.id
+  custom_data         = base64encode(data.template_file.user_data_server.rendered)
+  admin_username      = "ubuntu"
+
+  network_interface_ids = [
+    azurerm_network_interface.server_ni[count.index].id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  admin_ssh_key {
+    username   = "ubuntu"
+    public_key = tls_private_key.main.public_key_openssh
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.consul_auto_join.id]
+  }
+}
+
+# Networking
+resource "azurerm_public_ip" "server_public_ip" {
+  count               = var.server_count
+  name                = "server-${count.index + 1}-ip"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+  allocation_method   = "Static"
+}
+
+resource "azurerm_network_interface" "server_ni" {
+  count               = var.server_count
+  name                = "server-${count.index + 1}-ni"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+
+  ip_configuration {
+    name                          = "server-ipc"
+    subnet_id                     = azurerm_subnet.primary.id
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = azurerm_public_ip.server_public_ip[count.index].id
+  }
+
+  tags = {
+    ConsulAutoJoin = "auto-join"
+  }
+}
+
+# Load balancer
+resource "azurerm_network_interface_backend_address_pool_association" "server_ni_bap" {
+  count                   = var.server_count
+  ip_configuration_name   = "server-ipc"
+  network_interface_id    = azurerm_network_interface.server_ni[count.index].id
+  backend_address_pool_id = azurerm_lb_backend_address_pool.servers_lb.id
+}
+
+# Security group
+resource "azurerm_network_interface_security_group_association" "server_ni_sg" {
+  count                     = var.server_count
+  network_interface_id      = azurerm_network_interface.server_ni[count.index].id
+  network_security_group_id = azurerm_network_security_group.nomad_servers.id
+}
+
+# Consul Auto Join credentials
+resource "azurerm_user_assigned_identity" "consul_auto_join" {
+  name                = "consul-auto-join"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  location            = azurerm_resource_group.hashistack.location
+}
+
+resource "azurerm_role_assignment" "consul_auto_join" {
+  scope                = data.azurerm_subscription.main.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.consul_auto_join.principal_id
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/servers_lb.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/servers_lb.tf
@@ -1,0 +1,61 @@
+resource "azurerm_public_ip" "servers_lb" {
+  name                = "server-lb-ip"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+  allocation_method   = "Static"
+}
+
+resource "azurerm_lb" "servers" {
+  name                = "servers-lb"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+
+  frontend_ip_configuration {
+    name                 = "PublicIPAddress"
+    public_ip_address_id = azurerm_public_ip.servers_lb.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "servers_lb" {
+  name                = "servers-lb-backend"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.servers.id
+}
+
+resource "azurerm_lb_probe" "servers_nomad" {
+  name                = "servers-nomad-lb-probe"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.servers.id
+  port                = 4646
+}
+
+resource "azurerm_lb_rule" "servers_nomad" {
+  name                           = "servers-nomad-lb-rule"
+  resource_group_name            = azurerm_resource_group.hashistack.name
+  loadbalancer_id                = azurerm_lb.servers.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.servers_lb.id
+  probe_id                       = azurerm_lb_probe.servers_nomad.id
+  protocol                       = "Tcp"
+  frontend_port                  = 4646
+  backend_port                   = 4646
+  frontend_ip_configuration_name = "PublicIPAddress"
+}
+
+resource "azurerm_lb_probe" "servers_consul" {
+  name                = "servers-consul-lb-probe"
+  resource_group_name = azurerm_resource_group.hashistack.name
+  loadbalancer_id     = azurerm_lb.servers.id
+  port                = 8500
+}
+
+resource "azurerm_lb_rule" "servers_consul" {
+  name                           = "servers-consul-lb-rule"
+  resource_group_name            = azurerm_resource_group.hashistack.name
+  loadbalancer_id                = azurerm_lb.servers.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.servers_lb.id
+  probe_id                       = azurerm_lb_probe.servers_consul.id
+  protocol                       = "Tcp"
+  frontend_port                  = 8500
+  backend_port                   = 8500
+  frontend_ip_configuration_name = "PublicIPAddress"
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/sg.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/sg.tf
@@ -1,0 +1,176 @@
+resource "azurerm_network_security_group" "nomad_servers" {
+  name                = "nomad-servers-sg"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+
+  # SSH
+  security_rule {
+    name = "primary-sgr-22"
+
+    priority  = 100
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 22
+    destination_address_prefix = "*"
+  }
+
+  # Nomad
+  security_rule {
+    name = "primary-sgr-4646"
+
+    priority  = 101
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 4646
+    destination_address_prefix = "*"
+  }
+
+  # Consul
+  security_rule {
+    name = "primary-sgr-8500"
+
+    priority  = 102
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 8500
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_network_security_group" "nomad_clients" {
+  name                = "nomad-clients-sg"
+  location            = azurerm_resource_group.hashistack.location
+  resource_group_name = azurerm_resource_group.hashistack.name
+
+  # SSH
+  security_rule {
+    name = "primary-sgr-22"
+
+    priority  = 100
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 22
+    destination_address_prefix = "*"
+  }
+
+  # Nomad
+  security_rule {
+    name = "primary-sgr-4646"
+
+    priority  = 101
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 4646
+    destination_address_prefix = "*"
+  }
+
+  # Consul
+  security_rule {
+    name = "primary-sgr-8500"
+
+    priority  = 102
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 8500
+    destination_address_prefix = "*"
+  }
+
+  # HTTP
+  security_rule {
+    name = "primary-sgr-80"
+
+    priority  = 103
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 80
+    destination_address_prefix = "*"
+  }
+
+  # Grafana metrics dashboard.
+  security_rule {
+    name = "primary-sgr-3000"
+
+    priority  = 104
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 3000
+    destination_address_prefix = "*"
+  }
+
+  # Prometheus dashboard.
+  security_rule {
+    name = "primary-sgr-9090"
+
+    priority  = 105
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 9090
+    destination_address_prefix = "*"
+  }
+
+  # Traefik router.
+  security_rule {
+    name = "primary-sgr-8081"
+
+    priority  = 106
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = 8081
+    destination_address_prefix = "*"
+  }
+
+  # Nomad dynamic port allocation range.
+  security_rule {
+    name = "primary-sgr-nomad-alloc-range"
+
+    priority  = 107
+    direction = "Inbound"
+    access    = "Allow"
+    protocol  = "Tcp"
+
+    source_address_prefixes    = var.allowlist_ip
+    source_port_range          = "*"
+    destination_port_range     = "20000-32000"
+    destination_address_prefix = "*"
+  }
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/ssh.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/ssh.tf
@@ -1,0 +1,13 @@
+resource "tls_private_key" "main" {
+  algorithm = "RSA"
+}
+
+resource "null_resource" "main" {
+  provisioner "local-exec" {
+    command = "echo \"${tls_private_key.main.private_key_pem}\" > azure-hashistack.pem"
+  }
+
+  provisioner "local-exec" {
+    command = "chmod 600 azure-hashistack.pem"
+  }
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/templates.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/templates.tf
@@ -1,0 +1,38 @@
+data "azurerm_subscription" "main" {}
+
+data "template_file" "user_data_server" {
+  template = file("${path.module}/templates/user-data-server.sh")
+
+  vars = {
+    server_count  = var.server_count
+    retry_join    = "provider=azure tag_name=ConsulAutoJoin tag_value=auto-join subscription_id=${data.azurerm_subscription.main.subscription_id}"
+    consul_binary = var.consul_binary
+    nomad_binary  = var.nomad_binary
+  }
+}
+
+data "template_file" "user_data_client" {
+  template = file("${path.module}/templates/user-data-client.sh")
+
+  vars = {
+    retry_join    = "provider=azure tag_name=ConsulAutoJoin tag_value=auto-join subscription_id=${data.azurerm_subscription.main.subscription_id}"
+    consul_binary = var.consul_binary
+    nomad_binary  = var.nomad_binary
+    node_class    = "hashistack"
+  }
+}
+
+data "template_file" "nomad_autoscaler_jobspec" {
+  template = file("${path.module}/templates/azure_autoscaler.nomad")
+
+  vars = {
+    subscription_id = data.azurerm_subscription.main.subscription_id
+    resource_group  = azurerm_resource_group.hashistack.name
+  }
+}
+
+resource "null_resource" "nomad_autoscaler_jobspec" {
+  provisioner "local-exec" {
+    command = "echo '${data.template_file.nomad_autoscaler_jobspec.rendered}' > azure_autoscaler.nomad"
+  }
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/templates/azure_autoscaler.nomad
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/templates/azure_autoscaler.nomad
@@ -1,0 +1,119 @@
+job "autoscaler" {
+  datacenters = ["dc1"]
+
+  group "autoscaler" {
+    count = 1
+
+    task "autoscaler" {
+      driver = "docker"
+
+      config {
+        image   = "hashicorp/nomad-autoscaler:0.2.0"
+        command = "nomad-autoscaler"
+
+        args = [
+          "agent",
+          "-config",
+          "$${NOMAD_TASK_DIR}/config.hcl",
+          "-http-bind-address",
+          "0.0.0.0",
+          "-log-level",
+          "debug",
+          "-policy-dir",
+          "$${NOMAD_TASK_DIR}/policies/",
+        ]
+      }
+
+      template {
+        data = <<EOF
+nomad {
+  address = "http://{{env "attr.unique.network.ip-address" }}:4646"
+}
+
+apm "prometheus" {
+  driver = "prometheus"
+  config = {
+    address = "http://{{ range service "prometheus" }}{{ .Address }}:{{ .Port }}{{ end }}"
+  }
+}
+
+target "azure-vmss" {
+  driver = "azure-vmss"
+  config = {
+    subscription_id = "${subscription_id}"
+  }
+}
+
+strategy "target-value" {
+  driver = "target-value"
+}
+EOF
+
+        destination = "$${NOMAD_TASK_DIR}/config.hcl"
+      }
+
+      template {
+        data = <<EOF
+enabled = true
+min     = 1
+max     = 2
+
+policy {
+
+  cooldown            = "2m"
+  evaluation_interval = "1m"
+
+  check "cpu_allocated_percentage" {
+    source = "prometheus"
+    query  = "sum(nomad_client_allocated_cpu{node_class=\"hashistack\"}*100/(nomad_client_unallocated_cpu{node_class=\"hashistack\"}+nomad_client_allocated_cpu{node_class=\"hashistack\"}))/count(nomad_client_allocated_cpu{node_class=\"hashistack\"})"
+
+    strategy "target-value" {
+      target = 70
+    }
+  }
+
+  check "mem_allocated_percentage" {
+    source = "prometheus"
+    query  = "sum(nomad_client_allocated_memory{node_class=\"hashistack\"}*100/(nomad_client_unallocated_memory{node_class=\"hashistack\"}+nomad_client_allocated_memory{node_class=\"hashistack\"}))/count(nomad_client_allocated_memory{node_class=\"hashistack\"})"
+
+    strategy "target-value" {
+      target = 70
+    }
+  }
+
+  target "azure-vmss" {
+    resource_group      = "${resource_group}"
+    vm_scale_set        = "clients"
+    node_class          = "hashistack"
+    node_drain_deadline = "5m"
+  }
+}
+EOF
+
+        destination = "$${NOMAD_TASK_DIR}/policies/hashistack.hcl"
+      }
+
+      resources {
+        cpu    = 50
+        memory = 128
+
+        network {
+          mbits = 10
+          port "http" {}
+        }
+      }
+
+      service {
+        name = "autoscaler"
+        port = "http"
+
+        check {
+          type     = "http"
+          path     = "/v1/health"
+          interval = "5s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/demo/remote/azure/terraform/modules/azure-hashistack/templates/user-data-client.sh
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/templates/user-data-client.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+exec > >(sudo tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+sudo chmod +x /ops/scripts/client.sh
+sudo bash -c "NOMAD_BINARY=${nomad_binary} CONSUL_BINARY=${consul_binary}  /ops/scripts/client.sh \"azure\" \"${retry_join}\" \"${node_class}\""
+rm -rf /ops/

--- a/demo/remote/azure/terraform/modules/azure-hashistack/templates/user-data-server.sh
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/templates/user-data-server.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+exec > >(sudo tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+sudo chmod +x /ops/scripts/server.sh
+sudo bash -c "NOMAD_BINARY=${nomad_binary} CONSUL_BINARY=${consul_binary}  /ops/scripts/server.sh \"azure\" \"${server_count}\" \"${retry_join}\""
+rm -rf /ops/

--- a/demo/remote/azure/terraform/modules/azure-hashistack/variables.tf
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/variables.tf
@@ -1,0 +1,47 @@
+variable "location" {
+  description = "The Azure location to deploy to."
+  type        = string
+  default     = "East US"
+}
+
+variable "server_vm_size" {
+  description = "The Azure VM size to use for servers."
+  type        = string
+  default     = "Standard_DS1_v2"
+}
+
+variable "server_count" {
+  description = "The number of servers to provision."
+  type        = number
+  default     = 1
+}
+
+variable "client_vm_size" {
+  description = "The Azure VM size to use for clients."
+  type        = string
+  default     = "Standard_DS1_v2"
+}
+
+variable "client_count" {
+  description = "The number of clients to provision."
+  type        = number
+  default     = 1
+}
+
+variable "nomad_binary" {
+  description = "The URL to download a custom Nomad binary if desired."
+  type        = string
+  default     = "none"
+}
+
+variable "consul_binary" {
+  description = "The URL to download a custom Consul binary if desired."
+  type        = string
+  default     = "none"
+}
+
+variable "allowlist_ip" {
+  description = "A list of IP address to grant access via the LBs."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/demo/remote/shared/packer/config/10-consul.dnsmasq
+++ b/demo/remote/shared/packer/config/10-consul.dnsmasq
@@ -1,0 +1,2 @@
+# Enable forward lookup of the 'consul' domain:
+server=/consul/127.0.0.1#8600

--- a/demo/remote/shared/packer/config/99-default.dnsmasq.aws
+++ b/demo/remote/shared/packer/config/99-default.dnsmasq.aws
@@ -1,0 +1,2 @@
+# 99-default.dnsmasq
+server=169.254.169.253

--- a/demo/remote/shared/packer/config/99-default.dnsmasq.azure
+++ b/demo/remote/shared/packer/config/99-default.dnsmasq.azure
@@ -1,0 +1,2 @@
+# 99-default.dnsmasq
+server=168.63.129.16

--- a/demo/remote/shared/packer/config/consul.hcl
+++ b/demo/remote/shared/packer/config/consul.hcl
@@ -1,0 +1,21 @@
+advertise_addr = "IP_ADDRESS"
+
+bind_addr = "0.0.0.0"
+
+bootstrap_expect = SERVER_COUNT
+
+client_addr = "0.0.0.0"
+
+data_dir = "/opt/consul/data"
+
+log_level = "INFO"
+
+retry_join = ["RETRY_JOIN"]
+
+server = true
+
+ui = true
+
+service {
+  name = "consul"
+}

--- a/demo/remote/shared/packer/config/consul_aws.service
+++ b/demo/remote/shared/packer/config/consul_aws.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Consul Agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d"
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/demo/remote/shared/packer/config/consul_azure.service
+++ b/demo/remote/shared/packer/config/consul_azure.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Consul Agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d"
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/demo/remote/shared/packer/config/consul_client.hcl
+++ b/demo/remote/shared/packer/config/consul_client.hcl
@@ -1,0 +1,13 @@
+advertise_addr = "IP_ADDRESS"
+
+bind_addr = "0.0.0.0"
+
+client_addr = "0.0.0.0"
+
+data_dir = "/opt/consul/data"
+
+log_level = "INFO"
+
+retry_join = ["RETRY_JOIN"]
+
+ui = true

--- a/demo/remote/shared/packer/config/nomad.hcl
+++ b/demo/remote/shared/packer/config/nomad.hcl
@@ -1,0 +1,14 @@
+data_dir  = "/opt/nomad/data"
+bind_addr = "0.0.0.0"
+log_level = "DEBUG"
+
+telemetry {
+  publish_allocation_metrics = true
+  publish_node_metrics       = true
+  prometheus_metrics         = true
+}
+
+server {
+  enabled          = true
+  bootstrap_expect = SERVER_COUNT
+}

--- a/demo/remote/shared/packer/config/nomad.service
+++ b/demo/remote/shared/packer/config/nomad.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Nomad Agent
+Requires=network-online.target
+Wants=consul.service
+After=consul.service
+
+[Service]
+Restart=on-failure
+ExecStart=/usr/local/bin/nomad agent -config="/etc/nomad.d/nomad.hcl"
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/demo/remote/shared/packer/config/nomad_client.hcl
+++ b/demo/remote/shared/packer/config/nomad_client.hcl
@@ -1,0 +1,24 @@
+data_dir  = "/opt/nomad/data"
+bind_addr = "0.0.0.0"
+log_level = "DEBUG"
+
+telemetry {
+  publish_allocation_metrics = true
+  publish_node_metrics       = true
+  prometheus_metrics         = true
+}
+
+client {
+  enabled    = true
+  node_class = NODE_CLASS
+
+  options {
+    "driver.raw_exec.enable"    = "1"
+    "docker.privileged.enabled" = "true"
+  }
+}
+
+vault {
+  enabled = true
+  address = "http://active.vault.service.consul:8200"
+}

--- a/demo/remote/shared/packer/scripts/client.sh
+++ b/demo/remote/shared/packer/scripts/client.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+SHAREDDIR=/ops/
+CONFIGDIR=$SHAREDDIR/config
+SCRIPTDIR=$SHAREDDIR/scripts
+
+source $SCRIPTDIR/net.sh
+set -e
+
+CONSULCONFIGDIR=/etc/consul.d
+NOMADCONFIGDIR=/etc/nomad.d
+HOME_DIR=ubuntu
+
+# Wait for network
+sleep 15
+
+IP_ADDRESS=$(net_getDefaultRouteAddress)
+DOCKER_BRIDGE_IP_ADDRESS=$(net_getInterfaceAddress docker0)
+CLOUD=$1
+RETRY_JOIN=$2
+NODE_CLASS=$3
+
+# Consul
+sed -i "s/IP_ADDRESS/$IP_ADDRESS/g" $CONFIGDIR/consul_client.hcl
+sed -i "s/RETRY_JOIN/$RETRY_JOIN/g" $CONFIGDIR/consul_client.hcl
+sudo cp $CONFIGDIR/consul_client.hcl $CONSULCONFIGDIR/consul.hcl
+sudo cp $CONFIGDIR/consul_$CLOUD.service /etc/systemd/system/consul.service
+
+## Replace existing Consul binary if remote file exists
+if [[ `wget -S --spider $CONSUL_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
+  curl -L $CONSUL_BINARY > consul.zip
+  sudo unzip -o consul.zip -d /usr/local/bin
+  sudo chmod 0755 /usr/local/bin/consul
+  sudo chown root:root /usr/local/bin/consul
+fi
+
+sudo systemctl start consul.service
+sleep 10
+
+# Nomad
+
+## Replace existing Nomad binary if remote file exists
+if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
+  curl -L $NOMAD_BINARY > nomad.zip
+  sudo unzip -o nomad.zip -d /usr/local/bin
+  sudo chmod 0755 /usr/local/bin/nomad
+  sudo chown root:root /usr/local/bin/nomad
+fi
+
+sed -i "s/NODE_CLASS/\"$NODE_CLASS\"/g" $CONFIGDIR/nomad_client.hcl
+sudo cp $CONFIGDIR/nomad_client.hcl $NOMADCONFIGDIR/nomad.hcl
+sudo cp $CONFIGDIR/nomad.service /etc/systemd/system/nomad.service
+
+sudo systemctl start nomad.service
+sleep 10
+export NOMAD_ADDR=http://$IP_ADDRESS:4646
+
+# Add hostname to /etc/hosts
+echo "127.0.0.1 $(hostname)" | sudo tee --append /etc/hosts
+
+# dnsmasq config
+echo "DNSStubListener=no" | sudo tee -a /etc/systemd/resolved.conf
+sudo cp /ops/config/10-consul.dnsmasq /etc/dnsmasq.d/10-consul
+sudo cp /ops/config/99-default.dnsmasq.$CLOUD /etc/dnsmasq.d/99-default
+sudo mv /etc/resolv.conf /etc/resolv.conf.orig
+grep -v "nameserver" /etc/resolv.conf.orig | grep -v -e"^#" | grep -v -e '^$' | sudo tee /etc/resolv.conf
+echo "nameserver 127.0.0.1" | sudo tee -a /etc/resolv.conf
+sudo systemctl restart systemd-resolved
+sudo systemctl restart dnsmasq
+
+# Add Docker bridge network IP to /etc/resolv.conf (at the top)
+echo "nameserver $DOCKER_BRIDGE_IP_ADDRESS" | sudo tee /etc/resolv.conf.new
+cat /etc/resolv.conf | sudo tee --append /etc/resolv.conf.new
+sudo mv /etc/resolv.conf.new /etc/resolv.conf
+
+# Set env vars for tool CLIs
+echo "export VAULT_ADDR=http://$IP_ADDRESS:8200" | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre"  | sudo tee --append /home/$HOME_DIR/.bashrc

--- a/demo/remote/shared/packer/scripts/net.sh
+++ b/demo/remote/shared/packer/scripts/net.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+function net_getInterfaceAddress() {
+  ip -4 address show "${1}" | awk '/inet / { print $2 }' | cut -d/ -f1
+}
+
+function net_getDefaultRouteAddress() {
+  # Default route IP address (seems to be a good way to get host ip)
+  ip -4 route get 1.1.1.1 | grep -oP 'src \K\S+'
+}

--- a/demo/remote/shared/packer/scripts/server.sh
+++ b/demo/remote/shared/packer/scripts/server.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+SHAREDDIR=/ops/
+CONFIGDIR=$SHAREDDIR/config
+SCRIPTDIR=$SHAREDDIR/scripts
+
+source $SCRIPTDIR/net.sh
+set -e
+
+CONSULCONFIGDIR=/etc/consul.d
+NOMADCONFIGDIR=/etc/nomad.d
+HOME_DIR=ubuntu
+
+# Wait for network
+sleep 15
+
+IP_ADDRESS=$(net_getDefaultRouteAddress)
+DOCKER_BRIDGE_IP_ADDRESS=$(net_getInterfaceAddress docker0)
+CLOUD=$1
+SERVER_COUNT=$2
+RETRY_JOIN=$3
+
+# Consul
+## Replace existing Consul binary if remote file exists
+if [[ `wget -S --spider $CONSUL_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
+  curl -L $CONSUL_BINARY > consul.zip
+  sudo unzip -o consul.zip -d /usr/local/bin
+  sudo chmod 0755 /usr/local/bin/consul
+  sudo chown root:root /usr/local/bin/consul
+fi
+
+sed -i "s/IP_ADDRESS/$IP_ADDRESS/g" $CONFIGDIR/consul.hcl
+sed -i "s/SERVER_COUNT/$SERVER_COUNT/g" $CONFIGDIR/consul.hcl
+sed -i "s/RETRY_JOIN/$RETRY_JOIN/g" $CONFIGDIR/consul.hcl
+sudo cp $CONFIGDIR/consul.hcl $CONSULCONFIGDIR
+sudo cp $CONFIGDIR/consul_$CLOUD.service /etc/systemd/system/consul.service
+
+sudo systemctl start consul.service
+sleep 10
+export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500
+export CONSUL_RPC_ADDR=$IP_ADDRESS:8400
+
+# Nomad
+
+## Replace existing Nomad binary if remote file exists
+if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
+  curl -L $NOMAD_BINARY > nomad.zip
+  sudo unzip -o nomad.zip -d /usr/local/bin
+  sudo chmod 0755 /usr/local/bin/nomad
+  sudo chown root:root /usr/local/bin/nomad
+fi
+
+sed -i "s/SERVER_COUNT/$SERVER_COUNT/g" $CONFIGDIR/nomad.hcl
+sudo cp $CONFIGDIR/nomad.hcl $NOMADCONFIGDIR
+sudo cp $CONFIGDIR/nomad.service /etc/systemd/system/nomad.service
+
+sudo systemctl start nomad.service
+sleep 10
+export NOMAD_ADDR=http://$IP_ADDRESS:4646
+
+# Add hostname to /etc/hosts
+echo "127.0.0.1 $(hostname)" | sudo tee --append /etc/hosts
+
+# dnsmasq config
+echo "DNSStubListener=no" | sudo tee -a /etc/systemd/resolved.conf
+sudo cp /ops/config/10-consul.dnsmasq /etc/dnsmasq.d/10-consul
+sudo cp /ops/config/99-default.dnsmasq.$CLOUD /etc/dnsmasq.d/99-default
+sudo mv /etc/resolv.conf /etc/resolv.conf.orig
+grep -v "nameserver" /etc/resolv.conf.orig | grep -v -e"^#" | grep -v -e '^$' | sudo tee /etc/resolv.conf
+echo "nameserver 127.0.0.1" | sudo tee -a /etc/resolv.conf
+sudo systemctl restart systemd-resolved
+sudo systemctl restart dnsmasq
+
+# Add Docker bridge network IP to /etc/resolv.conf (at the top)
+echo "nameserver $DOCKER_BRIDGE_IP_ADDRESS" | sudo tee /etc/resolv.conf.new
+cat /etc/resolv.conf | sudo tee --append /etc/resolv.conf.new
+sudo mv /etc/resolv.conf.new /etc/resolv.conf
+
+
+# Set env vars for tool CLIs
+echo "export CONSUL_RPC_ADDR=$IP_ADDRESS:8400" | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500" | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre"  | sudo tee --append /home/$HOME_DIR/.bashrc
+

--- a/demo/remote/shared/packer/scripts/setup.sh
+++ b/demo/remote/shared/packer/scripts/setup.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -e
+
+echo "Waiting for cloud-init to update /etc/apt/sources.list"
+timeout 180 /bin/bash -c \
+  'until stat /var/lib/cloud/instance/boot-finished 2>/dev/null; do echo waiting ...; sleep 1; done'
+
+# Disable interactive apt prompts
+export DEBIAN_FRONTEND=noninteractive
+echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+
+cd /ops
+
+# Dependencies
+sudo apt-get update
+
+sudo apt-get install -y software-properties-common unzip tree redis-tools jq curl tmux dnsmasq
+
+CONFIGDIR=/ops/config
+
+CONSULVERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/consul | jq -r '.current_version')
+CONSULDOWNLOAD=https://releases.hashicorp.com/consul/${CONSULVERSION}/consul_${CONSULVERSION}_linux_amd64.zip
+CONSULCONFIGDIR=/etc/consul.d
+CONSULDIR=/opt/consul
+
+NOMADVERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/nomad | jq -r '.current_version')
+NOMADDOWNLOAD=https://releases.hashicorp.com/nomad/${NOMADVERSION}/nomad_${NOMADVERSION}_linux_amd64.zip
+NOMADCONFIGDIR=/etc/nomad.d
+NOMADDIR=/opt/nomad
+
+CNIVERSION=0.8.5
+CNIDOWNLOAD=https://github.com/containernetworking/plugins/releases/download/v${CNIVERSION}/cni-plugins-linux-amd64-v${CNIVERSION}.tgz
+CNIDIR=/opt/cni
+
+# Disable the firewall
+sudo ufw disable || echo "ufw not installed"
+
+# Consul
+curl -sL -o consul.zip ${CONSULDOWNLOAD}
+
+## Install
+sudo unzip consul.zip -d /usr/local/bin
+sudo chmod 0755 /usr/local/bin/consul
+sudo chown root:root /usr/local/bin/consul
+
+## Configure
+sudo mkdir -p ${CONSULCONFIGDIR}
+sudo chmod 755 ${CONSULCONFIGDIR}
+sudo mkdir -p ${CONSULDIR}
+sudo chmod 755 ${CONSULDIR}
+
+# Nomad
+curl -sL -o nomad.zip ${NOMADDOWNLOAD}
+
+## Install
+sudo unzip nomad.zip -d /usr/local/bin
+sudo chmod 0755 /usr/local/bin/nomad
+sudo chown root:root /usr/local/bin/nomad
+
+## Configure
+sudo mkdir -p ${NOMADCONFIGDIR}
+sudo chmod 755 ${NOMADCONFIGDIR}
+sudo mkdir -p ${NOMADDIR}
+sudo chmod 755 ${NOMADDIR}
+
+# Docker
+distro=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
+sudo apt-get install -y apt-transport-https ca-certificates gnupg2 
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/${distro} $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-get install -y docker-ce
+
+# Java
+sudo add-apt-repository -y ppa:openjdk-r/ppa
+sudo apt-get update 
+sudo apt-get install -y openjdk-8-jdk
+JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
+
+# CNI plugins
+curl -sL -o cni-plugins.tgz ${CNIDOWNLOAD}
+sudo mkdir -p ${CNIDIR}/bin
+sudo tar -C ${CNIDIR}/bin -xzf cni-plugins.tgz
+
+echo 'debconf debconf/frontend select Dialog' | sudo debconf-set-selections


### PR DESCRIPTION
This PR adds cluster scaling demo on Azure using the a VMSS instance. It follows a new folder structure to better organize files per cloud provider. A following PR will adapt the AWS demo to the same structured.

It's currently a WIP because it requires a new build of the Autoscaler that includes the [Azure VMSS plugin](https://github.com/hashicorp/nomad-autoscaler/pull/278) and a new version of Nomad that includes [Azure node fingerprinting](https://github.com/hashicorp/nomad/pull/8979).