### PR TITLE
agent: add pprof HTTP debug endpoints.

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -32,6 +32,9 @@ type Agent struct {
 	// LogJson enables log output in JSON format.
 	LogJson bool `hcl:"log_json,optional"`
 
+	// EnableDebug is used to enable debugging HTTP endpoints.
+	EnableDebug bool `hcl:"enable_debug,optional"`
+
 	// PluginDir is the directory that holds the autoscaler plugin binaries.
 	PluginDir string `hcl:"plugin_dir,optional"`
 
@@ -364,6 +367,9 @@ func Default() (*Agent, error) {
 func (a *Agent) Merge(b *Agent) *Agent {
 	result := *a
 
+	if b.EnableDebug {
+		result.EnableDebug = true
+	}
 	if b.LogLevel != "" {
 		result.LogLevel = b.LogLevel
 	}

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -31,6 +31,7 @@ func Test_Default(t *testing.T) {
 	assert.Len(t, def.Targets, 1)
 	assert.Len(t, def.Strategies, 1)
 	assert.Equal(t, 1*time.Second, def.Telemetry.CollectionInterval)
+	assert.False(t, def.EnableDebug, "ensure debugging is disabled by default")
 }
 
 func TestAgent_Merge(t *testing.T) {
@@ -61,9 +62,10 @@ func TestAgent_Merge(t *testing.T) {
 	}
 
 	cfg2 := &Agent{
-		LogLevel:  "trace",
-		LogJson:   true,
-		PluginDir: "/var/lib/nomad-autoscaler/plugins",
+		EnableDebug: true,
+		LogLevel:    "trace",
+		LogJson:     true,
+		PluginDir:   "/var/lib/nomad-autoscaler/plugins",
 		HTTP: &HTTP{
 			BindPort: 4646,
 		},
@@ -138,9 +140,10 @@ func TestAgent_Merge(t *testing.T) {
 	}
 
 	expectedResult := &Agent{
-		LogLevel:  "trace",
-		LogJson:   true,
-		PluginDir: "/var/lib/nomad-autoscaler/plugins",
+		EnableDebug: true,
+		LogLevel:    "trace",
+		LogJson:     true,
+		PluginDir:   "/var/lib/nomad-autoscaler/plugins",
 		HTTP: &HTTP{
 			BindAddress: "scaler.nomad",
 			BindPort:    4646,

--- a/agent/http/testing.go
+++ b/agent/http/testing.go
@@ -14,7 +14,7 @@ func TestServer(t *testing.T) (*Server, func()) {
 		BindPort:    0, // Use next available port.
 	}
 
-	s, err := NewHTTPServer(cfg, hclog.NewNullLogger(), &agent.MockAgentHTTP{})
+	s, err := NewHTTPServer(false, cfg, hclog.NewNullLogger(), &agent.MockAgentHTTP{})
 	if err != nil {
 		t.Fatalf("failed to start test server: %v", err)
 	}

--- a/command/agent.go
+++ b/command/agent.go
@@ -50,6 +50,9 @@ Options:
   -log-json
     Output logs in a JSON format. The default is false.
 
+  -enable-debug
+    Enable the agent debugging HTTP endpoints. The default is false.
+
   -plugin-dir=<path>
     The plugin directory is used to discover Nomad Autoscaler plugins. If not
     specified, the plugin directory defaults to be that of
@@ -265,7 +268,7 @@ func (c *AgentCommand) Run(args []string) int {
 
 	// create and run agent and HTTP server
 	c.agent = agent.NewAgent(parsedConfig, logger)
-	httpServer, err := agentHTTP.NewHTTPServer(parsedConfig.HTTP, logger, c.agent)
+	httpServer, err := agentHTTP.NewHTTPServer(parsedConfig.EnableDebug, parsedConfig.HTTP, logger, c.agent)
 	if err != nil {
 		logger.Error("failed to setup HTTP getHealth server", "error", err)
 		return 1
@@ -300,6 +303,7 @@ func (c *AgentCommand) readConfig() *config.Agent {
 	flags.Var((*flaghelper.StringFlag)(&configPath), "config", "")
 	flags.StringVar(&cmdConfig.LogLevel, "log-level", "", "")
 	flags.BoolVar(&cmdConfig.LogJson, "log-json", false, "")
+	flags.BoolVar(&cmdConfig.EnableDebug, "enable-debug", false, "")
 	flags.StringVar(&cmdConfig.PluginDir, "plugin-dir", "", "")
 
 	// Specify our HTTP bind flags.


### PR DESCRIPTION
The Nomad Autoscaler is mildly complex and debugging problems can be tricky when they are related to items such as go routine deadlocks. The optional pprof endpoints allow developers and operators to easily obtain profiling data from the Nomad Autoscaler, no matter the persons ability with the Go programming language.

We have no control over the API, therefore they do not sit under the `/v1` prefix.

p.s. @cgbaker sorry for adding more endpoints!