### PR TITLE
Print autoscaler version to log on agent startup

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -3,6 +3,7 @@ package command
 import (
 	"flag"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -231,7 +232,35 @@ func (c *AgentCommand) Run(args []string) int {
 		JSONFormat: parsedConfig.LogJson,
 	})
 
-	logger.Info(fmt.Sprintf("nomad-autoscaler version %s starting", version.GetHumanVersion()))
+	logger.Info("Starting nomad-autoscaler agent")
+	// Compile agent information for output later
+	info := make(map[string]string)
+	info["bind addrs"] = parsedConfig.HTTP.BindAddress
+	info["log level"] = parsedConfig.LogLevel
+	info["version"] = version.GetHumanVersion()
+	info["plugins"] = parsedConfig.PluginDir
+	info["policies"] = parsedConfig.Policy.Dir
+
+	// Sort the keys for output
+	infoKeys := make([]string, 0, len(info))
+	for key := range info {
+		infoKeys = append(infoKeys, key)
+	}
+	sort.Strings(infoKeys)
+
+	// Agent configuration output
+	padding := 18
+	logger.Info("Nomad agent configuration:")
+	for _, k := range infoKeys {
+		logger.Info(fmt.Sprintf(
+			"%s%s: %s",
+			strings.Repeat(" ", padding-len(k)),
+			strings.Title(k),
+			info[k]))
+	}
+	logger.Info("")
+	// Output the header that the server has started
+	logger.Info("Nomad agent started! Log data will stream in below:")
 
 	// create and run agent and HTTP server
 	c.agent = agent.NewAgent(parsedConfig, logger)

--- a/command/agent.go
+++ b/command/agent.go
@@ -232,7 +232,7 @@ func (c *AgentCommand) Run(args []string) int {
 		JSONFormat: parsedConfig.LogJson,
 	})
 
-	logger.Info("Starting nomad-autoscaler agent")
+	logger.Info("Starting Nomad Autoscaler agent")
 	// Compile agent information for output later
 	info := make(map[string]string)
 	info["bind addrs"] = parsedConfig.HTTP.BindAddress
@@ -250,7 +250,7 @@ func (c *AgentCommand) Run(args []string) int {
 
 	// Agent configuration output
 	padding := 18
-	logger.Info("Nomad agent configuration:")
+	logger.Info("Nomad Autoscaler agent configuration:")
 	logger.Info("")
 	for _, k := range infoKeys {
 		logger.Info(fmt.Sprintf(
@@ -261,7 +261,7 @@ func (c *AgentCommand) Run(args []string) int {
 	}
 	logger.Info("")
 	// Output the header that the server has started
-	logger.Info("Nomad agent started! Log data will stream in below:")
+	logger.Info("Nomad Autoscaler agent started! Log data will stream in below:")
 
 	// create and run agent and HTTP server
 	c.agent = agent.NewAgent(parsedConfig, logger)

--- a/command/agent.go
+++ b/command/agent.go
@@ -231,7 +231,7 @@ func (c *AgentCommand) Run(args []string) int {
 		JSONFormat: parsedConfig.LogJson,
 	})
 
-	logger.Info(fmt.Sprintf("nomad-autoscaler version %s starting", version.GetHumanVersion))
+	logger.Info(fmt.Sprintf("nomad-autoscaler version %s starting", version.GetHumanVersion()))
 
 	// create and run agent and HTTP server
 	c.agent = agent.NewAgent(parsedConfig, logger)

--- a/command/agent.go
+++ b/command/agent.go
@@ -251,6 +251,7 @@ func (c *AgentCommand) Run(args []string) int {
 	// Agent configuration output
 	padding := 18
 	logger.Info("Nomad agent configuration:")
+	logger.Info("")
 	for _, k := range infoKeys {
 		logger.Info(fmt.Sprintf(
 			"%s%s: %s",

--- a/command/agent.go
+++ b/command/agent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/agent/config"
 	agentHTTP "github.com/hashicorp/nomad-autoscaler/agent/http"
 	flaghelper "github.com/hashicorp/nomad-autoscaler/sdk/helper/flag"
+	"github.com/hashicorp/nomad-autoscaler/version"
 )
 
 type AgentCommand struct {
@@ -229,6 +230,8 @@ func (c *AgentCommand) Run(args []string) int {
 		Level:      hclog.LevelFromString(parsedConfig.LogLevel),
 		JSONFormat: parsedConfig.LogJson,
 	})
+
+	logger.Info(fmt.Sprintf("nomad-autoscaler version %s starting", version.GetHumanVersion))
 
 	// create and run agent and HTTP server
 	c.agent = agent.NewAgent(parsedConfig, logger)


### PR DESCRIPTION
Figured it'd be nice to know which version produced which logfiles while debugging issues.  Change emits: 
```
➜ ./nomad-autoscaler agent
2021-01-12T12:35:59.415-0500 [INFO]  agent: nomad-autoscaler version v0.3.0-dev starting````