### PR TITLE
Expand SIGHUP handling

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -171,10 +171,12 @@ func (a *Agent) reload() {
 	a.logger.Info("reloading Autoscaler configuration")
 
 	// Reload config files from disk.
+	// Exit on error so operators can detect and correct configuration early.
+	// TODO: revisit this once we have a better mechanism for surfacing errors.
 	newCfg, err := config.LoadPaths(a.configPaths)
 	if err != nil {
 		a.logger.Error("failed to reload Autoscaler configuration", "error", err)
-		return
+		os.Exit(1)
 	}
 
 	a.config = newCfg
@@ -182,7 +184,7 @@ func (a *Agent) reload() {
 
 	if err := a.generateNomadClient(); err != nil {
 		a.logger.Error("failed to reload Autoscaler configuration", "error", err)
-		return
+		os.Exit(1)
 	}
 
 	a.logger.Debug("reloading policy sources")

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -760,7 +760,7 @@ func LoadPaths(paths []string) (*Agent, error) {
 	for _, path := range paths {
 		current, err := Load(path)
 		if err != nil {
-			return nil, fmt.Errorf("error loading configuration from %s: %s\n", path, err)
+			return nil, fmt.Errorf("error loading configuration from %s: %s", path, err)
 		}
 
 		if err := current.Validate(); err != nil {

--- a/command/agent.go
+++ b/command/agent.go
@@ -369,6 +369,7 @@ func (c *AgentCommand) readConfig() (*config.Agent, []string) {
 
 	fileConfig, err := config.LoadPaths(configPath)
 	if err != nil {
+		fmt.Printf("%s\n", err)
 		return nil, configPath
 	}
 

--- a/plugins/builtin/target/nomad/plugin/plugin.go
+++ b/plugins/builtin/target/nomad/plugin/plugin.go
@@ -65,7 +65,8 @@ type TargetPlugin struct {
 	statusHandlersLock sync.RWMutex
 
 	// gcRunning indicates whether the GC loop is running or not.
-	gcRunning bool
+	gcRunning     bool
+	gcRunningLock sync.RWMutex
 }
 
 // namespacedJobID encapsulates the namespace and jobID, which together make a
@@ -85,6 +86,8 @@ func NewNomadPlugin(log hclog.Logger) *TargetPlugin {
 
 // SetConfig satisfies the SetConfig function on the base.Base interface.
 func (t *TargetPlugin) SetConfig(config map[string]string) error {
+	t.gcRunningLock.RLock()
+	defer t.gcRunningLock.RUnlock()
 
 	if !t.gcRunning {
 		go t.garbageCollectionLoop()
@@ -189,7 +192,10 @@ func (t *TargetPlugin) garbageCollectionLoop() {
 
 	// Setup the ticker and set that the loop is now running.
 	ticker := time.NewTicker(garbageCollectionSecondInterval * time.Second)
+
+	t.gcRunningLock.Lock()
 	t.gcRunning = true
+	t.gcRunningLock.Unlock()
 
 	for range ticker.C {
 		t.logger.Debug("triggering run of handler garbage collection")

--- a/plugins/manager/manager.go
+++ b/plugins/manager/manager.go
@@ -110,7 +110,10 @@ func (pm *PluginManager) Reload(newCfg map[string][]*config.Plugin) error {
 	}
 
 	for _, pID := range pluginsToStop {
+		// Stop current plugin instance.
 		pm.killPlugin(pID)
+
+		// And remove its configuration.
 		pm.pluginsLock.Lock()
 		delete(pm.plugins, pID)
 		pm.pluginsLock.Unlock()

--- a/policy/manager.go
+++ b/policy/manager.go
@@ -141,8 +141,12 @@ LOOP:
 	// of relying on the deferred statements, otherwise the next iteration of
 	// m.Run would be executed before they are complete.
 	m.stopHandlers()
-	m.handlers = make(map[PolicyID]*Handler)
 	cancel()
+
+	// Make sure we start the next iteration with an empty map of handlers.
+	m.lock.Lock()
+	m.handlers = make(map[PolicyID]*Handler)
+	m.lock.Unlock()
 
 	// Delay the next iteration of m.Run to avoid re-runs to start too often.
 	time.Sleep(10 * time.Second)


### PR DESCRIPTION
This PR expands the effect of sending a `SIGHUP` signal to reload the Autoscaler configuration.

It specifically reloads plugin configurations, stops/starts plugins if their blocks are removed/added, and updates instances of Nomad clients (withing plugins and the policy source).

Other configuration values are also updated in memory, but have no effect (for example, increasing the number of workers for a queue).

Closes  #375 