### PR TITLE
agent: fix Nomad config merging to pass env vars to plugins.

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"errors"
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAgent_generateNomadClient(t *testing.T) {
+	testCases := []struct {
+		inputAgent       *Agent
+		expectedOutputEr error
+		name             string
+	}{
+		{
+			inputAgent: &Agent{
+				nomadCfg: api.DefaultConfig(),
+			},
+			expectedOutputEr: nil,
+			name:             "default Nomad API config input",
+		},
+		{
+			inputAgent: &Agent{
+				nomadCfg: &api.Config{
+					Address: "\t",
+				},
+			},
+			expectedOutputEr: errors.New(`failed to instantiate Nomad client: invalid address '	': parse "\t": net/url: invalid control character in URL`),
+			name:             "invalid input Nomad address",
+		},
+	}
+
+	for _, tc := range testCases {
+		actualOutputErr := tc.inputAgent.generateNomadClient()
+		assert.Equal(t, tc.expectedOutputEr, actualOutputErr, tc.name)
+		if actualOutputErr == nil {
+			assert.Equal(t, tc.inputAgent.nomadCfg.Address, tc.inputAgent.nomadClient.Address(), tc.name)
+		}
+	}
+}

--- a/agent/plugins.go
+++ b/agent/plugins.go
@@ -62,7 +62,7 @@ func (a *Agent) setupPluginConfig(cfg map[string]string) {
 	// Nomad config from the agent. If we do not find it, opt-in by default.
 	val, ok := cfg[plugins.ConfigKeyNomadConfigInherit]
 	if !ok {
-		nomadHelper.MergeMapWithAgentConfig(cfg, a.config.Nomad)
+		nomadHelper.MergeMapWithAgentConfig(cfg, a.nomadCfg)
 		return
 	}
 
@@ -76,7 +76,7 @@ func (a *Agent) setupPluginConfig(cfg map[string]string) {
 		return
 	}
 	if boolVal {
-		nomadHelper.MergeMapWithAgentConfig(cfg, a.config.Nomad)
+		nomadHelper.MergeMapWithAgentConfig(cfg, a.nomadCfg)
 	}
 }
 

--- a/agent/plugins_test.go
+++ b/agent/plugins_test.go
@@ -3,8 +3,9 @@ package agent
 import (
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/agent/config"
+	"github.com/hashicorp/nomad/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,19 +22,22 @@ func TestAgent_setupPluginConfig(t *testing.T) {
 			},
 			inputAgent: &Agent{
 				logger: hclog.NewNullLogger(),
-				config: &config.Agent{
-					Nomad: &config.Nomad{
-						Address:       "test",
-						Region:        "test",
-						Namespace:     "test",
-						Token:         "test",
-						HTTPAuth:      "test",
+				nomadCfg: &api.Config{
+					Address:   "test",
+					Region:    "test",
+					SecretID:  "test",
+					Namespace: "test",
+					HttpAuth: &api.HttpBasicAuth{
+						Username: "test",
+						Password: "test",
+					},
+					TLSConfig: &api.TLSConfig{
 						CACert:        "test",
 						CAPath:        "test",
 						ClientCert:    "test",
 						ClientKey:     "test",
 						TLSServerName: "test",
-						SkipVerify:    true,
+						Insecure:      true,
 					},
 				},
 			},
@@ -48,19 +52,22 @@ func TestAgent_setupPluginConfig(t *testing.T) {
 			},
 			inputAgent: &Agent{
 				logger: hclog.NewNullLogger(),
-				config: &config.Agent{
-					Nomad: &config.Nomad{
-						Address:       "test",
-						Region:        "test",
-						Namespace:     "test",
-						Token:         "test",
-						HTTPAuth:      "test",
+				nomadCfg: &api.Config{
+					Address:   "test",
+					Region:    "test",
+					SecretID:  "test",
+					Namespace: "test",
+					HttpAuth: &api.HttpBasicAuth{
+						Username: "test",
+						Password: "test",
+					},
+					TLSConfig: &api.TLSConfig{
 						CACert:        "test",
 						CAPath:        "test",
 						ClientCert:    "test",
 						ClientKey:     "test",
 						TLSServerName: "test",
-						SkipVerify:    true,
+						Insecure:      true,
 					},
 				},
 			},
@@ -75,19 +82,22 @@ func TestAgent_setupPluginConfig(t *testing.T) {
 			},
 			inputAgent: &Agent{
 				logger: hclog.NewNullLogger(),
-				config: &config.Agent{
-					Nomad: &config.Nomad{
-						Address:       "test",
-						Region:        "test",
-						Namespace:     "test",
-						Token:         "test",
-						HTTPAuth:      "test",
+				nomadCfg: &api.Config{
+					Address:   "test",
+					Region:    "test",
+					SecretID:  "test",
+					Namespace: "test",
+					HttpAuth: &api.HttpBasicAuth{
+						Username: "test",
+						Password: "test",
+					},
+					TLSConfig: &api.TLSConfig{
 						CACert:        "test",
 						CAPath:        "test",
 						ClientCert:    "test",
 						ClientKey:     "test",
 						TLSServerName: "test",
-						SkipVerify:    true,
+						Insecure:      true,
 					},
 				},
 			},
@@ -97,7 +107,7 @@ func TestAgent_setupPluginConfig(t *testing.T) {
 				"nomad_region":          "test",
 				"nomad_namespace":       "test",
 				"nomad_token":           "test",
-				"nomad_http-auth":       "test",
+				"nomad_http-auth":       "test:test",
 				"nomad_ca-cert":         "test",
 				"nomad_ca-path":         "test",
 				"nomad_client-cert":     "test",
@@ -111,19 +121,22 @@ func TestAgent_setupPluginConfig(t *testing.T) {
 			inputCfg: map[string]string{},
 			inputAgent: &Agent{
 				logger: hclog.NewNullLogger(),
-				config: &config.Agent{
-					Nomad: &config.Nomad{
-						Address:       "test",
-						Region:        "test",
-						Namespace:     "test",
-						Token:         "test",
-						HTTPAuth:      "test",
+				nomadCfg: &api.Config{
+					Address:   "test",
+					Region:    "test",
+					SecretID:  "test",
+					Namespace: "test",
+					HttpAuth: &api.HttpBasicAuth{
+						Username: "test",
+						Password: "test",
+					},
+					TLSConfig: &api.TLSConfig{
 						CACert:        "test",
 						CAPath:        "test",
 						ClientCert:    "test",
 						ClientKey:     "test",
 						TLSServerName: "test",
-						SkipVerify:    true,
+						Insecure:      true,
 					},
 				},
 			},
@@ -132,7 +145,7 @@ func TestAgent_setupPluginConfig(t *testing.T) {
 				"nomad_region":          "test",
 				"nomad_namespace":       "test",
 				"nomad_token":           "test",
-				"nomad_http-auth":       "test",
+				"nomad_http-auth":       "test:test",
 				"nomad_ca-cert":         "test",
 				"nomad_ca-path":         "test",
 				"nomad_client-cert":     "test",


### PR DESCRIPTION
Fix an issue where parameters from the Nomad default config, which includes env var discovery, were not being correctly passed onto plugins which use a Nomad client.

The agent is now responsible for merging its own Nomad config with the Nomad API default configuration and storing this for use for all downstream clients where desired.

Viewed from a plugin receiving client config options, the following chain occurs starting from lowest to highest precedence:
- Nomad API defined default parameters
- Nomad API defined environment variables
- Nomad Autoscaler config file parameters, nomad block
- Nomad Autoscaler CLI parameters
- Nomad Autoscaler config file parameters, plugin specific block

closes #380 