### PR TITLE
Add `node_drain_ignore_system_jobs` to `gce-mig` target

### DIFF
--- a/plugins/builtin/target/gce-mig/plugin/gce_test.go
+++ b/plugins/builtin/target/gce-mig/plugin/gce_test.go
@@ -24,8 +24,9 @@ func TestTargetPlugin_generateScaleReq(t *testing.T) {
 				"node_drain_deadline": "5m",
 			},
 			expectedOutputReq: &scaleutils.ScaleInReq{
-				Num:           2,
-				DrainDeadline: 5 * time.Minute,
+				Num:              2,
+				DrainDeadline:    5 * time.Minute,
+				IgnoreSystemJobs: false,
 				PoolIdentifier: &scaleutils.PoolIdentifier{
 					IdentifierKey: scaleutils.IdentifierKeyClass,
 					Value:         "high-memory",
@@ -35,6 +36,26 @@ func TestTargetPlugin_generateScaleReq(t *testing.T) {
 			},
 			expectedOutputError: nil,
 			name:                "valid request with drain_deadline in config",
+		},
+		{
+			inputNum: 2,
+			inputConfig: map[string]string{
+				"node_class":                    "high-memory",
+				"node_drain_ignore_system_jobs": "true",
+			},
+			expectedOutputReq: &scaleutils.ScaleInReq{
+				Num:              2,
+				DrainDeadline:    15 * time.Minute,
+				IgnoreSystemJobs: true,
+				PoolIdentifier: &scaleutils.PoolIdentifier{
+					IdentifierKey: scaleutils.IdentifierKeyClass,
+					Value:         "high-memory",
+				},
+				RemoteProvider: scaleutils.RemoteProviderGCEInstanceID,
+				NodeIDStrategy: scaleutils.IDStrategyNewestCreateIndex,
+			},
+			expectedOutputError: nil,
+			name:                "valid request with node_drain_ignore_system_jobs in config",
 		},
 		{
 			inputNum:            2,
@@ -49,8 +70,9 @@ func TestTargetPlugin_generateScaleReq(t *testing.T) {
 				"node_class": "high-memory",
 			},
 			expectedOutputReq: &scaleutils.ScaleInReq{
-				Num:           2,
-				DrainDeadline: 15 * time.Minute,
+				Num:              2,
+				DrainDeadline:    15 * time.Minute,
+				IgnoreSystemJobs: false,
 				PoolIdentifier: &scaleutils.PoolIdentifier{
 					IdentifierKey: scaleutils.IdentifierKeyClass,
 					Value:         "high-memory",


### PR DESCRIPTION
Implement new cluster scaling config `node_drain_ignore_system_jobs` to the `gce-mig` target.

Closes #366.