### PR TITLE
scaleutils: add datacenter nodepool implementation

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/plugins"
 	nomadAPM "github.com/hashicorp/nomad-autoscaler/plugins/builtin/apm/nomad/plugin"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
+	errHelper "github.com/hashicorp/nomad-autoscaler/sdk/helper/error"
 )
 
 // Processor helps process policies and perform common actions on them when
@@ -64,7 +65,36 @@ func (pr *Processor) ValidatePolicy(p *sdk.ScalingPolicy) error {
 		mErr = multierror.Append(mErr, errors.New("policy Min must not be greater Max"))
 	}
 
+	if err := pr.validateHorizontalClusterPolicy(p); err != nil {
+		mErr = multierror.Append(mErr, err)
+	}
+
 	return mErr.ErrorOrNil()
+}
+
+// validateHorizontalClusterPolicy validates that the target config for a
+// horizontal cluster scaling policy is valid. Calling this function is safe in
+// situations where it is not known whether the policy is a horizontal cluster
+// target or not.
+func (pr *Processor) validateHorizontalClusterPolicy(p *sdk.ScalingPolicy) error {
+
+	// Protect against the policy not targeting a horizontal cluster target so
+	// callers don't have to perform this.
+	if !p.Target.IsNodePoolTarget() {
+		return nil
+	}
+
+	var mErr *multierror.Error
+
+	class := p.Target.Config[sdk.TargetConfigKeyClass]
+	dc := p.Target.Config[sdk.TargetConfigKeyDatacenter]
+
+	if class != "" && dc != "" {
+		mErr = multierror.Append(mErr, fmt.Errorf("target config must contain only one of %s",
+			strings.Join(sdk.TargetConfigConflictingClusterParams, ", ")))
+	}
+
+	return errHelper.FormattedMultiError(mErr)
 }
 
 // CanonicalizeCheck sets standardised values on fields.

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -78,6 +78,46 @@ func TestProcessor_ValidatePolicy(t *testing.T) {
 			},
 			name: "negative maximum value which is lower than minimum",
 		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
+				Min: 1,
+				Max: 10,
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"datacenter": "eu-east-17"},
+				},
+			},
+			expectedOutput: nil,
+			name:           "valid datacenter horizontal cluster scaling policy",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
+				Min: 1,
+				Max: 10,
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"node_class": "puppy"},
+				},
+			},
+			expectedOutput: nil,
+			name:           "valid node_class horizontal cluster scaling policy",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
+				Min: 1,
+				Max: 10,
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"node_class": "puppy", "datacenter": "eu-east-17"},
+				},
+			},
+			expectedOutput: &multierror.Error{
+				Errors: []error{
+					errors.New("target config must contain only one of datacenter, node_class"),
+				},
+			},
+			name: "invalid horizontal cluster scaling policy target config",
+		},
 	}
 
 	pr := Processor{}
@@ -86,6 +126,64 @@ func TestProcessor_ValidatePolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actualOutput := pr.ValidatePolicy(tc.inputPolicy)
 			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}
+
+func TestProcessor_validateHorizontalClusterPolicy(t *testing.T) {
+	testCases := []struct {
+		inputPolicy       *sdk.ScalingPolicy
+		expectedOutputErr error
+		name              string
+	}{
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"Job": "example", "Group": "cache"},
+				},
+			},
+			expectedOutputErr: nil,
+			name:              "non-horizontal cluster scaling policy target",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"node_class": "puppy"},
+				},
+			},
+			expectedOutputErr: nil,
+			name:              "node_class target policy",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"datacenter": "eu-west-13"},
+				},
+			},
+			expectedOutputErr: nil,
+			name:              "datacenter target policy",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"datacenter": "eu-west-13", "node_class": "puppy"},
+				},
+			},
+			expectedOutputErr: errors.New(`target config must contain only one of datacenter, node_class`),
+			name:              "datacenter and node_class configured target policy",
+		},
+	}
+
+	pr := Processor{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutputErr := pr.validateHorizontalClusterPolicy(tc.inputPolicy)
+			if tc.expectedOutputErr != nil {
+				assert.EqualError(t, tc.expectedOutputErr, actualOutputErr.Error(), tc.name)
+			} else {
+				assert.Nil(t, actualOutputErr)
+			}
 		})
 	}
 }

--- a/sdk/helper/scaleutils/cluster_test.go
+++ b/sdk/helper/scaleutils/cluster_test.go
@@ -1,42 +1,10 @@
 package scaleutils
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils/nodepool"
 	"github.com/stretchr/testify/assert"
 )
-
-func Test_classClusterPoolIdentifier(t *testing.T) {
-	testCases := []struct {
-		inputCfg            map[string]string
-		expectedOutputPI    nodepool.ClusterNodePoolIdentifier
-		expectedOutputError error
-		name                string
-	}{
-		{
-			inputCfg:            map[string]string{},
-			expectedOutputPI:    nil,
-			expectedOutputError: errors.New(`required config param "node_class" not set`),
-			name:                "node_class cfg param not set",
-		},
-		{
-			inputCfg:            map[string]string{"node_class": "my_pet_server"},
-			expectedOutputPI:    nodepool.NewNodeClassPoolIdentifier("my_pet_server"),
-			expectedOutputError: nil,
-			name:                "node_class cfg param set",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actualPI, actualError := classClusterPoolIdentifier(tc.inputCfg)
-			assert.Equal(t, tc.expectedOutputPI, actualPI, tc.name)
-			assert.Equal(t, tc.expectedOutputError, actualError, tc.name)
-		})
-	}
-}
 
 func Test_autoscalerNodeID(t *testing.T) {
 	testCases := []struct {

--- a/sdk/helper/scaleutils/node_identifier_test.go
+++ b/sdk/helper/scaleutils/node_identifier_test.go
@@ -6,6 +6,7 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	errHelper "github.com/hashicorp/nomad-autoscaler/sdk/helper/error"
+	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils/nodepool"
 	"github.com/hashicorp/nomad/api"
 	"github.com/stretchr/testify/assert"
 )
@@ -313,7 +314,7 @@ func Test_FilterNodes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			idFn, err := classClusterPoolIdentifier(tc.inputIDCfg)
+			idFn, err := nodepool.NewClusterNodePoolIdentifier(tc.inputIDCfg)
 			assert.NotNil(t, idFn, tc.name)
 			assert.Nil(t, err, tc.name)
 

--- a/sdk/helper/scaleutils/nodepool/class.go
+++ b/sdk/helper/scaleutils/nodepool/class.go
@@ -1,6 +1,9 @@
 package nodepool
 
-import "github.com/hashicorp/nomad/api"
+import (
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/hashicorp/nomad/api"
+)
 
 // defaultClassIdentifier is the class value used when the nodes NodeClass is
 // empty.
@@ -29,7 +32,7 @@ func (n nodeClassClusterPoolIdentifier) IsPoolMember(node *api.NodeListStub) boo
 }
 
 // Key satisfies the Key function on the ClusterNodePoolIdentifier interface.
-func (n nodeClassClusterPoolIdentifier) Key() string { return "node_class" }
+func (n nodeClassClusterPoolIdentifier) Key() string { return sdk.TargetConfigKeyClass }
 
 // Value satisfies the Value function on the ClusterNodePoolIdentifier
 // interface.

--- a/sdk/helper/scaleutils/nodepool/class.go
+++ b/sdk/helper/scaleutils/nodepool/class.go
@@ -21,7 +21,7 @@ func NewNodeClassPoolIdentifier(id string) ClusterNodePoolIdentifier {
 	}
 }
 
-// NodeIsPoolMember satisfies the NodeIsPoolMember function on the
+// IsPoolMember satisfies the IsPoolMember function on the
 // ClusterNodePoolIdentifier interface.
 func (n nodeClassClusterPoolIdentifier) IsPoolMember(node *api.NodeListStub) bool {
 	return node.NodeClass != "" && node.NodeClass == n.id ||

--- a/sdk/helper/scaleutils/nodepool/datacenter.go
+++ b/sdk/helper/scaleutils/nodepool/datacenter.go
@@ -1,0 +1,29 @@
+package nodepool
+
+import "github.com/hashicorp/nomad/api"
+
+type nodeDatacenterClusterPoolIdentifier struct {
+	id string
+}
+
+// NewNodeDatacenterPoolIdentifier returns a new
+// nodeDatacenterClusterPoolIdentifier implementation of the
+// ClusterNodePoolIdentifier interface.
+func NewNodeDatacenterPoolIdentifier(id string) ClusterNodePoolIdentifier {
+	return &nodeDatacenterClusterPoolIdentifier{
+		id: id,
+	}
+}
+
+// IsPoolMember satisfies the IsPoolMember function on the
+// ClusterNodePoolIdentifier interface.
+func (n nodeDatacenterClusterPoolIdentifier) IsPoolMember(node *api.NodeListStub) bool {
+	return node.Datacenter == n.id
+}
+
+// Key satisfies the Key function on the ClusterNodePoolIdentifier interface.
+func (n nodeDatacenterClusterPoolIdentifier) Key() string { return "datacenter" }
+
+// Value satisfies the Value function on the ClusterNodePoolIdentifier
+// interface.
+func (n nodeDatacenterClusterPoolIdentifier) Value() string { return n.id }

--- a/sdk/helper/scaleutils/nodepool/datacenter.go
+++ b/sdk/helper/scaleutils/nodepool/datacenter.go
@@ -1,6 +1,9 @@
 package nodepool
 
-import "github.com/hashicorp/nomad/api"
+import (
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/hashicorp/nomad/api"
+)
 
 type nodeDatacenterClusterPoolIdentifier struct {
 	id string
@@ -22,7 +25,7 @@ func (n nodeDatacenterClusterPoolIdentifier) IsPoolMember(node *api.NodeListStub
 }
 
 // Key satisfies the Key function on the ClusterNodePoolIdentifier interface.
-func (n nodeDatacenterClusterPoolIdentifier) Key() string { return "datacenter" }
+func (n nodeDatacenterClusterPoolIdentifier) Key() string { return sdk.TargetConfigKeyDatacenter }
 
 // Value satisfies the Value function on the ClusterNodePoolIdentifier
 // interface.

--- a/sdk/helper/scaleutils/nodepool/datacenter_test.go
+++ b/sdk/helper/scaleutils/nodepool/datacenter_test.go
@@ -1,0 +1,48 @@
+package nodepool
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewNodeDatacenterPoolIdentifier(t *testing.T) {
+	poolID := NewNodeDatacenterPoolIdentifier("eu-west-2a")
+	assert.Equal(t, "datacenter", poolID.Key())
+	assert.Equal(t, "eu-west-2a", poolID.Value())
+}
+
+func TestNodeDatacenterClusterPoolIdentifier_NodeIsPoolMember(t *testing.T) {
+	testCases := []struct {
+		inputPI        ClusterNodePoolIdentifier
+		inputNode      *api.NodeListStub
+		expectedOutput bool
+		name           string
+	}{
+		{
+			inputPI:        NewNodeDatacenterPoolIdentifier("dc1"),
+			inputNode:      &api.NodeListStub{Datacenter: "dc1"},
+			expectedOutput: true,
+			name:           "el classico dc1",
+		},
+		{
+			inputPI:        NewNodeDatacenterPoolIdentifier("dc1"),
+			inputNode:      &api.NodeListStub{Datacenter: "eu-west-2a"},
+			expectedOutput: false,
+			name:           "non-matching datacenter",
+		},
+		{
+			inputPI:        NewNodeDatacenterPoolIdentifier("eu-west-2a"),
+			inputNode:      &api.NodeListStub{Datacenter: "eu-west-2b"},
+			expectedOutput: false,
+			name:           "non-matching close",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputPI.IsPoolMember(tc.inputNode), tc.name)
+		})
+	}
+}

--- a/sdk/helper/scaleutils/nodepool/nodepool.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool.go
@@ -1,6 +1,11 @@
 package nodepool
 
-import "github.com/hashicorp/nomad/api"
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/hashicorp/nomad/api"
+)
 
 // ClusterNodePoolIdentifier is the interface that defines how nodes are
 // classed into pools of resources.
@@ -17,4 +22,18 @@ type ClusterNodePoolIdentifier interface {
 	// Value returns the pool identifier value that nodes are being filtered
 	// by.
 	Value() string
+}
+
+// NewClusterNodePoolIdentifier generates a new ClusterNodePoolIdentifier based
+// on the provided configuration. If a valid option is not found, an error will
+// be returned.
+func NewClusterNodePoolIdentifier(cfg map[string]string) (ClusterNodePoolIdentifier, error) {
+
+	if class, ok := cfg[sdk.TargetConfigKeyClass]; ok {
+		return NewNodeClassPoolIdentifier(class), nil
+	}
+	if dc, ok := cfg[sdk.TargetConfigKeyDatacenter]; ok {
+		return NewNodeDatacenterPoolIdentifier(dc), nil
+	}
+	return nil, fmt.Errorf("node pool identification method required")
 }

--- a/sdk/helper/scaleutils/nodepool/nodepool_test.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool_test.go
@@ -1,0 +1,60 @@
+package nodepool
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewClusterNodePoolIdentifier(t *testing.T) {
+	testCases := []struct {
+		inputCfg            map[string]string
+		expectedOutputKey   string
+		expectedOutputValue string
+		expectedOutputErr   error
+		name                string
+	}{
+		{
+			inputCfg:            map[string]string{},
+			expectedOutputKey:   "",
+			expectedOutputValue: "",
+			expectedOutputErr:   errors.New("node pool identification method required"),
+			name:                "empty input config",
+		},
+		{
+			inputCfg:            map[string]string{"datacentre": "dc1"},
+			expectedOutputKey:   "",
+			expectedOutputValue: "",
+			expectedOutputErr:   errors.New("node pool identification method required"),
+			name:                "input config with incorrect key",
+		},
+		{
+			inputCfg:            map[string]string{"datacenter": "dc1"},
+			expectedOutputKey:   "datacenter",
+			expectedOutputValue: "dc1",
+			expectedOutputErr:   nil,
+			name:                "datacenter configured in config",
+		},
+		{
+			inputCfg:            map[string]string{"node_class": "high-memory"},
+			expectedOutputKey:   "node_class",
+			expectedOutputValue: "high-memory",
+			expectedOutputErr:   nil,
+			name:                "node_class configured in config",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			impl, err := NewClusterNodePoolIdentifier(tc.inputCfg)
+			if tc.expectedOutputErr != nil {
+				assert.Equal(t, tc.expectedOutputErr, err, tc.name)
+			} else {
+				assert.NotNil(t, impl, tc.name)
+				assert.Equal(t, tc.expectedOutputKey, impl.Key(), tc.name)
+				assert.Equal(t, tc.expectedOutputValue, impl.Value(), tc.name)
+			}
+		})
+	}
+}

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -115,8 +115,12 @@ func (t *ScalingPolicyTarget) IsJobTaskGroupTarget() bool {
 // IsNodePoolTarget identifies whether the ScalingPolicyTarget relates to Nomad
 // client nodes and therefore horizontal cluster scaling.
 func (t *ScalingPolicyTarget) IsNodePoolTarget() bool {
-	_, ok := t.Config[TargetConfigKeyClass]
-	return ok
+	if t == nil || t.Config == nil {
+		return false
+	}
+	_, classOK := t.Config[TargetConfigKeyClass]
+	_, dcOK := t.Config[TargetConfigKeyDatacenter]
+	return classOK || dcOK
 }
 
 type FileDecodeScalingPolicies struct {

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -7,6 +7,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestScalingPolicyTarget_IsNodePoolTarget(t *testing.T) {
+	testCases := []struct {
+		inputScalingPolicyTarget *ScalingPolicyTarget
+		expectedOutput           bool
+		name                     string
+	}{
+		{
+			inputScalingPolicyTarget: &ScalingPolicyTarget{
+				Config: map[string]string{"Job": "example", "Group": "cache"},
+			},
+			expectedOutput: false,
+			name:           "job input target",
+		},
+		{
+			inputScalingPolicyTarget: &ScalingPolicyTarget{
+				Config: map[string]string{"node_class": "high-memory"},
+			},
+			expectedOutput: true,
+			name:           "node_class input target",
+		},
+		{
+			inputScalingPolicyTarget: &ScalingPolicyTarget{
+				Config: map[string]string{"datacenter": "dc1"},
+			},
+			expectedOutput: true,
+			name:           "datacenter input target",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputScalingPolicyTarget.IsNodePoolTarget(), tc.name)
+		})
+	}
+}
+
 func TestFileDecodePolicy_Translate(t *testing.T) {
 	testCases := []struct {
 		inputFileDecodePolicy *FileDecodeScalingPolicy

--- a/sdk/target.go
+++ b/sdk/target.go
@@ -35,10 +35,15 @@ const (
 	// scaling to identify the Nomad job group targeted for autoscaling.
 	TargetConfigKeyTaskGroup = "Group"
 
-	// TargetConfigKeyClass is the config key used with horizontal cluster
-	// scaling to identify Nomad clients as part of a pool of resources. This
-	// pool of resources forms the scalable target.
+	// TargetConfigKeyClass is the horizontal cluster scaling target
+	// config key which identifies nodes as part of a pool of resources using
+	// the clients node_class configuration param.
 	TargetConfigKeyClass = "node_class"
+
+	// TargetConfigKeyDatacenter is the horizontal cluster scaling target
+	// config key which identifies nodes as part of a pool of resources using
+	// the agents datacenter configuration param.
+	TargetConfigKeyDatacenter = "datacenter"
 
 	// TargetConfigKeyDrainDeadline is the config key which defines the
 	// override value to use when draining a Nomad client during the scale in
@@ -84,3 +89,8 @@ const (
 	// allocations, without considering system jobs.
 	TargetNodeSelectorStrategyEmptyIgnoreSystemJobs = "empty_ignore_system"
 )
+
+// TargetConfigConflictingClusterParams is a list containing horizontal cluster
+// scaling target configuration options which conflict. This makes it easier to
+// create error messages.
+var TargetConfigConflictingClusterParams = []string{TargetConfigKeyDatacenter, TargetConfigKeyClass}


### PR DESCRIPTION
closes #459 

When understanding the nodes which form a scalable pool of resource, the Nomad Autoscaler uses the nodepool interface which provides functionality to understand node grouping. This change adds a new implementation, `datacenter`, which allows nodes to be group according to their datacenter configuration option.

The cluster policy validation has been updated to account for this change. Particuary the `node_class` and `datacenter` options are mutually exclusive. The new validation functions use the `helper/error` pkg to create better formatted errors. Work to update the entire error chain will be conducted in a follow up PR. 

The Nomad project site will need updating to document the new config option. It may also prove valuable to add a demo, or at least commented out examples of using `datacenter` rather than `node_class`.