### PR TITLE
demo/das: update limits and fix nginx config file reload

### DIFF
--- a/demo/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/demo/vagrant/dynamic-app-sizing/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
   # VM configuration.
   config.vm.provider "virtualbox" do |vb|
     vb.customize [ "modifyvm", :id, "--uartmode1", "file", File::NULL ]
-    vb.memory = "4096"
+    vb.memory = "2048"
     vb.cpus = 2
   end
 

--- a/demo/vagrant/dynamic-app-sizing/jobs/das-autoscaler.nomad
+++ b/demo/vagrant/dynamic-app-sizing/jobs/das-autoscaler.nomad
@@ -5,10 +5,11 @@ job "das-autoscaler" {
     count = 1
 
     task "autoscaler" {
-      driver = "exec"
+      driver = "docker"
 
       config {
-        command = "/bin/nomad-autoscaler"
+        image   = "hashicorp/nomad-autoscaler-enterprise:0.2.0-beta2"
+        command = "nomad-autoscaler"
         args    = ["agent", "-config", "local/autoscaler.hcl"]
       }
 
@@ -70,8 +71,8 @@ EOH
       }
 
       resources {
-        cpu    = 1024
-        memory = 1024
+        cpu    = 512
+        memory = 512
 
         network {
           mbits = 10

--- a/demo/vagrant/dynamic-app-sizing/jobs/das-load-test.nomad
+++ b/demo/vagrant/dynamic-app-sizing/jobs/das-load-test.nomad
@@ -40,6 +40,11 @@ REQUESTS={{ or (env "NOMAD_META_requests") "100000" }}
 CLIENTS={{  or (env "NOMAD_META_clients") "50" }}
 EOF
       }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
     }
   }
 }

--- a/demo/vagrant/dynamic-app-sizing/jobs/example.nomad
+++ b/demo/vagrant/dynamic-app-sizing/jobs/example.nomad
@@ -31,21 +31,30 @@ job "example" {
         ports = ["lb"]
         volumes = [
           "local/nginx.conf:/etc/nginx/nginx.conf",
+          "local/nginx:/etc/nginx/conf.d"
         ]
       }
 
       template {
-        data          = <<EOF
+        data        = <<EOF
 user  nginx;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
+
 events {
     worker_connections  1024;
 }
 
+include /etc/nginx/conf.d/*.conf;
+EOF
+        destination = "local/nginx.conf"
+      }
+
+      template {
+        data          = <<EOF
 stream {
   server {
     listen 6379;
@@ -60,14 +69,14 @@ stream {
   }
 }
 EOF
-        destination   = "local/nginx.conf"
+        destination   = "local/nginx/nginx.conf"
         change_mode   = "signal"
         change_signal = "SIGHUP"
       }
 
       resources {
-        cpu    = 500
-        memory = 128
+        cpu    = 50
+        memory = 10
       }
 
       scaling "cpu" {

--- a/demo/vagrant/dynamic-app-sizing/jobs/example.nomad
+++ b/demo/vagrant/dynamic-app-sizing/jobs/example.nomad
@@ -30,11 +30,15 @@ job "example" {
         image = "nginx"
         ports = ["lb"]
         volumes = [
+          # It's safe to mount this path as a file because it won't re-render.
           "local/nginx.conf:/etc/nginx/nginx.conf",
+          # This path hosts files that will re-render with Consul Template.
           "local/nginx:/etc/nginx/conf.d"
         ]
       }
 
+      # This template overwrites the embedded nginx.conf file so it loads
+      # conf.d/*.conf files outside of the `http` block.
       template {
         data        = <<EOF
 user  nginx;
@@ -53,6 +57,7 @@ EOF
         destination = "local/nginx.conf"
       }
 
+      # This template creates a TCP proxy to Redis.
       template {
         data          = <<EOF
 stream {


### PR DESCRIPTION
The nginx task was mounting the config file also as a file inside the Docker container. When Consul Template re-rendered the file, the inode reference would change, so nginx wouldn't see the updated version, even after a `SIGHUP`