### PR TITLE
add CLI flags for PolicyEval config

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -131,7 +131,9 @@ Policy Evaluation Options:
 
   -policy-eval-workers=<key:value>
     The number of workers to initialize for each queue, formatted as
-    <queue1>:<num>,<queue2>:<num>.
+    <queue1>:<num>,<queue2>:<num>. Nomad Autoscaler supports "cluster" and
+	"horizontal" queues. Nomad Autoscaler Enterprise supports additional
+	"vertical_mem" and "vertical_cpu" queues.
 
 Telemetry Options:
 

--- a/command/agent.go
+++ b/command/agent.go
@@ -129,7 +129,7 @@ Policy Evaluation Options:
   -policy-eval-delivery-limit=<num>
     The maximum number of times a policy evaluation can be dequeued from the broker.
 
-  -policy-eval-workers
+  -policy-eval-workers=<key:value>
     The number of workers to initialize for each queue, formatted as
     <queue1>:<num>,<queue2>:<num>.
 

--- a/sdk/helper/flag/flag.go
+++ b/sdk/helper/flag/flag.go
@@ -1,6 +1,8 @@
 package flag
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -31,3 +33,30 @@ func (f FuncDurationVar) Set(s string) error {
 }
 func (f FuncDurationVar) String() string   { return "" }
 func (f FuncDurationVar) IsBoolFlag() bool { return false }
+
+// FuncMapStringIngVar is a type of flag that accepts a function, converts the
+// user's value to a map[string]int, and then calls the given function.
+// User input should be in the <k1>:<v1>,<k2>:<v2>,... format.
+type FuncMapStringIngVar func(m map[string]int) error
+
+func (f FuncMapStringIngVar) Set(s string) error {
+	m := make(map[string]int)
+
+	for _, kv := range strings.Split(s, ",") {
+		parts := strings.Split(kv, ":")
+		if len(parts) != 2 {
+			return fmt.Errorf("%q should be in <key>:<value> format", kv)
+		}
+
+		k := parts[0]
+		v, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return fmt.Errorf("%q is not a number", parts[1])
+		}
+
+		m[k] = v
+	}
+	return f(m)
+}
+
+func (f FuncMapStringIngVar) String() string { return "" }

--- a/sdk/helper/flag/flag_test.go
+++ b/sdk/helper/flag/flag_test.go
@@ -28,3 +28,20 @@ func TestFuncDurationVar(t *testing.T) {
 	assert.Equal(t, "", sv.String())
 	assert.False(t, sv.IsBoolFlag())
 }
+
+func TestFuncMapStringIntVar(t *testing.T) {
+	var result map[string]int
+
+	sv := FuncMapStringIngVar(func(m map[string]int) error {
+		result = m
+		return nil
+	})
+	err := sv.Set("a:1,b:2")
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]int{"a": 1, "b": 2}, result)
+	assert.Equal(t, "", sv.String())
+
+	err = sv.Set("a:invalid")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
The `EvaluateAfter` config will be moved to a new configuration block, so it was left out of this PR.

Closes #291 