### PR TITLE
Make `query` optional inside checks

### DIFF
--- a/policy/nomad/test-fixtures/src/strategy-without-metric.hcl
+++ b/policy/nomad/test-fixtures/src/strategy-without-metric.hcl
@@ -1,0 +1,28 @@
+job "strategy-without-metric" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  group "test" {
+    scaling {
+      max = 10
+
+      policy {
+        check "check" {
+          strategy "fixed-value" {
+            int_config  = 2
+            bool_config = true
+            str_config  = "str"
+          }
+        }
+      }
+    }
+
+    task "echo" {
+      driver = "raw_exec"
+      config {
+        command = "echo"
+        args    = ["hi"]
+      }
+    }
+  }
+}

--- a/policy/nomad/test-fixtures/strategy-without-metric.json.golden
+++ b/policy/nomad/test-fixtures/strategy-without-metric.json.golden
@@ -1,0 +1,170 @@
+{
+  "Job": {
+    "Affinities": null,
+    "AllAtOnce": false,
+    "Constraints": null,
+    "ConsulToken": "",
+    "CreateIndex": 10,
+    "Datacenters": [
+      "dc1"
+    ],
+    "Dispatched": false,
+    "ID": "strategy-without-metric",
+    "JobModifyIndex": 10,
+    "Meta": null,
+    "Migrate": null,
+    "ModifyIndex": 14,
+    "Multiregion": null,
+    "Name": "strategy-without-metric",
+    "Namespace": "default",
+    "NomadTokenID": "",
+    "ParameterizedJob": null,
+    "ParentID": "",
+    "Payload": null,
+    "Periodic": null,
+    "Priority": 50,
+    "Region": "global",
+    "Reschedule": null,
+    "Spreads": null,
+    "Stable": false,
+    "Status": "dead",
+    "StatusDescription": "",
+    "Stop": false,
+    "SubmitTime": 1617295837558199000,
+    "TaskGroups": [
+      {
+        "Affinities": null,
+        "Constraints": null,
+        "Count": 1,
+        "EphemeralDisk": {
+          "Migrate": false,
+          "SizeMB": 300,
+          "Sticky": false
+        },
+        "Meta": null,
+        "Migrate": null,
+        "Name": "test",
+        "Networks": null,
+        "ReschedulePolicy": {
+          "Attempts": 1,
+          "Delay": 5000000000,
+          "DelayFunction": "constant",
+          "Interval": 86400000000000,
+          "MaxDelay": 0,
+          "Unlimited": false
+        },
+        "RestartPolicy": {
+          "Attempts": 3,
+          "Delay": 15000000000,
+          "Interval": 86400000000000,
+          "Mode": "fail"
+        },
+        "Scaling": {
+          "CreateIndex": 10,
+          "Enabled": true,
+          "ID": "id",
+          "Max": 10,
+          "Min": 1,
+          "ModifyIndex": 10,
+          "Namespace": "",
+          "Policy": {
+            "check": [
+              {
+                "check": [
+                  {
+                    "strategy": [
+                      {
+                        "fixed-value": [
+                          {
+                            "bool_config": true,
+                            "int_config": 2,
+                            "str_config": "str"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "Target": {
+            "Namespace": "default",
+            "Job": "strategy-without-metric",
+            "Group": "test"
+          },
+          "Type": "horizontal"
+        },
+        "Services": null,
+        "ShutdownDelay": null,
+        "Spreads": null,
+        "StopAfterClientDisconnect": null,
+        "Tasks": [
+          {
+            "Affinities": null,
+            "Artifacts": null,
+            "Config": {
+              "command": "echo",
+              "args": [
+                "hi"
+              ]
+            },
+            "Constraints": null,
+            "DispatchPayload": null,
+            "Driver": "raw_exec",
+            "Env": null,
+            "KillSignal": "",
+            "KillTimeout": 5000000000,
+            "Kind": "",
+            "Leader": false,
+            "Lifecycle": null,
+            "LogConfig": {
+              "MaxFileSizeMB": 10,
+              "MaxFiles": 10
+            },
+            "Meta": null,
+            "Name": "echo",
+            "Resources": {
+              "CPU": 100,
+              "Devices": null,
+              "DiskMB": 0,
+              "IOPS": 0,
+              "MemoryMB": 300,
+              "Networks": null
+            },
+            "RestartPolicy": {
+              "Attempts": 3,
+              "Delay": 15000000000,
+              "Interval": 86400000000000,
+              "Mode": "fail"
+            },
+            "ScalingPolicies": null,
+            "Services": null,
+            "ShutdownDelay": 0,
+            "Templates": null,
+            "User": "",
+            "Vault": null,
+            "VolumeMounts": null
+          }
+        ],
+        "Update": null,
+        "Volumes": null
+      }
+    ],
+    "Type": "batch",
+    "Update": {
+      "AutoPromote": false,
+      "AutoRevert": false,
+      "Canary": 0,
+      "HealthCheck": "",
+      "HealthyDeadline": 0,
+      "MaxParallel": 0,
+      "MinHealthyTime": 0,
+      "ProgressDeadline": 0,
+      "Stagger": 0
+    },
+    "VaultNamespace": "",
+    "VaultToken": "",
+    "Version": 0
+  }
+}

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -5,11 +5,18 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad-autoscaler/plugins"
 	"github.com/hashicorp/nomad-autoscaler/sdk/helper/ptr"
 	"github.com/hashicorp/nomad/api"
 )
 
 type validatorFunc func(in map[string]interface{}, path string) error
+type validatorWithLabelFunc func(in map[string]interface{}, path string, label string) error
+
+// nonMetricStrategies is a set of strategies that do not require an APM
+var nonMetricStrategies = map[string]bool{
+	plugins.InternalStrategyFixedValue: true,
+}
 
 // validateScalingPolicy validates an api.ScalingPolicy object from the Nomad API
 func validateScalingPolicy(policy *api.ScalingPolicy) error {
@@ -159,7 +166,7 @@ func validateChecks(in map[string]interface{}, path string) error {
 //      }
 //    }
 //  }
-func validateCheck(c map[string]interface{}, path string) error {
+func validateCheck(c map[string]interface{}, path string, label string) error {
 	var result *multierror.Error
 
 	if c == nil {
@@ -168,8 +175,8 @@ func validateCheck(c map[string]interface{}, path string) error {
 
 	// Validate Source, if present.
 	//   1. Source value must be a string if defined.
-	source, ok := c[keySource]
-	if ok {
+	source, sourceOk := c[keySource]
+	if sourceOk {
 		_, ok := source.(string)
 		if !ok {
 			result = multierror.Append(result, fmt.Errorf("%s.%s must be string, found %T", path, keySource, source))
@@ -179,8 +186,8 @@ func validateCheck(c map[string]interface{}, path string) error {
 	// Validate Query.
 	//   1. Query must have string value.
 	//   2. Query must not be empty.
-	query, ok := c[keyQuery]
-	if ok {
+	query, queryOk := c[keyQuery]
+	if queryOk {
 		queryStr, ok := query.(string)
 		if !ok {
 			result = multierror.Append(result, fmt.Errorf("%s.%s must be string, found %T", path, keyQuery, query))
@@ -200,11 +207,17 @@ func validateCheck(c map[string]interface{}, path string) error {
 		}
 	}
 
+	// Some strategy plugins do not require an APM
+	strategyValidator := validateStrategy
+	if !queryOk && !sourceOk {
+		strategyValidator = validateStrategyWithoutAPM
+	}
+
 	// Validate Strategy.
 	//   1. Strategy key must exist.
 	//   2. Strategy must be a valid block.
 	//   3. Only 1 Strategy allowed.
-	strategyErrs := validateBlocks(c[keyStrategy], path+"."+keyStrategy, validateStrategy)
+	strategyErrs := validateBlocks(c[keyStrategy], path+"."+keyStrategy, strategyValidator)
 	if strategyErrs != nil {
 		result = multierror.Append(result, strategyErrs)
 	}
@@ -232,6 +245,21 @@ func validateCheck(c map[string]interface{}, path string) error {
 //   3. Block structure should be valid.
 func validateStrategy(s map[string]interface{}, path string) error {
 	return validateLabeledBlocks(s, path, ptr.IntToPtr(1), ptr.IntToPtr(1), nil)
+}
+
+// validateStrategyWithoutAPM accounts for the strategies that do not require an APM,
+//
+// Validation rules:
+//   1. Strategy does not require source
+//   2. Strategy does not require query
+func validateStrategyWithoutAPM(s map[string]interface{}, path string) error {
+	validator := func(in map[string]interface{}, path string, label string) error {
+		if _, ok := nonMetricStrategies[label]; ok {
+			return nil
+		}
+		return fmt.Errorf("%s strategy requires a query", path)
+	}
+	return validateLabeledBlocks(s, path, ptr.IntToPtr(1), ptr.IntToPtr(1), validator)
 }
 
 // validateDuration validates if the input has a valid time.Duration format.
@@ -378,7 +406,7 @@ func validateBlocks(in interface{}, path string, validator validatorFunc) error 
 //       }
 //     }
 //   }
-func validateLabeledBlocks(b map[string]interface{}, path string, min, max *int, validator validatorFunc) error {
+func validateLabeledBlocks(b map[string]interface{}, path string, min, max *int, validator validatorWithLabelFunc) error {
 	var result *multierror.Error
 
 	if b == nil {
@@ -408,7 +436,13 @@ func validateLabeledBlocks(b map[string]interface{}, path string, min, max *int,
 
 		// Validate block content.
 		//   1. Content must be a block.
-		if err := validateBlock(block, fmt.Sprintf("%s[%s]", path, name), validator); err != nil {
+		if err := validateBlock(block, fmt.Sprintf("%s[%s]", path, name),
+			func(in map[string]interface{}, path string) error {
+				if validator == nil {
+					return nil
+				}
+				return validator(in, path, name)
+		}); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}

--- a/policy/nomad/validate_horizontal.go
+++ b/policy/nomad/validate_horizontal.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 )
 
+
 func validateHorizontalPolicy(policy *api.ScalingPolicy) error {
 	var result *multierror.Error
 
@@ -49,14 +50,7 @@ func validateChecksHorizontal(in map[string]interface{}, path string) error {
 	return validateLabeledBlocks(in, path, ptr.IntToPtr(1), nil, validateCheckHorizontal)
 }
 
-func validateCheckHorizontal(c map[string]interface{}, path string) error {
-	var result *multierror.Error
-
-	// Validate Query.
-	//   1. Query key must exist.
-	if _, ok := c[keyQuery]; !ok {
-		result = multierror.Append(result, fmt.Errorf("%s.%s is missing", path, keyQuery))
-	}
-
-	return result.ErrorOrNil()
+func validateCheckHorizontal(c map[string]interface{}, path string, label string) error {
+	// Nothing to check at this time
+	return nil
 }

--- a/policy/nomad/validate_horizontal.go
+++ b/policy/nomad/validate_horizontal.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/nomad/api"
 )
 
-
 func validateHorizontalPolicy(policy *api.ScalingPolicy) error {
 	var result *multierror.Error
 

--- a/policy/nomad/validate_test.go
+++ b/policy/nomad/validate_test.go
@@ -279,6 +279,11 @@ func Test_validateScalingPolicy(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:        "policy.check.strategy without metrics",
+			inputFile:   "strategy-without-metric",
+			expectError: false,
+		},
+		{
 			name: "policy.check.strategy.name is empty",
 			input: &api.ScalingPolicy{
 				ID:   "id",

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -148,7 +148,7 @@ type FileDecodePolicyDoc struct {
 type FileDecodePolicyCheckDoc struct {
 	Name           string `hcl:"name,label"`
 	Source         string `hcl:"source,optional"`
-	Query          string `hcl:"query"`
+	Query          string `hcl:"query,optional"`
 	QueryWindow    time.Duration
 	QueryWindowHCL string                 `hcl:"query_window,optional"`
 	Strategy       *ScalingPolicyStrategy `hcl:"strategy,block"`


### PR DESCRIPTION
Some strategy plugins don't require an APM query result (for example, `fixed-value`), so the PRs modifies the scaling policy validation rules to allow checks without a `query`.