### PR TITLE
Return no-op scaling action when there are no metrics

### DIFF
--- a/plugins/builtin/strategy/pass-through/plugin/plugin.go
+++ b/plugins/builtin/strategy/pass-through/plugin/plugin.go
@@ -61,8 +61,6 @@ func (s *StrategyPlugin) PluginInfo() (*base.PluginInfo, error) {
 
 // Run satisfies the Run function on the strategy.Strategy interface.
 func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sdk.ScalingCheckEvaluation, error) {
-
-	// This shouldn't happen, but check it just in case.
 	if len(eval.Metrics) == 0 {
 		eval.Action.Direction = sdk.ScaleDirectionNone
 		return eval, nil

--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -73,6 +73,10 @@ func (s *StrategyPlugin) PluginInfo() (*base.PluginInfo, error) {
 
 // Run satisfies the Run function on the strategy.Strategy interface.
 func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sdk.ScalingCheckEvaluation, error) {
+	if len(eval.Metrics) == 0 {
+		eval.Action.Direction = sdk.ScaleDirectionNone
+		return eval, nil
+	}
 
 	// Read and parse target value from req.Config.
 	t := eval.Check.Strategy.Config[runConfigKeyTarget]
@@ -97,11 +101,6 @@ func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sd
 	}
 
 	var factor float64
-
-	// This shouldn't happen, but check it just in case.
-	if len(eval.Metrics) == 0 {
-		return nil, nil
-	}
 
 	// Use only the latest value for now.
 	metric := eval.Metrics[len(eval.Metrics)-1]

--- a/plugins/builtin/strategy/target-value/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin_test.go
@@ -37,9 +37,11 @@ func TestStrategyPlugin_Run(t *testing.T) {
 	}{
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 13}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{},
 				},
+				Action: &sdk.ScalingAction{},
 			},
 			expectedResp:  nil,
 			expectedError: fmt.Errorf("missing required field `target`"),
@@ -47,11 +49,13 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 13}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "not-the-float-you're-looking-for"},
 					},
 				},
+				Action: &sdk.ScalingAction{},
 			},
 			expectedResp:  nil,
 			expectedError: fmt.Errorf("invalid value for `target`: not-the-float-you're-looking-for (string)"),
@@ -59,6 +63,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{
+				Metrics: sdk.TimestampedMetrics{sdk.TimestampedMetric{Value: 13}},
 				Check: &sdk.ScalingPolicyCheck{
 					Strategy: &sdk.ScalingPolicyStrategy{
 						Config: map[string]string{"target": "0", "threshold": "not-the-float-you're-looking-for"},
@@ -68,6 +73,31 @@ func TestStrategyPlugin_Run(t *testing.T) {
 			expectedResp:  nil,
 			expectedError: fmt.Errorf("invalid value for `threshold`: not-the-float-you're-looking-for (string)"),
 			name:          "incorrect input strategy config threshold value",
+		},
+		{
+			inputEval: &sdk.ScalingCheckEvaluation{
+				Metrics: sdk.TimestampedMetrics{},
+				Check: &sdk.ScalingPolicyCheck{
+					Strategy: &sdk.ScalingPolicyStrategy{
+						Config: map[string]string{"target": "13"},
+					},
+				},
+				Action: &sdk.ScalingAction{},
+			},
+			inputCount: 2,
+			expectedResp: &sdk.ScalingCheckEvaluation{
+				Metrics: sdk.TimestampedMetrics{},
+				Check: &sdk.ScalingPolicyCheck{
+					Strategy: &sdk.ScalingPolicyStrategy{
+						Config: map[string]string{"target": "13"},
+					},
+				},
+				Action: &sdk.ScalingAction{
+					Direction: sdk.ScaleDirectionNone,
+				},
+			},
+			expectedError: nil,
+			name:          "empty metrics",
 		},
 		{
 			inputEval: &sdk.ScalingCheckEvaluation{


### PR DESCRIPTION
With [`query` being optional](#442), there's a possibility that strategy plugins are called with empty metric results. So return a no-op scaling action.