### PR TITLE
Allow multiple policies per file

### DIFF
--- a/demo/remote/aws_autoscaler.nomad
+++ b/demo/remote/aws_autoscaler.nomad
@@ -58,38 +58,40 @@ EOF
 
       template {
         data = <<EOF
-enabled = true
-min     = 1
-max     = 2
+scaling "cluster_policy" {
+  enabled = true
+  min     = 1
+  max     = 2
 
-policy {
+  policy {
 
-  cooldown            = "2m"
-  evaluation_interval = "1m"
+    cooldown            = "2m"
+    evaluation_interval = "1m"
 
-  check "cpu_allocated_percentage" {
-    source = "prometheus"
-    query  = "scalar(sum(nomad_client_allocated_cpu{node_class=\"hashistack\"}*100/(nomad_client_unallocated_cpu{node_class=\"hashistack\"}+nomad_client_allocated_cpu{node_class=\"hashistack\"}))/count(nomad_client_allocated_cpu{node_class=\"hashistack\"}))"
+    check "cpu_allocated_percentage" {
+      source = "prometheus"
+      query  = "scalar(sum(nomad_client_allocated_cpu{node_class=\"hashistack\"}*100/(nomad_client_unallocated_cpu{node_class=\"hashistack\"}+nomad_client_allocated_cpu{node_class=\"hashistack\"}))/count(nomad_client_allocated_cpu{node_class=\"hashistack\"}))"
 
-    strategy "target-value" {
-      target = 70
+      strategy "target-value" {
+        target = 70
+      }
     }
-  }
 
-  check "mem_allocated_percentage" {
-    source = "prometheus"
-    query  = "scalar(sum(nomad_client_allocated_memory{node_class=\"hashistack\"}*100/(nomad_client_unallocated_memory{node_class=\"hashistack\"}+nomad_client_allocated_memory{node_class=\"hashistack\"}))/count(nomad_client_allocated_memory{node_class=\"hashistack\"}))"
+    check "mem_allocated_percentage" {
+      source = "prometheus"
+      query  = "scalar(sum(nomad_client_allocated_memory{node_class=\"hashistack\"}*100/(nomad_client_unallocated_memory{node_class=\"hashistack\"}+nomad_client_allocated_memory{node_class=\"hashistack\"}))/count(nomad_client_allocated_memory{node_class=\"hashistack\"}))"
 
-    strategy "target-value" {
-      target = 70
+      strategy "target-value" {
+        target = 70
+      }
     }
-  }
 
-  target "aws-asg" {
-    dry-run             = "false"
-    aws_asg_name        = "hashistack-nomad_client"
-    node_class          = "hashistack"
-    node_drain_deadline = "5m"
+    target "aws-asg" {
+      dry-run             = "false"
+      aws_asg_name        = "hashistack-nomad_client"
+      node_class          = "hashistack"
+      node_drain_deadline = "5m"
+    }
   }
 }
 EOF

--- a/demo/remote/azure/terraform/modules/azure-hashistack/templates/azure_autoscaler.nomad
+++ b/demo/remote/azure/terraform/modules/azure-hashistack/templates/azure_autoscaler.nomad
@@ -54,38 +54,40 @@ EOF
 
       template {
         data = <<EOF
-enabled = true
-min     = 1
-max     = 2
+scaling "cluster_policy" {
+  enabled = true
+  min     = 1
+  max     = 2
 
-policy {
+  policy {
 
-  cooldown            = "2m"
-  evaluation_interval = "1m"
+    cooldown            = "2m"
+    evaluation_interval = "1m"
 
-  check "cpu_allocated_percentage" {
-    source = "prometheus"
-    query  = "sum(nomad_client_allocated_cpu{node_class=\"hashistack\"}*100/(nomad_client_unallocated_cpu{node_class=\"hashistack\"}+nomad_client_allocated_cpu{node_class=\"hashistack\"}))/count(nomad_client_allocated_cpu{node_class=\"hashistack\"})"
+    check "cpu_allocated_percentage" {
+      source = "prometheus"
+      query  = "sum(nomad_client_allocated_cpu{node_class=\"hashistack\"}*100/(nomad_client_unallocated_cpu{node_class=\"hashistack\"}+nomad_client_allocated_cpu{node_class=\"hashistack\"}))/count(nomad_client_allocated_cpu{node_class=\"hashistack\"})"
 
-    strategy "target-value" {
-      target = 70
+      strategy "target-value" {
+        target = 70
+      }
     }
-  }
 
-  check "mem_allocated_percentage" {
-    source = "prometheus"
-    query  = "sum(nomad_client_allocated_memory{node_class=\"hashistack\"}*100/(nomad_client_unallocated_memory{node_class=\"hashistack\"}+nomad_client_allocated_memory{node_class=\"hashistack\"}))/count(nomad_client_allocated_memory{node_class=\"hashistack\"})"
+    check "mem_allocated_percentage" {
+      source = "prometheus"
+      query  = "sum(nomad_client_allocated_memory{node_class=\"hashistack\"}*100/(nomad_client_unallocated_memory{node_class=\"hashistack\"}+nomad_client_allocated_memory{node_class=\"hashistack\"}))/count(nomad_client_allocated_memory{node_class=\"hashistack\"})"
 
-    strategy "target-value" {
-      target = 70
+      strategy "target-value" {
+        target = 70
+      }
     }
-  }
 
-  target "azure-vmss" {
-    resource_group      = "${resource_group}"
-    vm_scale_set        = "clients"
-    node_class          = "hashistack"
-    node_drain_deadline = "5m"
+    target "azure-vmss" {
+      resource_group      = "${resource_group}"
+      vm_scale_set        = "clients"
+      node_class          = "hashistack"
+      node_drain_deadline = "5m"
+    }
   }
 }
 EOF

--- a/policy/file/parse_test.go
+++ b/policy/file/parse_test.go
@@ -10,54 +10,54 @@ import (
 
 func Test_decodeFile(t *testing.T) {
 	testCases := []struct {
-		inputFile            string
-		inputPolicy          *sdk.ScalingPolicy
-		expectedOutputPolicy *sdk.ScalingPolicy
-		expectedOutputError  error
-		name                 string
+		inputFile              string
+		expectedOutputPolicies map[string]*sdk.ScalingPolicy
+		expectedOutputError    error
+		name                   string
 	}{
 		{
-			inputFile:   "./test-fixtures/full-cluster-policy.hcl",
-			inputPolicy: &sdk.ScalingPolicy{},
-			expectedOutputPolicy: &sdk.ScalingPolicy{
-				ID:                 "",
-				Type:               sdk.ScalingPolicyTypeCluster,
-				Enabled:            true,
-				Min:                10,
-				Max:                100,
-				Cooldown:           10 * time.Minute,
-				EvaluationInterval: 1 * time.Minute,
-				Checks: []*sdk.ScalingPolicyCheck{
-					{
-						Name:        "cpu_nomad",
-						Source:      "nomad_apm",
-						Query:       "cpu_high-memory",
-						QueryWindow: time.Minute,
-						Strategy: &sdk.ScalingPolicyStrategy{
-							Name: "target-value",
-							Config: map[string]string{
-								"target": "80",
+			inputFile: "./test-fixtures/full-cluster-policy.hcl",
+			expectedOutputPolicies: map[string]*sdk.ScalingPolicy{
+				"full-cluster-policy": &sdk.ScalingPolicy{
+					ID:                 "",
+					Type:               sdk.ScalingPolicyTypeCluster,
+					Enabled:            true,
+					Min:                10,
+					Max:                100,
+					Cooldown:           10 * time.Minute,
+					EvaluationInterval: 1 * time.Minute,
+					Checks: []*sdk.ScalingPolicyCheck{
+						{
+							Name:        "cpu_nomad",
+							Source:      "nomad_apm",
+							Query:       "cpu_high-memory",
+							QueryWindow: time.Minute,
+							Strategy: &sdk.ScalingPolicyStrategy{
+								Name: "target-value",
+								Config: map[string]string{
+									"target": "80",
+								},
+							},
+						},
+						{
+							Name:   "memory_prom",
+							Source: "prometheus",
+							Query:  "nomad_client_allocated_memory*100/(nomad_client_allocated_memory+nomad_client_unallocated_memory)",
+							Strategy: &sdk.ScalingPolicyStrategy{
+								Name: "target-value",
+								Config: map[string]string{
+									"target": "80",
+								},
 							},
 						},
 					},
-					{
-						Name:   "memory_prom",
-						Source: "prometheus",
-						Query:  "nomad_client_allocated_memory*100/(nomad_client_allocated_memory+nomad_client_unallocated_memory)",
-						Strategy: &sdk.ScalingPolicyStrategy{
-							Name: "target-value",
-							Config: map[string]string{
-								"target": "80",
-							},
+					Target: &sdk.ScalingPolicyTarget{
+						Name: "aws-asg",
+						Config: map[string]string{
+							"aws_asg_name":        "my-target-asg",
+							"node_class":          "high-memory",
+							"node_drain_deadline": "15m",
 						},
-					},
-				},
-				Target: &sdk.ScalingPolicyTarget{
-					Name: "aws-asg",
-					Config: map[string]string{
-						"aws_asg_name":        "my-target-asg",
-						"node_class":          "high-memory",
-						"node_drain_deadline": "15m",
 					},
 				},
 			},
@@ -65,45 +65,46 @@ func Test_decodeFile(t *testing.T) {
 			name:                "full parsable cluster scaling policy",
 		},
 		{
-			inputFile:   "./test-fixtures/full-task-group-policy.hcl",
-			inputPolicy: &sdk.ScalingPolicy{},
-			expectedOutputPolicy: &sdk.ScalingPolicy{
-				ID:                 "",
-				Type:               sdk.ScalingPolicyTypeHorizontal,
-				Enabled:            true,
-				Min:                1,
-				Max:                10,
-				Cooldown:           1 * time.Minute,
-				EvaluationInterval: 30 * time.Second,
-				Checks: []*sdk.ScalingPolicyCheck{
-					{
-						Name:   "cpu_nomad",
-						Source: "nomad_apm",
-						Query:  "avg_cpu",
-						Strategy: &sdk.ScalingPolicyStrategy{
-							Name: "target-value",
-							Config: map[string]string{
-								"target": "80",
+			inputFile: "./test-fixtures/full-task-group-policy.hcl",
+			expectedOutputPolicies: map[string]*sdk.ScalingPolicy{
+				"full-task-group-policy": &sdk.ScalingPolicy{
+					ID:                 "",
+					Type:               sdk.ScalingPolicyTypeHorizontal,
+					Enabled:            true,
+					Min:                1,
+					Max:                10,
+					Cooldown:           1 * time.Minute,
+					EvaluationInterval: 30 * time.Second,
+					Checks: []*sdk.ScalingPolicyCheck{
+						{
+							Name:   "cpu_nomad",
+							Source: "nomad_apm",
+							Query:  "avg_cpu",
+							Strategy: &sdk.ScalingPolicyStrategy{
+								Name: "target-value",
+								Config: map[string]string{
+									"target": "80",
+								},
+							},
+						},
+						{
+							Name:   "memory_nomad",
+							Source: "nomad_apm",
+							Query:  "avg_memory",
+							Strategy: &sdk.ScalingPolicyStrategy{
+								Name: "target-value",
+								Config: map[string]string{
+									"target": "80",
+								},
 							},
 						},
 					},
-					{
-						Name:   "memory_nomad",
-						Source: "nomad_apm",
-						Query:  "avg_memory",
-						Strategy: &sdk.ScalingPolicyStrategy{
-							Name: "target-value",
-							Config: map[string]string{
-								"target": "80",
-							},
+					Target: &sdk.ScalingPolicyTarget{
+						Name: "nomad",
+						Config: map[string]string{
+							"Group": "cache",
+							"Job":   "example",
 						},
-					},
-				},
-				Target: &sdk.ScalingPolicyTarget{
-					Name: "nomad",
-					Config: map[string]string{
-						"Group": "cache",
-						"Job":   "example",
 					},
 				},
 			},
@@ -114,8 +115,8 @@ func Test_decodeFile(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualError := decodeFile(tc.inputFile, tc.inputPolicy)
-			assert.Equal(t, tc.expectedOutputPolicy, tc.inputPolicy, tc.name)
+			got, actualError := decodeFile(tc.inputFile)
+			assert.Equal(t, tc.expectedOutputPolicies, got, tc.name)
 			assert.Equal(t, tc.expectedOutputError, actualError, tc.name)
 
 			// Print unexpected errors.

--- a/policy/file/source_test.go
+++ b/policy/file/source_test.go
@@ -9,38 +9,41 @@ import (
 
 func TestSource_getFilePolicyID(t *testing.T) {
 	testCases := []struct {
-		inputFile   string
-		existingID  policy.PolicyID
-		inputSource *Source
-		name        string
+		inputFile       string
+		inputPolicyName string
+		existingID      policy.PolicyID
+		inputSource     *Source
+		name            string
 	}{
 		{
-			inputFile:  "/this/test/file.hcl",
-			existingID: "587a5903-f77b-c7e6-a07a-def5af92f791",
+			inputFile:       "/this/test/file.hcl",
+			inputPolicyName: "policy_name",
+			existingID:      "b65aa225-35bd-aa72-29d0-a1d228662817",
 			inputSource: &Source{idMap: map[pathMD5Sum]policy.PolicyID{
-				md5Sum("/this/test/file.hcl"): "587a5903-f77b-c7e6-a07a-def5af92f791",
+				md5Sum("/this/test/file.hcl/policy_name"): "b65aa225-35bd-aa72-29d0-a1d228662817",
 			}},
 			name: "file already within idMap",
 		},
 
 		{
-			inputFile:   "/this/test/file.hcl",
-			existingID:  "",
-			inputSource: &Source{idMap: map[pathMD5Sum]policy.PolicyID{}},
-			name:        "file not within idMap",
+			inputFile:       "/this/test/file.hcl",
+			inputPolicyName: "policy_name",
+			existingID:      "",
+			inputSource:     &Source{idMap: map[pathMD5Sum]policy.PolicyID{}},
+			name:            "file not within idMap",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			outputID := tc.inputSource.getFilePolicyID(tc.inputFile)
+			outputID := tc.inputSource.getFilePolicyID(tc.inputFile, tc.inputPolicyName)
 
 			if tc.existingID != "" {
 				assert.Equal(t, tc.existingID, outputID, tc.name)
 			}
 
-			policyID, ok := tc.inputSource.idMap[md5Sum(tc.inputFile)]
-			assert.Equal(t, outputID, policyID, tc.name)
+			policyID, ok := tc.inputSource.idMap[md5Sum(tc.inputFile+"/"+tc.inputPolicyName)]
+			assert.Equal(t, policyID, outputID, tc.name)
 			assert.True(t, ok, tc.name)
 		})
 	}

--- a/policy/file/test-fixtures/full-cluster-policy.hcl
+++ b/policy/file/test-fixtures/full-cluster-policy.hcl
@@ -1,35 +1,37 @@
-enabled = true
-min     = 10
-max     = 100
-type    = "cluster"
+scaling "full-cluster-policy" {
+  enabled = true
+  min     = 10
+  max     = 100
+  type    = "cluster"
 
-policy {
+  policy {
 
-  cooldown            = "10m"
-  evaluation_interval = "1m"
+    cooldown            = "10m"
+    evaluation_interval = "1m"
 
-  check "cpu_nomad" {
-    source       = "nomad_apm"
-    query        = "cpu_high-memory"
-    query_window = "1m"
+    check "cpu_nomad" {
+      source       = "nomad_apm"
+      query        = "cpu_high-memory"
+      query_window = "1m"
 
-    strategy "target-value" {
-      target = "80"
+      strategy "target-value" {
+        target = "80"
+      }
     }
-  }
 
-  check "memory_prom" {
-    source = "prometheus"
-    query  = "nomad_client_allocated_memory*100/(nomad_client_allocated_memory+nomad_client_unallocated_memory)"
+    check "memory_prom" {
+      source = "prometheus"
+      query  = "nomad_client_allocated_memory*100/(nomad_client_allocated_memory+nomad_client_unallocated_memory)"
 
-    strategy "target-value" {
-      target = "80"
+      strategy "target-value" {
+        target = "80"
+      }
     }
-  }
 
-  target "aws-asg" {
-    aws_asg_name        = "my-target-asg"
-    node_class          = "high-memory"
-    node_drain_deadline = "15m"
+    target "aws-asg" {
+      aws_asg_name        = "my-target-asg"
+      node_class          = "high-memory"
+      node_drain_deadline = "15m"
+    }
   }
 }

--- a/policy/file/test-fixtures/full-task-group-policy.hcl
+++ b/policy/file/test-fixtures/full-task-group-policy.hcl
@@ -1,33 +1,35 @@
-enabled = true
-min     = 1
-max     = 10
-type    = "horizontal"
+scaling "full-task-group-policy" {
+  enabled = true
+  min     = 1
+  max     = 10
+  type    = "horizontal"
 
-policy {
+  policy {
 
-  cooldown            = "1m"
-  evaluation_interval = "30s"
+    cooldown            = "1m"
+    evaluation_interval = "30s"
 
-  check "cpu_nomad" {
-    source = "nomad_apm"
-    query  = "avg_cpu"
+    check "cpu_nomad" {
+      source = "nomad_apm"
+      query  = "avg_cpu"
 
-    strategy "target-value" {
-      target = "80"
+      strategy "target-value" {
+        target = "80"
+      }
     }
-  }
 
-  check "memory_nomad" {
-    source = "nomad_apm"
-    query  = "avg_memory"
+    check "memory_nomad" {
+      source = "nomad_apm"
+      query  = "avg_memory"
 
-    strategy "target-value" {
-      target = "80"
+      strategy "target-value" {
+        target = "80"
+      }
     }
-  }
 
-  target "nomad" {
-    Group = "cache"
-    Job   = "example"
+    target "nomad" {
+      Group = "cache"
+      Job   = "example"
+    }
   }
 }

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -119,11 +119,16 @@ func (t *ScalingPolicyTarget) IsNodePoolTarget() bool {
 	return ok
 }
 
+type FileDecodeScalingPolicies struct {
+	ScalingPolicies []*FileDecodeScalingPolicy `hcl:"scaling,block"`
+}
+
 // FileDecodeScalingPolicy is used as an intermediate step when decoding a
 // policy from a file. It is needed because the internal Policy object is
 // flattened when compared to the literal HCL version. Therefore we cannot
 // translate into the internal struct but use this.
 type FileDecodeScalingPolicy struct {
+	Name    string               `hcl:"name,label"`
 	Enabled bool                 `hcl:"enabled,optional"`
 	Type    string               `hcl:"type,optional"`
 	Min     int64                `hcl:"min,optional"`
@@ -151,7 +156,9 @@ type FileDecodePolicyCheckDoc struct {
 
 // Translate all values from the decoded policy file into our internal policy
 // object.
-func (fpd *FileDecodeScalingPolicy) Translate(p *ScalingPolicy) {
+func (fpd *FileDecodeScalingPolicy) Translate() *ScalingPolicy {
+	p := &ScalingPolicy{}
+
 	p.Min = fpd.Min
 	p.Max = fpd.Max
 	p.Enabled = fpd.Enabled
@@ -161,6 +168,8 @@ func (fpd *FileDecodeScalingPolicy) Translate(p *ScalingPolicy) {
 	p.Target = fpd.Doc.Target
 
 	fpd.translateChecks(p)
+
+	return p
 }
 
 func (fpd *FileDecodeScalingPolicy) translateChecks(p *ScalingPolicy) {

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -10,7 +10,6 @@ import (
 func TestFileDecodePolicy_Translate(t *testing.T) {
 	testCases := []struct {
 		inputFileDecodePolicy *FileDecodeScalingPolicy
-		inputPolicy           *ScalingPolicy
 		expectedOutputPolicy  *ScalingPolicy
 		name                  string
 	}{
@@ -47,7 +46,6 @@ func TestFileDecodePolicy_Translate(t *testing.T) {
 					},
 				},
 			},
-			inputPolicy: &ScalingPolicy{},
 			expectedOutputPolicy: &ScalingPolicy{
 				ID:                 "",
 				Min:                1,
@@ -82,8 +80,8 @@ func TestFileDecodePolicy_Translate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.inputFileDecodePolicy.Translate(tc.inputPolicy)
-			assert.Equal(t, tc.expectedOutputPolicy, tc.inputPolicy, tc.name)
+			got := tc.inputFileDecodePolicy.Translate()
+			assert.Equal(t, tc.expectedOutputPolicy, got, tc.name)
 		})
 	}
 }


### PR DESCRIPTION
This PR allows for policy files to store multiple policies. This is a useful feature when using the Autoscaler as a Nomad job as it allows for dynamic policy generation based on Consul keys and other sources supported by Nomad's `template` stanza`.

It changes the format of policy file slightly by wrapping it around a `scaling` block, similarly to how a horizontal policy is defined in the jobspec.

Each `scaling` stanza requires a label so that policies within the same file can be differentiated.

#### Example
This jobspec:

```hcl
job "autoscaler" {
  datacenters = ["dc1"]

  group "autoscaler" {
    count = 1

    task "autoscaler" {
      driver = "docker"

      config {
        image   = "hashicorp/nomad-autoscaler:0.1.0"
        command = "nomad-autoscaler"
        ...
      }

      template {
        data = <<EOF
{{ $prefix := "nomad-autoscaler/policies" }}
{{ range ls (printf "%s/" $prefix ) }}
scaling "{{ .Key }}" {
  enabled = {{ keyOrDefault (printf "%s/%s/enabled" $prefix .Key) "true" }}
  min     = 1
  max     = 2

  policy {
    cooldown            = "{{ key (printf "%s/%s/cooldown" $prefix .Key) }}"
    evaluation_interval = "{{ key (printf "%s/%s/evaluation_interval" $prefix .Key) }}"

    check "my-check" { 
      ... 
    }

    target "my-target" {
      ...
    }
  }
}
{{ end }}
EOF

        destination = "${NOMAD_TASK_DIR}/policies/policies.hcl"
      }

      ...
    }
  }
}
```

With these Consul keys:

```
nomad-autoscaler/policies/policy1:
nomad-autoscaler/policies/policy1/cooldown: 5s
nomad-autoscaler/policies/policy1/evaluation_interval: 10s
nomad-autoscaler/policies/policy2:
nomad-autoscaler/policies/policy2/cooldown: 10s
nomad-autoscaler/policies/policy2/enabled: false
nomad-autoscaler/policies/policy2/evaluation_interval: 3s
```

Will generate a policy file like this:

```hcl
scaling "policy1" {
  enabled = true
  min     = 1
  max     = 2

  policy {
    cooldown            = "5s"
    evaluation_interval = "10s"

    check "my-check" { 
      ... 
    }

    target "my-target" {
      ...
    }
  }
}

scaling "policy2" {
  enabled = false
  min     = 1
  max     = 2

  policy {
    cooldown            = "10s"
    evaluation_interval = "3s"

    check "my-check" { 
      ... 
    }

    target "my-target" {
      ...
    }
  }
}
```

Each of the `scaling` block will be considered as a separate policy internally.

Closes #307 