### PR TITLE
demo/vagrant/das: remove use for deprecated network spec params.

### DIFF
--- a/demo/vagrant/dynamic-app-sizing/jobs/prometheus.nomad
+++ b/demo/vagrant/dynamic-app-sizing/jobs/prometheus.nomad
@@ -4,11 +4,19 @@ job "prometheus" {
   group "prometheus" {
     count = 1
 
+    network {
+      port "prometheus_ui" {
+        static = 9090
+        to     = 9090
+      }
+    }
+
     task "prometheus" {
       driver = "docker"
 
       config {
         image = "prom/prometheus:v2.18.1"
+        ports = ["prometheus_ui"]
 
         args = [
           "--config.file=/etc/prometheus/config/prometheus.yml",
@@ -20,10 +28,6 @@ job "prometheus" {
         volumes = [
           "local/config:/etc/prometheus/config",
         ]
-
-        port_map {
-          prometheus_ui = 9090
-        }
       }
 
       template {
@@ -57,14 +61,6 @@ EOH
       resources {
         cpu    = 100
         memory = 256
-
-        network {
-          mbits = 10
-
-          port "prometheus_ui" {
-            static = 9090
-          }
-        }
       }
 
       service {


### PR DESCRIPTION
Updates the job files used within the Vagrant DAS demo to use the
group level network stanza.

This change also adds a Consul health check for the Autoscaler
using the health endpoint. This matches what is done within the
horizontal vagrant demo.

closes #327 