### PR TITLE
plugin/target/aws-asg: use single ASG call rather than split ASG/EC2 on scale-in.

### DIFF
--- a/plugins/builtin/target/aws-asg/plugin/aws_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws_test.go
@@ -4,9 +4,71 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils"
 	"github.com/hashicorp/nomad/api"
 	"github.com/stretchr/testify/assert"
 )
+
+func Test_instancesBelongToASG(t *testing.T) {
+	testCases := []struct {
+		inputASG            *autoscaling.AutoScalingGroup
+		inputIDs            []scaleutils.NodeResourceID
+		expectedOutputList  []string
+		expectedOutputError error
+		name                string
+	}{
+		{
+			inputASG: &autoscaling.AutoScalingGroup{
+				Instances: []autoscaling.Instance{
+					{InstanceId: aws.String("i-08d2c60605d210f51")},
+					{InstanceId: aws.String("i-08d2c60605d210f52")},
+					{InstanceId: aws.String("i-08d2c60605d210f53")},
+					{InstanceId: aws.String("i-08d2c60605d210f54")},
+					{InstanceId: aws.String("i-08d2c60605d210f55")},
+				},
+			},
+			inputIDs: []scaleutils.NodeResourceID{
+				{RemoteResourceID: "i-08d2c60605d210f51"},
+				{RemoteResourceID: "i-08d2c60605d210f54"},
+			},
+			expectedOutputList: []string{
+				"i-08d2c60605d210f51",
+				"i-08d2c60605d210f54",
+			},
+			expectedOutputError: nil,
+			name:                "multiple matches with zero failure",
+		},
+		{
+			inputASG: &autoscaling.AutoScalingGroup{
+				Instances: []autoscaling.Instance{
+					{InstanceId: aws.String("i-08d2c60605d210f51")},
+					{InstanceId: aws.String("i-08d2c60605d210f52")},
+					{InstanceId: aws.String("i-08d2c60605d210f53")},
+					{InstanceId: aws.String("i-08d2c60605d210f54")},
+					{InstanceId: aws.String("i-08d2c60605d210f55")},
+				},
+			},
+			inputIDs: []scaleutils.NodeResourceID{
+				{RemoteResourceID: "i-08d2c60605d210f51"},
+				{RemoteResourceID: "i-08d2c60605d210f54"},
+				{RemoteResourceID: "i-08d2c60605d210f58"},
+			},
+			expectedOutputList:  nil,
+			expectedOutputError: errors.New("1 selected nodes are not found within ASG"),
+			name:                "multiple matches with zero failure",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualList, actualErr := instancesBelongToASG(tc.inputASG, tc.inputIDs)
+			assert.Equal(t, tc.expectedOutputList, actualList, tc.name)
+			assert.Equal(t, tc.expectedOutputError, actualErr, tc.name)
+		})
+	}
+}
 
 func Test_awsNodeIDMap(t *testing.T) {
 	testCases := []struct {

--- a/plugins/builtin/target/aws-asg/plugin/event.go
+++ b/plugins/builtin/target/aws-asg/plugin/event.go
@@ -16,7 +16,6 @@ type scalingEvent string
 
 const (
 	scalingEventDrain     scalingEvent = "drain"
-	scalingEventDetach    scalingEvent = "detach"
 	scalingEventTerminate scalingEvent = "terminate"
 )
 

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/plugins"
 	"github.com/hashicorp/nomad-autoscaler/plugins/base"
@@ -52,7 +51,6 @@ type TargetPlugin struct {
 	config map[string]string
 	logger hclog.Logger
 	asg    *autoscaling.Client
-	ec2    *ec2.Client
 
 	// clusterUtils provides general cluster scaling utilities for querying the
 	// state of nodes pools and performing scaling tasks.

--- a/plugins/builtin/target/aws-asg/plugin/status.go
+++ b/plugins/builtin/target/aws-asg/plugin/status.go
@@ -1,0 +1,129 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils"
+)
+
+// instanceTerminationResult tracks the state when performing a scale in action
+// and helps account for the nature of the AWS API which only accepts a single
+// instanceID per request.
+type instanceTerminationResult struct {
+	failed  []instanceFailure
+	success []instanceSuccess
+}
+
+// instanceSuccess tracks the details of an instance whose terminate API call
+// returned an error.
+type instanceFailure struct {
+	instance scaleutils.NodeResourceID
+	err      error
+}
+
+// instanceSuccess tracks the details of an instance whose terminate API call
+// completed successfully.
+type instanceSuccess struct {
+	instance   scaleutils.NodeResourceID
+	activityID *string
+}
+
+// logResults is a convenience function that logs all the currently held status
+// details to their appropriate logging level.
+func (i *instanceTerminationResult) logResults(log hclog.Logger) {
+
+	for _, success := range i.success {
+		log.Debug("successfully terminated instance in ASG",
+			"instance_id", success.instance.RemoteResourceID, "node_id", success.instance.NomadNodeID)
+	}
+
+	for _, failure := range i.failed {
+		log.Error("failed to terminate instance in ASG",
+			"instance_id", failure.instance.RemoteResourceID, "node_id", failure.instance.NomadNodeID,
+			"error", failure.err)
+	}
+}
+
+// Error satisfies the error interface, outputting all errors in a nicely
+// formatted string.
+func (i *instanceTerminationResult) Error() string {
+	if i.lenFailure() < 1 {
+		return ""
+	}
+
+	points := make([]string, i.lenFailure())
+	for i, err := range i.failed {
+		points[i] = fmt.Sprintf(
+			"failed to terminate node %s with AWS ID %s: %v",
+			err.instance.NomadNodeID, err.instance.RemoteResourceID, err.err)
+	}
+	return strings.Join(points, ", ")
+}
+
+// errorOrNil returns a new error if the result contains error entries, or nil
+// if there are not any.
+func (i *instanceTerminationResult) errorOrNil() error {
+	if i.lenFailure() < 1 {
+		return nil
+	}
+	return errors.New(i.Error())
+}
+
+// activityIDs returns a list of AWS AutoScaling activity IDs which were
+// generated as a result of terminating instances.
+func (i *instanceTerminationResult) activityIDs() []string {
+
+	if i.lenSuccess() < 1 {
+		return nil
+	}
+
+	activityIDs := make([]string, i.lenSuccess())
+	for i, id := range i.success {
+		activityIDs[i] = *id.activityID
+	}
+	return activityIDs
+}
+
+// successfulIDs returns the list of instances which were unsuccessfully
+// terminated.
+func (i *instanceTerminationResult) failedIDs() []scaleutils.NodeResourceID {
+
+	if i.lenFailure() < 1 {
+		return nil
+	}
+
+	ids := make([]scaleutils.NodeResourceID, i.lenFailure())
+	for i, inst := range i.failed {
+		ids[i] = inst.instance
+	}
+	return ids
+}
+
+// successfulIDs returns the list of instances which were successfully
+// terminated.
+func (i *instanceTerminationResult) successfulIDs() []scaleutils.NodeResourceID {
+
+	if i.lenSuccess() < 1 {
+		return nil
+	}
+
+	ids := make([]scaleutils.NodeResourceID, i.lenSuccess())
+	for i, inst := range i.success {
+		ids[i] = inst.instance
+	}
+	return ids
+}
+
+func (i *instanceTerminationResult) appendFailure(err instanceFailure) {
+	i.failed = append(i.failed, err)
+}
+
+func (i *instanceTerminationResult) appendSuccess(inf instanceSuccess) {
+	i.success = append(i.success, inf)
+}
+
+func (i *instanceTerminationResult) lenFailure() int { return len(i.failed) }
+func (i *instanceTerminationResult) lenSuccess() int { return len(i.success) }

--- a/plugins/builtin/target/aws-asg/plugin/status_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/status_test.go
@@ -1,0 +1,448 @@
+package plugin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_instanceTerminationResult_Error(t *testing.T) {
+	testCases := []struct {
+		inputResult    *instanceTerminationResult
+		expectedOutput string
+		name           string
+	}{
+		{
+			inputResult:    &instanceTerminationResult{},
+			expectedOutput: "",
+			name:           "empty input result",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				failed: []instanceFailure{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						err: errors.New("this is the error you're looking for"),
+					},
+				},
+			},
+			expectedOutput: "failed to terminate node 711eb2aa-48cc-2dc7-32fa-b359878121cd with AWS ID i-08d2c60605d210f57: this is the error you're looking for",
+			name:           "single input result error",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				failed: []instanceFailure{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						err: errors.New("this is the error you're looking for"),
+					},
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121ce",
+							RemoteResourceID: "i-08d2c60605d210f58",
+						},
+						err: errors.New("this isn't the error you're looking for"),
+					},
+				},
+			},
+			expectedOutput: "failed to terminate node 711eb2aa-48cc-2dc7-32fa-b359878121cd with AWS ID i-08d2c60605d210f57: this is the error you're looking for, failed to terminate node 711eb2aa-48cc-2dc7-32fa-b359878121ce with AWS ID i-08d2c60605d210f58: this isn't the error you're looking for",
+			name:           "multiple input result error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputResult.Error(), tc.name)
+		})
+	}
+}
+
+func Test_instanceTerminationResult_errorOrNil(t *testing.T) {
+	testCases := []struct {
+		inputResult    *instanceTerminationResult
+		expectedOutput error
+		name           string
+	}{
+		{
+			inputResult:    &instanceTerminationResult{},
+			expectedOutput: nil,
+			name:           "no errors",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				failed: []instanceFailure{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						err: errors.New("this is the error you're looking for"),
+					},
+				},
+			},
+			expectedOutput: errors.New("failed to terminate node 711eb2aa-48cc-2dc7-32fa-b359878121cd with AWS ID i-08d2c60605d210f57: this is the error you're looking for"),
+			name:           "error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputResult.errorOrNil(), tc.name)
+		})
+	}
+}
+
+func Test_instanceTerminationResult_activityIDs(t *testing.T) {
+	testCases := []struct {
+		inputResult    *instanceTerminationResult
+		expectedOutput []string
+		name           string
+	}{
+		{
+			inputResult:    &instanceTerminationResult{},
+			expectedOutput: nil,
+			name:           "empty result",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				success: []instanceSuccess{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						activityID: aws.String("f9f2d65b-f1f2-43e7-b46d-d86756459690"),
+					},
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cf",
+							RemoteResourceID: "i-08d2c60605d210f59",
+						},
+						activityID: aws.String("f9f2d65b-f1f2-43e7-b46d-d86756459691"),
+					},
+				},
+				failed: []instanceFailure{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121ce",
+							RemoteResourceID: "i-08d2c60605d210f58",
+						},
+						err: errors.New("this is the error you're looking for"),
+					},
+				},
+			},
+			expectedOutput: []string{
+				"f9f2d65b-f1f2-43e7-b46d-d86756459690",
+				"f9f2d65b-f1f2-43e7-b46d-d86756459691",
+			},
+			name: "failed and success within result",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputResult.activityIDs(), tc.name)
+		})
+	}
+}
+
+func Test_instanceTerminationResult_failedIDs(t *testing.T) {
+	testCases := []struct {
+		inputResult    *instanceTerminationResult
+		expectedOutput []scaleutils.NodeResourceID
+		name           string
+	}{
+		{
+			inputResult:    &instanceTerminationResult{},
+			expectedOutput: nil,
+			name:           "empty input result",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				failed: []instanceFailure{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						err: errors.New("this is the error you're looking for"),
+					},
+				},
+			},
+			expectedOutput: []scaleutils.NodeResourceID{
+				{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+					RemoteResourceID: "i-08d2c60605d210f57",
+				},
+			},
+			name: "single entry",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				failed: []instanceFailure{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						err: errors.New("this is the error you're looking for"),
+					},
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121ce",
+							RemoteResourceID: "i-08d2c60605d210f58",
+						},
+						err: errors.New("this isn't the error you're looking for"),
+					},
+				},
+			},
+			expectedOutput: []scaleutils.NodeResourceID{
+				{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+					RemoteResourceID: "i-08d2c60605d210f57",
+				},
+				{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121ce",
+					RemoteResourceID: "i-08d2c60605d210f58",
+				},
+			},
+			name: "multiple entries",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputResult.failedIDs(), tc.name)
+		})
+	}
+}
+
+func Test_instanceTerminationResult_successfulIDs(t *testing.T) {
+	testCases := []struct {
+		inputResult    *instanceTerminationResult
+		expectedOutput []scaleutils.NodeResourceID
+		name           string
+	}{
+		{
+			inputResult:    &instanceTerminationResult{},
+			expectedOutput: nil,
+			name:           "empty input result",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				success: []instanceSuccess{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						activityID: aws.String("f9f2d65b-f1f2-43e7-b46d-d86756459690"),
+					},
+				},
+			},
+			expectedOutput: []scaleutils.NodeResourceID{
+				{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+					RemoteResourceID: "i-08d2c60605d210f57",
+				},
+			},
+			name: "single entry",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				success: []instanceSuccess{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						activityID: aws.String("f9f2d65b-f1f2-43e7-b46d-d86756459690"),
+					},
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121ce",
+							RemoteResourceID: "i-08d2c60605d210f58",
+						},
+						activityID: aws.String("f9f2d65b-f1f2-43e7-b46d-d86756459691"),
+					},
+				},
+			},
+			expectedOutput: []scaleutils.NodeResourceID{
+				{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+					RemoteResourceID: "i-08d2c60605d210f57",
+				},
+				{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121ce",
+					RemoteResourceID: "i-08d2c60605d210f58",
+				},
+			},
+			name: "multiple entries",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputResult.successfulIDs(), tc.name)
+		})
+	}
+}
+
+func Test_instanceTerminationResult_appendFailure(t *testing.T) {
+	testCases := []struct {
+		inputResult *instanceTerminationResult
+		inputErr    instanceFailure
+		name        string
+	}{
+		{
+			inputResult: &instanceTerminationResult{},
+			inputErr: instanceFailure{
+				instance: scaleutils.NodeResourceID{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cb",
+					RemoteResourceID: "i-08d2c60605d210f56",
+				},
+				err: errors.New("this isn't the error you're looking for"),
+			},
+			name: "empty input result",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				failed: []instanceFailure{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						err: errors.New("this is the error you're looking for"),
+					},
+				},
+			},
+			inputErr: instanceFailure{
+				instance: scaleutils.NodeResourceID{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cb",
+					RemoteResourceID: "i-08d2c60605d210f56",
+				},
+				err: errors.New("this isn't the error you're looking for"),
+			},
+			name: "non-empty input result",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.inputResult.appendFailure(tc.inputErr)
+			assert.Contains(t, tc.inputResult.failed, tc.inputErr, tc.name)
+		})
+	}
+}
+
+func Test_instanceTerminationResult_appendSuccess(t *testing.T) {
+	testCases := []struct {
+		inputResult *instanceTerminationResult
+		inputInf    instanceSuccess
+		name        string
+	}{
+		{
+			inputResult: &instanceTerminationResult{},
+			inputInf: instanceSuccess{
+				instance: scaleutils.NodeResourceID{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cb",
+					RemoteResourceID: "i-08d2c60605d210f56",
+				},
+				activityID: aws.String("f9f2d65b-f1f2-43e7-b46d-d86756459699"),
+			},
+			name: "empty input result",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				success: []instanceSuccess{
+					{
+						instance: scaleutils.NodeResourceID{
+							NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cd",
+							RemoteResourceID: "i-08d2c60605d210f57",
+						},
+						activityID: aws.String("f9f2d65b-f1f2-43e7-b46d-d86756459690"),
+					},
+				},
+			},
+			inputInf: instanceSuccess{
+				instance: scaleutils.NodeResourceID{
+					NomadNodeID:      "711eb2aa-48cc-2dc7-32fa-b359878121cb",
+					RemoteResourceID: "i-08d2c60605d210f56",
+				},
+				activityID: aws.String("f9f2d65b-f1f2-43e7-b46d-d86756459699"),
+			},
+			name: "non-empty input result",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.inputResult.appendSuccess(tc.inputInf)
+			assert.Contains(t, tc.inputResult.success, tc.inputInf, tc.name)
+		})
+	}
+}
+
+func Test_instanceTerminationResult_lenFailure(t *testing.T) {
+	testCases := []struct {
+		inputResult    *instanceTerminationResult
+		expectedOutput int
+		name           string
+	}{
+		{
+			inputResult:    &instanceTerminationResult{},
+			expectedOutput: 0,
+			name:           "empty input result",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				failed: make([]instanceFailure, 13),
+			},
+			expectedOutput: 13,
+			name:           "non-zero input result",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputResult.lenFailure(), tc.name)
+		})
+	}
+}
+
+func Test_instanceTerminationResult_lenSuccess(t *testing.T) {
+	testCases := []struct {
+		inputResult    *instanceTerminationResult
+		expectedOutput int
+		name           string
+	}{
+		{
+			inputResult:    &instanceTerminationResult{},
+			expectedOutput: 0,
+			name:           "empty input result",
+		},
+		{
+			inputResult: &instanceTerminationResult{
+				success: make([]instanceSuccess, 13),
+			},
+			expectedOutput: 13,
+			name:           "non-zero input result",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputResult.lenSuccess(), tc.name)
+		})
+	}
+}

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -64,7 +64,7 @@ func (c *ClusterScaleUtils) RunPreScaleInTasks(ctx context.Context, cfg map[stri
 		return nil, errors.New("required ClusterNodeIDLookupFunc not set")
 	}
 
-	nodes, err := c.identifyScaleInNodes(cfg, num)
+	nodes, err := c.IdentifyScaleInNodes(cfg, num)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (c *ClusterScaleUtils) RunPreScaleInTasks(ctx context.Context, cfg map[stri
 	// Technically we do not need this information until after the nodes have
 	// been drained. However, this doesn't change cluster state and so do this
 	// first to make sure there are no issues in translating.
-	nodeResourceIDs, err := c.identifyScaleInRemoteIDs(nodes)
+	nodeResourceIDs, err := c.IdentifyScaleInRemoteIDs(nodes)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (c *ClusterScaleUtils) RunPreScaleInTasks(ctx context.Context, cfg map[stri
 	// Drain the nodes.
 	// TODO(jrasell) we should try some reconciliation here, where we identify
 	//  failed nodes and continue with nodes that drained successfully.
-	if err := c.drainNodes(ctx, cfg, nodeResourceIDs); err != nil {
+	if err := c.DrainNodes(ctx, cfg, nodeResourceIDs); err != nil {
 		return nil, err
 	}
 	c.log.Info("pre scale-in tasks now complete")
@@ -88,7 +88,7 @@ func (c *ClusterScaleUtils) RunPreScaleInTasks(ctx context.Context, cfg map[stri
 	return nodeResourceIDs, nil
 }
 
-func (c *ClusterScaleUtils) identifyScaleInNodes(cfg map[string]string, num int) ([]*api.NodeListStub, error) {
+func (c *ClusterScaleUtils) IdentifyScaleInNodes(cfg map[string]string, num int) ([]*api.NodeListStub, error) {
 
 	// The Nomad Autoscaler can only handle node class identifiers currently
 	// and therefore we just set that up. In the future if we wish to expand on
@@ -152,7 +152,7 @@ func (c *ClusterScaleUtils) identifyScaleInNodes(cfg map[string]string, num int)
 	return out, nil
 }
 
-func (c *ClusterScaleUtils) identifyScaleInRemoteIDs(nodes []*api.NodeListStub) ([]NodeResourceID, error) {
+func (c *ClusterScaleUtils) IdentifyScaleInRemoteIDs(nodes []*api.NodeListStub) ([]NodeResourceID, error) {
 
 	var (
 		out  []NodeResourceID

--- a/sdk/helper/scaleutils/node_drain.go
+++ b/sdk/helper/scaleutils/node_drain.go
@@ -17,10 +17,10 @@ const (
 	defaultNodeIgnoreSystemJobs = false
 )
 
-// drainNodes iterates the provided nodeID list and performs a drain on each
+// DrainNodes iterates the provided nodeID list and performs a drain on each
 // one. Each node drain is monitored and events logged until the context is
 // closed or all drains reach a terminal state.
-func (c *ClusterScaleUtils) drainNodes(ctx context.Context, cfg map[string]string, nodes []NodeResourceID) error {
+func (c *ClusterScaleUtils) DrainNodes(ctx context.Context, cfg map[string]string, nodes []NodeResourceID) error {
 
 	drainSpec, err := drainSpec(cfg)
 	if err != nil {
@@ -150,4 +150,20 @@ func (c *ClusterScaleUtils) monitorNodeDrain(ctx context.Context, nodeID string,
 		}
 	}
 	return ctx.Err()
+}
+
+// RunPostScaleInTasksOnFailure is a utility that runs tasks on nodes which
+// were unable to be successfully terminated. The current tasks are:
+//
+//   - modify node eligibility to true
+func (c *ClusterScaleUtils) RunPostScaleInTasksOnFailure(nodes []NodeResourceID) {
+	for _, node := range nodes {
+		resp, err := c.client.Nodes().ToggleEligibility(node.NomadNodeID, true, nil)
+		if err != nil {
+			c.log.Error("failed to toggle node eligibility", "error", err)
+			continue
+		}
+		c.log.Info("successfully toggled node eligibility",
+			"node_id", node.NomadNodeID, "evals", resp.EvalIDs)
+	}
 }


### PR DESCRIPTION
closes #361 
closes #412 

This changes the AWS ASG plugin to use `TerminateInstanceInAutoScalingGroup` when scaling in nodes rather than a call against the ASG to detach instances and then another to terminate instances. This solves a core bug, whereby decrementing an ASG accepts a maximum of 20 instance IDs.

The downside of moving to this function, is that unlike Azure and GCP, AWS ASG only accepts a single instance ID per call to terminate an instance from an ASG. In order to accommodate this, the plugin includes some additional logic in order to understand and correctly respond to situations where, in a single scaling event, some termination calls might succeed, and others might fail. This creates a partial success. In partial success situations, the plugin attempts to toggle the eligibility on the instances that failed to terminate, in order to reconcile the node pool.

When performing the AWS API call, the ASG name does not need to be passed. This creates a potential situation where a node is misconfigured to reside in the pool. To counter this, before scaling in, the plugin ensures all selected instances do in-fact belong to the target ASG. This has resulted in exporting the functions that were hidden behind the scaleutils `RunPreScaleInTasks` so the workflow can be better controlled.