### PR TITLE
Use default values for the Nomad client as provided by the `api` package

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -294,14 +294,6 @@ const (
 	// the PluginDir default value.
 	defaultPluginDirSuffix = "/plugins"
 
-	// defaultNomadAddress is the default address used for Nomad API
-	// connectivity.
-	defaultNomadAddress = "http://127.0.0.1:4646"
-
-	// defaultNomadRegion is the default Nomad region to use when performing
-	// Nomad API calls.
-	defaultNomadRegion = "global"
-
 	// defaultPolicyCooldown is the default time duration applied to policies
 	// which do not explicitly configure a cooldown.
 	defaultPolicyCooldown = 5 * time.Minute
@@ -341,10 +333,7 @@ func Default() (*Agent, error) {
 			BindAddress: defaultHTTPBindAddress,
 			BindPort:    defaultHTTPBindPort,
 		},
-		Nomad: &Nomad{
-			Address: defaultNomadAddress,
-			Region:  defaultNomadRegion,
-		},
+		Nomad: &Nomad{},
 		Telemetry: &Telemetry{
 			CollectionInterval: defaultTelemetryCollectionInterval,
 		},

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -20,7 +20,6 @@ func Test_Default(t *testing.T) {
 	assert.Equal(t, def.LogLevel, "info")
 	assert.True(t, strings.HasSuffix(def.PluginDir, "/plugins"))
 	assert.Equal(t, def.Policy.DefaultEvaluationInterval, 10*time.Second)
-	assert.Equal(t, def.Nomad.Address, "http://127.0.0.1:4646")
 	assert.Equal(t, "127.0.0.1", def.HTTP.BindAddress)
 	assert.Equal(t, 8080, def.HTTP.BindPort)
 	assert.Equal(t, def.Policy.DefaultCooldown, 5*time.Minute)


### PR DESCRIPTION
The Autoscaler was accidentally overriding the defaults returned by Nomad's [`api.DefaultConfig()`](https://github.com/hashicorp/nomad/blob/v1.0.2/api/api.go#L243). 

I couldn't see a reason why the Autoscaler would need to set default values on its own, so I just removed them. But I could be missing something.

It's also not a breaking change since the default values being set are the same as `api.DefaultConfig()` defines.

Closes #357 