### PR TITLE
scaleutils: filter nodes to ensure unstable pools do not run eval.

### DIFF
--- a/plugins/builtin/apm/nomad/plugin/node.go
+++ b/plugins/builtin/apm/nomad/plugin/node.go
@@ -89,7 +89,7 @@ func (a *APMPlugin) getPoolResources(id *scaleutils.PoolIdentifier) (*nodePoolRe
 	// our pool and that are in the correct state.
 	nodePoolList, err := id.IdentifyNodes(nodes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to identify nodes within pool")
+		return nil, fmt.Errorf("failed to identify nodes within pool: %v", err)
 	}
 	if len(nodePoolList) == 0 {
 		return nil, errors.New("no nodes identified within pool")

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -151,7 +151,7 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 		Value:         class,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to run Nomad node rediness check: %v", err)
+		return nil, fmt.Errorf("failed to run Nomad node readiness check: %v", err)
 	}
 	if !ready {
 		return &sdk.TargetStatus{Ready: ready}, nil

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -144,7 +144,7 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 	}
 
 	// Perform our check of the Nomad node pool. If the pool is not ready, we
-	// can exit here and avoid calling the AWS API as it wont affect the
+	// can exit here and avoid calling the AWS API as it won't affect the
 	// outcome.
 	ready, err := t.scaleInUtils.Ready(scaleutils.PoolIdentifier{
 		IdentifierKey: scaleutils.IdentifierKeyClass,

--- a/plugins/builtin/target/azure-vmss/plugin/plugin.go
+++ b/plugins/builtin/target/azure-vmss/plugin/plugin.go
@@ -142,7 +142,7 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 	}
 
 	// Perform our check of the Nomad node pool. If the pool is not ready, we
-	// can exit here and avoid calling the Azure API as it wont affect the
+	// can exit here and avoid calling the Azure API as it won't affect the
 	// outcome.
 	ready, err := t.scaleInUtils.Ready(scaleutils.PoolIdentifier{
 		IdentifierKey: scaleutils.IdentifierKeyClass,

--- a/plugins/builtin/target/azure-vmss/plugin/plugin.go
+++ b/plugins/builtin/target/azure-vmss/plugin/plugin.go
@@ -149,7 +149,7 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 		Value:         class,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to run Nomad node rediness check: %v", err)
+		return nil, fmt.Errorf("failed to run Nomad node readiness check: %v", err)
 	}
 	if !ready {
 		return &sdk.TargetStatus{Ready: ready}, nil

--- a/plugins/builtin/target/azure-vmss/plugin/plugin.go
+++ b/plugins/builtin/target/azure-vmss/plugin/plugin.go
@@ -136,6 +136,25 @@ func (t *TargetPlugin) Scale(action sdk.ScalingAction, config map[string]string)
 // Status satisfies the Status function on the target.Target interface.
 func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, error) {
 
+	class, ok := config[sdk.TargetConfigKeyClass]
+	if !ok {
+		return nil, fmt.Errorf("required config param %q not found", sdk.TargetConfigKeyClass)
+	}
+
+	// Perform our check of the Nomad node pool. If the pool is not ready, we
+	// can exit here and avoid calling the Azure API as it wont affect the
+	// outcome.
+	ready, err := t.scaleInUtils.Ready(scaleutils.PoolIdentifier{
+		IdentifierKey: scaleutils.IdentifierKeyClass,
+		Value:         class,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to run Nomad node rediness check: %v", err)
+	}
+	if !ready {
+		return &sdk.TargetStatus{Ready: ready}, nil
+	}
+
 	// We cannot scale an vmss without knowing the vmss resource group and name.
 	resourceGroup, ok := config[configKeyResoureGroup]
 	if !ok {

--- a/plugins/builtin/target/gce-mig/plugin/plugin.go
+++ b/plugins/builtin/target/gce-mig/plugin/plugin.go
@@ -136,7 +136,7 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 		Value:         class,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to run Nomad node rediness check: %v", err)
+		return nil, fmt.Errorf("failed to run Nomad node readiness check: %v", err)
 	}
 	if !ready {
 		return &sdk.TargetStatus{Ready: ready}, nil

--- a/plugins/builtin/target/gce-mig/plugin/plugin.go
+++ b/plugins/builtin/target/gce-mig/plugin/plugin.go
@@ -123,6 +123,25 @@ func (t *TargetPlugin) Scale(action sdk.ScalingAction, config map[string]string)
 // Status satisfies the Status function on the target.Target interface.
 func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, error) {
 
+	class, ok := config[sdk.TargetConfigKeyClass]
+	if !ok {
+		return nil, fmt.Errorf("required config param %q not found", sdk.TargetConfigKeyClass)
+	}
+
+	// Perform our check of the Nomad node pool. If the pool is not ready, we
+	// can exit here and avoid calling the Google API as it wont affect the
+	// outcome.
+	ready, err := t.scaleInUtils.Ready(scaleutils.PoolIdentifier{
+		IdentifierKey: scaleutils.IdentifierKeyClass,
+		Value:         class,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to run Nomad node rediness check: %v", err)
+	}
+	if !ready {
+		return &sdk.TargetStatus{Ready: ready}, nil
+	}
+
 	group, err := t.calculateMIG(config)
 	if err != nil {
 		return nil, err

--- a/plugins/builtin/target/gce-mig/plugin/plugin.go
+++ b/plugins/builtin/target/gce-mig/plugin/plugin.go
@@ -129,7 +129,7 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 	}
 
 	// Perform our check of the Nomad node pool. If the pool is not ready, we
-	// can exit here and avoid calling the Google API as it wont affect the
+	// can exit here and avoid calling the Google API as it won't affect the
 	// outcome.
 	ready, err := t.scaleInUtils.Ready(scaleutils.PoolIdentifier{
 		IdentifierKey: scaleutils.IdentifierKeyClass,

--- a/sdk/helper/scaleutils/filter.go
+++ b/sdk/helper/scaleutils/filter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/api"
 )
 
@@ -20,12 +21,22 @@ type PoolIdentifier struct {
 	Value         string
 }
 
+// Validate is used to check the validation of the PoolIdentifier object.
+func (p *PoolIdentifier) Validate() error {
+	switch p.IdentifierKey {
+	case IdentifierKeyClass:
+		return nil
+	default:
+		return fmt.Errorf("unsupported node pool identifier: %q", p.IdentifierKey)
+	}
+}
+
 // IdentifyNodes filters the supplied node list based on the PoolIdentifier
 // params.
 func (p *PoolIdentifier) IdentifyNodes(n []*api.NodeListStub) ([]*api.NodeListStub, error) {
 	switch p.IdentifierKey {
 	case IdentifierKeyClass:
-		return filterByClass(n, p.Value), nil
+		return filterByClass(n, p.Value)
 	default:
 		return nil, fmt.Errorf("unsupported node pool identifier: %q", p.IdentifierKey)
 	}
@@ -88,37 +99,78 @@ const nodeAttrGCEZone = "platform.gce.zone"
 const defaultClassIdentifier = "autoscaler-default-pool"
 
 // filterByClass returns a filtered list of nodes which are active in the
-// cluster and where the specified class matches that of the nodes.
-func filterByClass(n []*api.NodeListStub, id string) []*api.NodeListStub {
+// cluster and where the specified class matches that of the nodes. In the
+// event that nodes are found within the class pool in an unstable state, and
+// thus indicating there is change occurring; an error will be returned.
+func filterByClass(n []*api.NodeListStub, id string) ([]*api.NodeListStub, error) {
 
 	// Create our output list object.
 	var out []*api.NodeListStub
 
+	// Track all nodes which are deemed to cause an error to the autoscaler. It
+	// is possible to make an argument that the first error should be returned
+	// in order to improve speed. In a situation where two nodes are in an
+	// undesired state, it would require the operator to perform the same tidy
+	// and restart of the autoscaler loop twice, which seems worse than having
+	// some extra time within this function.
+	var err *multierror.Error
+
 	for _, node := range n {
 
-		// Ignore nodes that are not in a ready state.
-		if node.Status != api.NodeStatusReady {
+		// Filter out all nodes which do not match the target class first.
+		if node.NodeClass != "" && node.NodeClass != id ||
+			node.NodeClass == "" && id != defaultClassIdentifier {
 			continue
 		}
 
-		// Ignore nodes that are not currently eligible.
-		if node.SchedulingEligibility != api.NodeSchedulingEligible {
+		// We should class an initializing node as an error, this is caused by
+		// node registration and could be sourced from scaling out.
+		if node.Status == api.NodeStatusInit {
+			err = multierror.Append(err, fmt.Errorf("node %s is initializing", node.ID))
 			continue
 		}
 
-		if node.Drain {
+		// Assuming a cluster has most, if not all nodes in a correct state for
+		// scheduling then this is the fastest route. Only append in the event
+		// we have not encountered any error to save some cycles.
+		if node.SchedulingEligibility == api.NodeSchedulingEligible {
+			if err == nil {
+				out = append(out, node)
+			}
 			continue
 		}
 
-		// Perform the node class check. We ensure an empty class is treated as
-		// the default value.
-		if node.NodeClass != "" && node.NodeClass == id ||
-			node.NodeClass == "" && id == defaultClassIdentifier {
-			out = append(out, node)
+		// This lifecycle phase relates to nodes that are being drained.
+		if node.Drain && node.Status == api.NodeStatusReady {
+			err = multierror.Append(err, fmt.Errorf("node %s is draining", node.ID))
+			continue
+		}
+
+		// This lifecycle phase relates to nodes that typically have had their
+		// drain completed, and now await removal from the cluster.
+		if !node.Drain && node.Status == api.NodeStatusReady {
+			err = multierror.Append(err, fmt.Errorf("node %s is ineligible", node.ID))
 		}
 	}
 
-	return out
+	// Be choosy with our returns to avoid sending a large list to the caller
+	// that will just get ignored.
+	if err != nil {
+		err.ErrorFormat = multiErrorFunc
+		return nil, err
+	}
+	return out, nil
+}
+
+// multiErrorFunc is a helper to convert the standard multierror output into
+// something a little more friendly to consoles. This is currently only used by
+// the node filter, but could be more useful elsewhere in the future.
+func multiErrorFunc(err []error) string {
+	points := make([]string, len(err))
+	for i, err := range err {
+		points[i] = err.Error()
+	}
+	return strings.Join(points, ", ")
 }
 
 // nodeIDMapFunc is the function signature used to find the Nomad node's remote

--- a/sdk/helper/scaleutils/filter.go
+++ b/sdk/helper/scaleutils/filter.go
@@ -121,7 +121,7 @@ func filterByClass(n []*api.NodeListStub, id string) ([]*api.NodeListStub, error
 		// efficiency, whilst still responding with useful information. It also
 		// avoids error logs messages which are extremely long and potentially
 		// unsuitable for log aggregators.
-		if err != nil && err.Len() == 10 {
+		if err != nil && err.Len() >= 10 {
 			err.ErrorFormat = multiErrorFunc
 			return nil, err
 		}

--- a/sdk/helper/scaleutils/status.go
+++ b/sdk/helper/scaleutils/status.go
@@ -1,0 +1,27 @@
+package scaleutils
+
+import "fmt"
+
+// Ready provides a method for understanding whether the node pool is in a
+// state that allows it to be safely scaled. This should be used by target
+// plugins when providing their status response. A non-nil error indicates
+// there was a problem performing the check.
+func (si *ScaleIn) Ready(id PoolIdentifier) (bool, error) {
+
+	nodes, _, err := si.nomad.Nodes().List(nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to list Nomad nodes: %v", err)
+	}
+
+	// Validate the request object so we can differentiate between errors here
+	// and errors as a result of node inconsistencies.
+	if err := id.Validate(); err != nil {
+		return false, fmt.Errorf("failed to validate pool identifier: %v", err)
+	}
+
+	if _, err := id.IdentifyNodes(nodes); err != nil {
+		si.log.Warn("node pool status readiness check failed", "error", err)
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
In situations where cluster scaling evaluations are triggered at
a rate faster than cluster scaling actions can complete,
the autoscaler would drain more and more nodes, eventually leaving
the pool without any.

The fix adds better, more thorough node pool filtering to error in
situations where the nodes within a pool are considered unstable.
This ensures the Nomad Autoscaler will only perform cluster scaling
evaluations when we can be sure the state is stable and known.

closes #376 