### PR TITLE
plugin/apm/prometheus: only access config map once to set config.

### DIFF
--- a/plugins/builtin/apm/prometheus/plugin/plugin.go
+++ b/plugins/builtin/apm/prometheus/plugin/plugin.go
@@ -60,12 +60,13 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 	// If the address is not set, or is empty within the config, any client
 	// calls will fail. It seems logical to catch this here rather than just
 	// let queries fail.
-	if a.config[configKeyAddress] == "" {
+	addr, ok := a.config[configKeyAddress]
+	if !ok || addr == "" {
 		return fmt.Errorf("%q config value cannot be empty", configKeyAddress)
 	}
 
 	promCfg := api.Config{
-		Address: a.config[configKeyAddress],
+		Address: addr,
 	}
 
 	// create Prometheus client


### PR DESCRIPTION
This little manoeuvre's gonna save us 4 nanoseconds.