### PR TITLE
chore: don't use fmt.Errorf when not formatting the error.

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -727,7 +728,7 @@ func (pw *PolicyEval) validate() *multierror.Error {
 	prefix := "policy_workers ->"
 
 	if pw.DeliveryLimitPtr != nil && pw.DeliveryLimit <= 0 {
-		result = multierror.Append(result, fmt.Errorf("delivery_limit must be bigger than 0"))
+		result = multierror.Append(result, errors.New("delivery_limit must be bigger than 0"))
 	}
 
 	for k, v := range pw.Workers {

--- a/plugins/builtin/apm/prometheus/plugin/plugin.go
+++ b/plugins/builtin/apm/prometheus/plugin/plugin.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -204,7 +205,7 @@ func parseSample(s interface{}) (sdk.TimestampedMetric, error) {
 	valFloat := float64(val)
 	// Check whether the sample value is an IEEE 754 not-a-number value.
 	if math.IsNaN(valFloat) {
-		return result, fmt.Errorf("query result value is not-a-number")
+		return result, errors.New("query result value is not-a-number")
 	}
 
 	tsTime := time.Unix(int64(ts)/1e3, 0)

--- a/plugins/builtin/strategy/fixed-value/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/fixed-value/plugin/plugin_test.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -41,7 +41,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 				},
 			},
 			expectedResp:  nil,
-			expectedError: fmt.Errorf("missing required field `value`"),
+			expectedError: errors.New("missing required field `value`"),
 			name:          "incorrect strategy input config",
 		},
 		{
@@ -53,7 +53,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 				},
 			},
 			expectedResp:  nil,
-			expectedError: fmt.Errorf("invalid value for `value`: not-the-int-you're-looking-for (string)"),
+			expectedError: errors.New("invalid value for `value`: not-the-int-you're-looking-for (string)"),
 			name:          "incorrect input strategy config fixed value - string",
 		},
 		{

--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -81,7 +82,7 @@ func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sd
 	// Read and parse target value from req.Config.
 	t := eval.Check.Strategy.Config[runConfigKeyTarget]
 	if t == "" {
-		return nil, fmt.Errorf("missing required field `target`")
+		return nil, errors.New("missing required field `target`")
 	}
 
 	target, err := strconv.ParseFloat(t, 64)

--- a/plugins/builtin/strategy/target-value/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin_test.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -44,7 +44,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 				Action: &sdk.ScalingAction{},
 			},
 			expectedResp:  nil,
-			expectedError: fmt.Errorf("missing required field `target`"),
+			expectedError: errors.New("missing required field `target`"),
 			name:          "incorrect strategy input config",
 		},
 		{
@@ -58,7 +58,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 				Action: &sdk.ScalingAction{},
 			},
 			expectedResp:  nil,
-			expectedError: fmt.Errorf("invalid value for `target`: not-the-float-you're-looking-for (string)"),
+			expectedError: errors.New("invalid value for `target`: not-the-float-you're-looking-for (string)"),
 			name:          "incorrect input strategy config target value",
 		},
 		{
@@ -71,7 +71,7 @@ func TestStrategyPlugin_Run(t *testing.T) {
 				},
 			},
 			expectedResp:  nil,
-			expectedError: fmt.Errorf("invalid value for `threshold`: not-the-float-you're-looking-for (string)"),
+			expectedError: errors.New("invalid value for `threshold`: not-the-float-you're-looking-for (string)"),
 			name:          "incorrect input strategy config threshold value",
 		},
 		{

--- a/plugins/builtin/target/gce-mig/plugin/gce.go
+++ b/plugins/builtin/target/gce-mig/plugin/gce.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -117,7 +118,7 @@ func (t *TargetPlugin) ensureInstanceGroupIsStable(ctx context.Context, group in
 		if stable || err != nil {
 			return true, err
 		} else {
-			return false, fmt.Errorf("waiting for instance group to become stable")
+			return false, errors.New("waiting for instance group to become stable")
 		}
 	}
 

--- a/plugins/builtin/target/nomad/plugin/state_test.go
+++ b/plugins/builtin/target/nomad/plugin/state_test.go
@@ -1,7 +1,7 @@
 package nomad
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -33,10 +33,10 @@ func Test_jobStateHandler_status(t *testing.T) {
 		name           string
 	}{
 		{
-			inputJSH:       &jobScaleStatusHandler{scaleStatusError: fmt.Errorf("this is an error message")},
+			inputJSH:       &jobScaleStatusHandler{scaleStatusError: errors.New("this is an error message")},
 			inputGroup:     "test",
 			expectedReturn: nil,
-			expectedError:  fmt.Errorf("this is an error message"),
+			expectedError:  errors.New("this is an error message"),
 			name:           "job status response currently in error",
 		},
 		{
@@ -54,7 +54,7 @@ func Test_jobStateHandler_status(t *testing.T) {
 			},
 			inputGroup:     "this-doesnt-exist",
 			expectedReturn: nil,
-			expectedError:  fmt.Errorf("task group \"this-doesnt-exist\" not found"),
+			expectedError:  errors.New("task group \"this-doesnt-exist\" not found"),
 			name:           "job group not found within scale status task groups",
 		},
 		{
@@ -125,9 +125,9 @@ func Test_jobStateHandler_updateStatusState(t *testing.T) {
 	assert.Greater(t, newTimestamp, int64(0))
 
 	// Write a second update and ensure it is persisted.
-	jsh.updateStatusState(nil, fmt.Errorf("oh no, something went wrong"))
+	jsh.updateStatusState(nil, errors.New("oh no, something went wrong"))
 	assert.Greater(t, jsh.lastUpdated, newTimestamp)
-	assert.Equal(t, fmt.Errorf("oh no, something went wrong"), jsh.scaleStatusError)
+	assert.Equal(t, errors.New("oh no, something went wrong"), jsh.scaleStatusError)
 	assert.Nil(t, jsh.scaleStatus)
 }
 

--- a/policy/handler.go
+++ b/policy/handler.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -245,7 +246,7 @@ func (h *Handler) generateEvaluation(policy *sdk.ScalingPolicy) (*sdk.ScalingEva
 	if policy == nil {
 		// Initial ticker ticked without a policy being set, assume we are not able
 		// to retrieve the policy and exit.
-		return nil, fmt.Errorf("timeout: failed to read policy in time")
+		return nil, errors.New("timeout: failed to read policy in time")
 	}
 
 	// Exit early if the policy is not enabled.

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -2,6 +2,7 @@ package nomad
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -241,7 +242,7 @@ func (s *Source) MonitorPolicy(ctx context.Context, req policy.MonitorPolicyReq)
 			errMsg := "policy validation failed"
 			if _, ok := err.(*multierror.Error); ok {
 				// Add new error message as first error item.
-				err = multierror.Append(fmt.Errorf(errMsg), err)
+				err = multierror.Append(errors.New(errMsg), err)
 			} else {
 				err = fmt.Errorf("%s: %v", errMsg, err)
 			}

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -24,17 +25,17 @@ func validateScalingPolicy(policy *api.ScalingPolicy) error {
 	var result *multierror.Error
 
 	if policy == nil {
-		return multierror.Append(result, fmt.Errorf("ScalingPolicy is nil"))
+		return multierror.Append(result, errors.New("ScalingPolicy is nil"))
 	}
 
 	// Validate ID.
 	if policy.ID == "" {
-		result = multierror.Append(result, fmt.Errorf("ID is empty"))
+		result = multierror.Append(result, errors.New("ID is empty"))
 	}
 
 	// Validate Target.
 	if policy.Target == nil {
-		result = multierror.Append(result, fmt.Errorf("Target is nil")) //lint:ignore ST1005 Target is a field value
+		result = multierror.Append(result, errors.New("Target is nil")) //lint:ignore ST1005 Target is a field value
 	}
 
 	// Validate Policy.

--- a/policy/nomad/validate_horizontal.go
+++ b/policy/nomad/validate_horizontal.go
@@ -1,7 +1,7 @@
 package nomad
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad-autoscaler/sdk/helper/ptr"
@@ -18,21 +18,21 @@ func validateHorizontalPolicy(policy *api.ScalingPolicy) error {
 	//   4. Max must not be nil.
 	//   5. Min must be smaller than Max.
 	if policy.Min == nil {
-		result = multierror.Append(result, fmt.Errorf("scaling.min is missing"))
+		result = multierror.Append(result, errors.New("scaling.min is missing"))
 	} else if policy.Max == nil {
-		result = multierror.Append(result, fmt.Errorf("scaling.max is missing"))
+		result = multierror.Append(result, errors.New("scaling.max is missing"))
 	} else {
 		min := *policy.Min
 		if min < 0 {
-			result = multierror.Append(result, fmt.Errorf("scaling.min can't be negative"))
+			result = multierror.Append(result, errors.New("scaling.min can't be negative"))
 		}
 
 		if min > *policy.Max {
-			result = multierror.Append(result, fmt.Errorf("scaling.min must be smaller than scaling.max"))
+			result = multierror.Append(result, errors.New("scaling.min must be smaller than scaling.max"))
 		}
 
 		if *policy.Max < 0 {
-			result = multierror.Append(result, fmt.Errorf("scaling.max can't be negative"))
+			result = multierror.Append(result, errors.New("scaling.max can't be negative"))
 		}
 	}
 

--- a/policy/nomad/validate_test.go
+++ b/policy/nomad/validate_test.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"testing"
@@ -551,7 +552,7 @@ func Test_validateBlock(t *testing.T) {
 				},
 			},
 			validator: func(in map[string]interface{}, path string) error {
-				return fmt.Errorf("error from validator")
+				return errors.New("error from validator")
 			},
 			expectError: true,
 		},
@@ -561,7 +562,7 @@ func Test_validateBlock(t *testing.T) {
 				"key": "value",
 			},
 			validator: func(in map[string]interface{}, path string) error {
-				return fmt.Errorf("error from validator")
+				return errors.New("error from validator")
 			},
 			expectError: true,
 		},

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -51,16 +52,16 @@ func (pr *Processor) ValidatePolicy(p *sdk.ScalingPolicy) error {
 	var mErr *multierror.Error
 
 	if p.ID == "" {
-		mErr = multierror.Append(mErr, fmt.Errorf("policy ID is empty"))
+		mErr = multierror.Append(mErr, errors.New("policy ID is empty"))
 	}
 	if p.Min < 0 {
-		mErr = multierror.Append(mErr, fmt.Errorf("policy Min can't be negative"))
+		mErr = multierror.Append(mErr, errors.New("policy Min can't be negative"))
 	}
 	if p.Max < 0 {
-		mErr = multierror.Append(mErr, fmt.Errorf("policy Max can't be negative"))
+		mErr = multierror.Append(mErr, errors.New("policy Max can't be negative"))
 	}
 	if p.Min > p.Max {
-		mErr = multierror.Append(mErr, fmt.Errorf("policy Min must not be greater Max"))
+		mErr = multierror.Append(mErr, errors.New("policy Min must not be greater Max"))
 	}
 
 	return mErr.ErrorOrNil()

--- a/policyeval/broker.go
+++ b/policyeval/broker.go
@@ -3,7 +3,7 @@ package policyeval
 import (
 	"container/heap"
 	"context"
-	"fmt"
+	"errors"
 	"sync"
 	"time"
 
@@ -263,15 +263,15 @@ func (b *Broker) Ack(evalID, token string) error {
 	// Lookup the unack'd eval.
 	unack, ok := b.unack[evalID]
 	if !ok {
-		return fmt.Errorf("evaluation ID not found")
+		return errors.New("evaluation ID not found")
 	}
 	if unack.Token != token {
-		return fmt.Errorf("token does not match for evaluation ID")
+		return errors.New("token does not match for evaluation ID")
 	}
 
 	// Ensure we were able to stop the timer.
 	if !unack.NackTimer.Stop() {
-		return fmt.Errorf("evaluation ID Ack'd after Nack timer expiration")
+		return errors.New("evaluation ID Ack'd after Nack timer expiration")
 	}
 
 	// Cleanup.
@@ -295,10 +295,10 @@ func (b *Broker) Nack(evalID, token string) error {
 	// Lookup the unack'd eval
 	unack, ok := b.unack[evalID]
 	if !ok {
-		return fmt.Errorf("evaluation ID not found")
+		return errors.New("evaluation ID not found")
 	}
 	if unack.Token != token {
-		return fmt.Errorf("token does not match for evaluation ID")
+		return errors.New("token does not match for evaluation ID")
 	}
 
 	logger = logger.With("policy_id", unack.Eval.Policy.ID)


### PR DESCRIPTION
Using the stdlib `errors.New` call to create errors that are not formatted is quicker and more memory efficient. This change therefore moves all non-formatted error creations to use this func.

Just imagine what we can achieve with the 80ns we save each time. 