### PR TITLE
new policy.Source for filtering policies for HA capability

### DIFF
--- a/policy/ha/filter.go
+++ b/policy/ha/filter.go
@@ -14,7 +14,7 @@ type MonitorFilterRequest struct {
 // PolicyFilter defines the interface for policy filters
 // used by the autoscaler's HA capability.
 type PolicyFilter interface {
-	// MonitorFilter accepts a context and a channel for informing the caller
+	// MonitorFilterUpdates accepts a context and a channel for informing the caller
 	// of asynchronous updates to the underlying filter.
 	MonitorFilterUpdates(ctx context.Context, req MonitorFilterRequest)
 	// ReloadFilterMonitor indicates that the filter should be reloaded

--- a/policy/ha/filter.go
+++ b/policy/ha/filter.go
@@ -1,0 +1,27 @@
+package ha
+
+import (
+	"context"
+
+	"github.com/hashicorp/nomad-autoscaler/policy"
+)
+
+type MonitorFilterRequest struct {
+	ErrCh    chan<- error
+	UpdateCh chan<- struct{}
+}
+
+// PolicyFilter defines the interface for policy filters
+// used by the autoscaler's HA capability.
+type PolicyFilter interface {
+	// MonitorFilter accepts a context and a channel for informing the caller
+	// of asynchronous updates to the underlying filter.
+	MonitorFilterUpdates(ctx context.Context, req MonitorFilterRequest)
+	// ReloadFilterMonitor indicates that the filter should be reloaded
+	// due to potential changes to configuration and/or clients.
+	ReloadFilterMonitor()
+	// FilterPolicies should return a list of policies appropriate for this
+	// autoscaler agent; policies for other autoscaler agents in the HA pool
+	// should be neglected from the returned slice.
+	FilterPolicies(policyIDs []policy.PolicyID) []policy.PolicyID
+}

--- a/policy/ha/source.go
+++ b/policy/ha/source.go
@@ -1,0 +1,120 @@
+package ha
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/policy"
+)
+
+// NewFilteredSource accepts an upstream policy.Source and an ha.PolicyFilter
+// and constructs a FilteredSource
+func NewFilteredSource(log hclog.Logger, upstreamSource policy.Source, filter PolicyFilter) policy.Source {
+	return &FilteredSource{
+		log:            log,
+		upstreamSource: upstreamSource,
+		policyFilter:   filter,
+		filterCond:     sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+// FilteredSource is a policy.Source which accepts policy IDs from an upstream
+// policy.Source and filters them through an ha.PolicyFilter
+type FilteredSource struct {
+	log            hclog.Logger
+	upstreamSource policy.Source
+	policyFilter   PolicyFilter
+	filterCond     *sync.Cond
+}
+
+// MonitorIDs calls the same method on the configured upstream policy.Source,
+// and filters the discovered policy IDs using the configured PolicyFilter.
+func (fs *FilteredSource) MonitorIDs(ctx context.Context, req policy.MonitorIDsReq) {
+	if fs.upstreamSource == nil || fs.policyFilter == nil {
+		return
+	}
+
+	// buffer both of these channels, to prevent the goroutines below from
+	// blocking on send between checks of ctx.Done()
+	upstreamPolicyCh := make(chan policy.IDMessage, 1)
+	filterUpdateCh := make(chan struct{}, 1)
+	// create separate error channels just for augmenting the log messages
+	policyErrCh := make(chan error, 1)
+	filterErrCh := make(chan error, 1)
+
+	go fs.upstreamSource.MonitorIDs(ctx, policy.MonitorIDsReq{
+		ErrCh:    policyErrCh,
+		ResultCh: upstreamPolicyCh,
+	})
+	go fs.policyFilter.MonitorFilterUpdates(ctx, MonitorFilterRequest{
+		ErrCh:    filterErrCh,
+		UpdateCh: filterUpdateCh,
+	})
+
+	// keep track of the previous policyIDs, in case the filter updates
+	var policyIDs []policy.PolicyID
+	// don't emit policy IDs until both the  filter and the upstream policy
+	// source have sent their first update
+	haveFirstPolicies, haveFirstFilter := false, false
+	for {
+		select {
+		case <-ctx.Done():
+			fs.log.Trace("stopping file policy source ID monitor")
+			return
+
+		case err := <-policyErrCh:
+			if err == nil {
+				continue
+			}
+			req.ErrCh <- fmt.Errorf("error from upstream policy source monitor: %v", err)
+			continue
+
+		case err := <-filterErrCh:
+			if err == nil {
+				continue
+			}
+			req.ErrCh <- fmt.Errorf("error from policy filter monitor: %v", err)
+			continue
+
+		case newUpstreamIDs := <-upstreamPolicyCh:
+			policyIDs = newUpstreamIDs.IDs
+			haveFirstPolicies = true
+
+		case <-filterUpdateCh:
+			haveFirstFilter = true
+		}
+
+		if !haveFirstPolicies || !haveFirstFilter {
+			continue
+		}
+
+		newPolicyIDs := fs.policyFilter.FilterPolicies(policyIDs)
+		fs.log.Trace("filtered policies", "original_len", len(policyIDs), "filtered_len", len(newPolicyIDs))
+		req.ResultCh <- policy.IDMessage{
+			IDs:    newPolicyIDs,
+			Source: fs.Name(),
+		}
+	}
+}
+
+// MonitorPolicy calls the same method on the configured policy.Source.
+// This method doesn't need to worry about the policy filter, because the policy.Manager
+// will close the context if the corresponding policy is removed.
+func (fs *FilteredSource) MonitorPolicy(ctx context.Context, req policy.MonitorPolicyReq) {
+	fs.log.Trace("delegating MonitorPolicy", "policy_id", req.ID)
+	fs.upstreamSource.MonitorPolicy(ctx, req)
+}
+
+// Name satisfies the Name function of the policy.Source interface.
+func (fs *FilteredSource) Name() policy.SourceName {
+	return policy.SourceNameHA
+}
+
+// ReloadIDsMonitor implements policy.Source by calling the appropriate
+// reload method on the underlying policy source and filter.
+func (fs *FilteredSource) ReloadIDsMonitor() {
+	fs.upstreamSource.ReloadIDsMonitor()
+	fs.policyFilter.ReloadFilterMonitor()
+}

--- a/policy/ha/source_test.go
+++ b/policy/ha/source_test.go
@@ -1,0 +1,195 @@
+package ha
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/nomad-autoscaler/policy"
+)
+
+// TestFilteredSource_MonitorIDs_FilterInput tests that MonitorIDs
+// filters the upstream policy IDs
+func TestFilteredSource_MonitorIDs_FilterInput(t *testing.T) {
+	require := require.New(t)
+
+	monitorCtx, monitorCancel := context.WithCancel(context.Background())
+
+	inputCh := make(chan policy.IDMessage)
+	errCh := make(chan error)
+	testFilter := NewTesterFilter(nil)
+	testSource := NewTestSource(inputCh, errCh)
+
+	source := NewFilteredSource(hclog.NewNullLogger(), testSource, testFilter)
+	outputCh := make(chan policy.IDMessage)
+	outputErrCh := make(chan error)
+	monitorExited := false
+	go func() {
+		source.MonitorIDs(monitorCtx, policy.MonitorIDsReq{
+			ErrCh:    outputErrCh,
+			ResultCh: outputCh,
+		})
+		monitorExited = true
+	}()
+
+	// send the message from the upstream
+	expected := []policy.PolicyID{
+		"abcde",
+		"a1234",
+		"aaaaa",
+	}
+	unexpected := []policy.PolicyID{
+		"badbad",
+		"zzzzzz",
+		"123456",
+	}
+	go func() {
+		inputCh <- policy.IDMessage{
+			IDs:    append(expected, unexpected...),
+			Source: "test",
+		}
+	}()
+
+	// should not receive a message before BOTH filter and upstream have messaged
+	select {
+	case <-outputCh:
+		require.Fail("received message before filter sent message")
+	case <-time.After(2 * time.Second):
+	}
+
+	// now set the filter
+	testFilter.UpdateFilter(startsWith("a"))
+
+	// check that the policies returned from upstream are filtered
+	select {
+	case results := <-outputCh:
+		require.ElementsMatch(expected, results.IDs)
+	case <-time.After(2 * time.Second):
+		require.Fail("timed out waiting for output message")
+	}
+
+	// update the filter, should get new entries
+	testFilter.UpdateFilter(startsWith("z"))
+	select {
+	case results := <-outputCh:
+		require.ElementsMatch([]policy.PolicyID{"zzzzzz"}, results.IDs)
+	case <-time.After(2 * time.Second):
+		require.Fail("timed out waiting for output message")
+	}
+
+	// check that MonitorIDs returns on context cancel
+	monitorCancel()
+	require.Eventually(func() bool {
+		return monitorExited
+	}, 5*time.Second, 1*time.Second)
+}
+
+// TestFilteredSource_MonitorIDs_Errors tests that MonitorIDs
+// propagates errors from the underlying policy source and
+// filter.
+func TestFilteredSource_MonitorIDs_Errors(t *testing.T) {
+	require := require.New(t)
+
+	filterErrCh := make(chan error)
+	testFilter := NewTesterFilter(filterErrCh)
+	upstreamErrCh := make(chan error)
+	testSource := NewTestSource(make(chan policy.IDMessage), upstreamErrCh)
+
+	source := NewFilteredSource(hclog.NewNullLogger(), testSource, testFilter)
+	outputErrCh := make(chan error)
+	go source.MonitorIDs(context.Background(), policy.MonitorIDsReq{
+		ErrCh:    outputErrCh,
+		ResultCh: make(chan policy.IDMessage),
+	})
+
+	// set the filter to anything
+	testFilter.UpdateFilter(startsWith(""))
+
+	// send an error from the filter
+	go func() {
+		filterErrCh <- errors.New("filter_error")
+	}()
+
+	// check that the policies returned from policy filter are propagated
+	select {
+	case err := <-outputErrCh:
+		require.EqualError(err, "error from policy filter monitor: filter_error")
+	case <-time.After(2 * time.Second):
+		require.Fail("timed out waiting for filter error")
+	}
+
+	// send an error from the upstream source
+	go func() {
+		upstreamErrCh <- errors.New("source_error")
+	}()
+
+	// check that the policies returned from upstream policy source are propagated
+	select {
+	case err := <-outputErrCh:
+		require.EqualError(err, "error from upstream policy source monitor: source_error")
+	case <-time.After(2 * time.Second):
+		require.Fail("timed out waiting for source error")
+	}
+}
+
+// TestFilteredSource_Reload verifies that reload will, at least,
+// call the ReloadFilterMonitor() method on the ha.PolicyFilter
+func TestFilteredSource_Reload(t *testing.T) {
+	require := require.New(t)
+
+	inputCh := make(chan policy.IDMessage)
+	errCh := make(chan error)
+	testFilter := NewTesterFilter(nil)
+	testSource := NewTestSource(inputCh, errCh)
+
+	source := NewFilteredSource(hclog.NewNullLogger(), testSource, testFilter)
+	outputCh := make(chan policy.IDMessage)
+	outputErrCh := make(chan error)
+	go source.MonitorIDs(context.Background(), policy.MonitorIDsReq{
+		ErrCh:    outputErrCh,
+		ResultCh: outputCh,
+	})
+
+	// send the message from the upstream
+	expected := []policy.PolicyID{
+		"abcde",
+		"a1234",
+		"aaaaa",
+	}
+	unexpected := []policy.PolicyID{
+		"badbad",
+		"zzzzzz",
+		"123456",
+	}
+	go func() {
+		inputCh <- policy.IDMessage{
+			IDs:    append(expected, unexpected...),
+			Source: "test",
+		}
+	}()
+	// set the filter
+	testFilter.UpdateFilter(startsWith("a"))
+
+	// check that the policies returned from upstream are filtered
+	select {
+	case results := <-outputCh:
+		require.ElementsMatch(expected, results.IDs)
+	case <-time.After(2 * time.Second):
+		require.Fail("timed out waiting for output message")
+	}
+
+	// call reload, this should trigger another message send
+	source.ReloadIDsMonitor()
+
+	// check that the policies returned from upstream are filtered
+	select {
+	case results := <-outputCh:
+		require.ElementsMatch(expected, results.IDs)
+	case <-time.After(2 * time.Second):
+		require.Fail("timed out waiting for output message")
+	}
+}

--- a/policy/ha/source_test.go
+++ b/policy/ha/source_test.go
@@ -7,9 +7,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/nomad-autoscaler/policy"
+	"github.com/stretchr/testify/require"
 )
 
 // TestFilteredSource_MonitorIDs_FilterInput tests that MonitorIDs

--- a/policy/ha/testing_test.go
+++ b/policy/ha/testing_test.go
@@ -1,0 +1,134 @@
+package ha
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/nomad-autoscaler/policy"
+)
+
+// filterFunc is a simple function to return a list of desired PolicyID
+// from a larger list
+type filterFunc func(policies []policy.PolicyID) []policy.PolicyID
+
+// testFilter implements ha.PolicyFilter for the purpose of testing.
+// It adds a method UpdateFilter which persists the provided
+// filterFunc.
+type testFilter struct {
+	updatedCh chan struct{}
+	errCh     chan error
+
+	filter     filterFunc
+	filterLock *sync.RWMutex
+}
+
+// NewTestFilter returns a testFilter.
+// Before using, UpdateFilter must be called.
+func NewTesterFilter(errCh chan error) *testFilter {
+	return &testFilter{
+		updatedCh:  make(chan struct{}),
+		errCh:      errCh,
+		filter:     nil,
+		filterLock: &sync.RWMutex{},
+	}
+}
+
+// MonitorFilterUpdates fulfills the ha.PolicyFilter interface.
+// It returns a message on the provided channel when the filter is updated.
+func (f *testFilter) MonitorFilterUpdates(ctx context.Context, req MonitorFilterRequest) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-f.updatedCh:
+			req.UpdateCh <- struct{}{}
+		case err := <-f.errCh:
+			req.ErrCh <- err
+		}
+	}
+}
+
+// UpdateFilter is a method extended ha.PolicyFilter, used for testing
+// filter updates.
+func (f *testFilter) UpdateFilter(ff filterFunc) {
+	f.filterLock.Lock()
+	f.filter = ff
+	f.filterLock.Unlock()
+	f.updatedCh <- struct{}{}
+}
+
+// ReloadFilterMonitor implements ha.PolicyFilter
+// For the purpose of testing, this is equivalent to a filter update and
+// immediately sends a message to the caller of MonitorFilterUpdates
+func (f *testFilter) ReloadFilterMonitor() {
+	f.updatedCh <- struct{}{}
+}
+
+// FilterPolicies implements ha.PolicyFilter by applying the specified
+// filterFunc to the provided policies.
+func (f *testFilter) FilterPolicies(policyIDs []policy.PolicyID) []policy.PolicyID {
+	f.filterLock.RLock()
+	defer f.filterLock.RUnlock()
+	if f.filter == nil {
+		return policyIDs
+	}
+	return f.filter(policyIDs)
+}
+
+// startsWith is a filterFunc which accepts any PolicyID which starts with the
+// configured string.
+func startsWith(prefix string) filterFunc {
+	return func(input []policy.PolicyID) []policy.PolicyID {
+		output := make([]policy.PolicyID, 0)
+		for _, pid := range input {
+			if strings.HasPrefix(pid.String(), prefix) {
+				output = append(output, pid)
+			}
+		}
+		return output
+	}
+}
+
+// testSource is a test implementation of source.Policy, which simply passes
+// messages/errors from input channels to output channels.
+type testSource struct {
+	inputCh chan policy.IDMessage
+	errCh   chan error
+}
+
+// NewTestSource returns a policy.Source for testing, which simply echoes
+// policy.IDMessage messages from the inputCh to the result channel on
+// MonitorIDs
+func NewTestSource(inputCh chan policy.IDMessage, errCh chan error) policy.Source {
+	return &testSource{
+		inputCh: inputCh,
+		errCh:   errCh,
+	}
+}
+
+func (t *testSource) MonitorIDs(ctx context.Context, req policy.MonitorIDsReq) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-t.inputCh:
+			req.ResultCh <- msg
+		case err := <-t.errCh:
+			req.ErrCh <- err
+		}
+	}
+}
+
+func (t *testSource) MonitorPolicy(ctx context.Context, req policy.MonitorPolicyReq) {
+	panic("implement me")
+}
+
+func (t *testSource) Name() policy.SourceName {
+	return "test-source"
+}
+
+// ReloadIDsMonitor is a no-op
+func (t *testSource) ReloadIDsMonitor() {
+	return
+}

--- a/policy/ha/testing_test.go
+++ b/policy/ha/testing_test.go
@@ -130,5 +130,4 @@ func (t *testSource) Name() policy.SourceName {
 
 // ReloadIDsMonitor is a no-op
 func (t *testSource) ReloadIDsMonitor() {
-	return
 }

--- a/policy/source.go
+++ b/policy/source.go
@@ -46,6 +46,8 @@ type Source interface {
 	ReloadIDsMonitor()
 }
 
+// PolicyID contains identifying information about a policy, as returned by
+// policy.Source.MonitorIDs()
 type PolicyID string
 
 // String satisfies the Stringer interface.
@@ -65,6 +67,9 @@ const (
 
 	// SourceNameFile is the source for policies that are loaded from disk.
 	SourceNameFile SourceName = "file"
+
+	// SourceNameFiltered is the source for HA policy sources
+	SourceNameHA SourceName = "ha"
 )
 
 // HandleSourceError provides common functionality when a policy source

--- a/policy/source.go
+++ b/policy/source.go
@@ -68,7 +68,7 @@ const (
 	// SourceNameFile is the source for policies that are loaded from disk.
 	SourceNameFile SourceName = "file"
 
-	// SourceNameFiltered is the source for HA policy sources
+	// SourceNameHA is the source for HA policy sources
 	SourceNameHA SourceName = "ha"
 )
 


### PR DESCRIPTION
this provides a new `policy.Source`, which accepts a policy filter and an upstream `policy.Source` and applies the filter to the results of `MonitorIDs` on the upstream.