### PR TITLE
agent: return req error if prometheus metrics are disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 BUG FIXES:
+ * agent: Only allow querying Prometheus formatted metrics if Prometheus is enabled within the config [[GH-416](https://github.com/hashicorp/nomad-autoscaler/pull/416)]
  * policy: Ensure metric emitters use the correct context and are stopped when appropriate [[GH-408](https://github.com/hashicorp/nomad-autoscaler/pull/408)]
 
 ## 0.3.0 (February 25, 2021)

--- a/agent/http/agent_test.go
+++ b/agent/http/agent_test.go
@@ -26,7 +26,7 @@ func TestServer_agentReload(t *testing.T) {
 		},
 	}
 
-	srv, stopSrv := TestServer(t)
+	srv, stopSrv := TestServer(t, false)
 	defer stopSrv()
 
 	for _, tc := range testCases {

--- a/agent/http/health_test.go
+++ b/agent/http/health_test.go
@@ -41,7 +41,7 @@ func TestServer_getHealth(t *testing.T) {
 	}
 
 	// Create our HTTP server.
-	srv, stopSrv := TestServer(t)
+	srv, stopSrv := TestServer(t, false)
 	defer stopSrv()
 
 	for _, tc := range testCases {

--- a/agent/http/metrics.go
+++ b/agent/http/metrics.go
@@ -25,6 +25,12 @@ func (s *Server) getMetrics(w http.ResponseWriter, r *http.Request) (interface{}
 	}
 
 	if format := r.URL.Query().Get("format"); format == "prometheus" {
+
+		// Only return Prometheus formatted metrics if the user has enabled
+		// this functionality.
+		if !s.promEnabled {
+			return nil, newCodedError(http.StatusUnsupportedMediaType, "Prometheus is not enabled")
+		}
 		s.getPrometheusMetrics().ServeHTTP(w, r)
 		return nil, nil
 	}

--- a/agent/http/server.go
+++ b/agent/http/server.go
@@ -51,6 +51,10 @@ type Server struct {
 	mux *http.ServeMux
 	srv *http.Server
 
+	// promEnabled tracks whether Prometheus formatted metrics should be
+	// enabled.
+	promEnabled bool
+
 	// aliveness is used to describe the health response and should be set
 	// atomically using healthAlivenessReady and healthAlivenessUnavailable
 	// const declarations.
@@ -62,12 +66,13 @@ type Server struct {
 }
 
 // NewHTTPServer creates a new agent HTTP server.
-func NewHTTPServer(debug bool, cfg *config.HTTP, log hclog.Logger, agent AgentHTTP) (*Server, error) {
+func NewHTTPServer(debug, prom bool, cfg *config.HTTP, log hclog.Logger, agent AgentHTTP) (*Server, error) {
 
 	srv := &Server{
-		log:   log.Named("http_server"),
-		mux:   http.NewServeMux(),
-		agent: agent,
+		log:         log.Named("http_server"),
+		mux:         http.NewServeMux(),
+		agent:       agent,
+		promEnabled: prom,
 	}
 
 	// Setup our handlers.

--- a/agent/http/testing.go
+++ b/agent/http/testing.go
@@ -8,13 +8,13 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/agent/config"
 )
 
-func TestServer(t *testing.T) (*Server, func()) {
+func TestServer(t *testing.T, enableProm bool) (*Server, func()) {
 	cfg := &config.HTTP{
 		BindAddress: "127.0.0.1",
 		BindPort:    0, // Use next available port.
 	}
 
-	s, err := NewHTTPServer(false, cfg, hclog.NewNullLogger(), &agent.MockAgentHTTP{})
+	s, err := NewHTTPServer(false, enableProm, cfg, hclog.NewNullLogger(), &agent.MockAgentHTTP{})
 	if err != nil {
 		t.Fatalf("failed to start test server: %v", err)
 	}

--- a/command/agent.go
+++ b/command/agent.go
@@ -267,7 +267,8 @@ func (c *AgentCommand) Run(args []string) int {
 
 	// create and run agent and HTTP server
 	c.agent = agent.NewAgent(parsedConfig, configPaths, logger)
-	httpServer, err := agentHTTP.NewHTTPServer(parsedConfig.EnableDebug, parsedConfig.HTTP, logger, c.agent)
+	httpServer, err := agentHTTP.NewHTTPServer(
+		parsedConfig.Telemetry.PrometheusMetrics, parsedConfig.EnableDebug, parsedConfig.HTTP, logger, c.agent)
 	if err != nil {
 		logger.Error("failed to setup HTTP getHealth server", "error", err)
 		return 1


### PR DESCRIPTION
If the user has disabled Prometheus metrics and a request is
sent to the metrics endpoint requesting Prometheus formatted
metrics, then the request should fail.

The returned response code copies that of Consul and Nomad,
to provide a consistent user experience.

closes #398 