### PR TITLE
plugins/target/aws-asg: correctly order region config setting.

### DIFF
--- a/plugins/builtin/target/aws-asg/plugin/aws.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws.go
@@ -30,17 +30,18 @@ func (t *TargetPlugin) setupAWSClients(config map[string]string) error {
 		return fmt.Errorf("failed to load default AWS config: %v", err)
 	}
 
-	// Check for a configured region and set the value to our internal default
-	// if nothing is found.
+	// If the operator has provided a configuration region, overwrite that set
+	// by the AWS client.
 	region, ok := config[configKeyRegion]
-	if !ok {
-		region = configValueRegionDefault
+	if ok {
+		t.logger.Debug("setting AWS region for client", "region", region)
+		cfg.Region = region
 	}
 
-	// If the default config is empty, update it.
+	// In the situation where the plugin is not running on an EC2 instance, nor
+	// has the operator set an parameter, set the region to the default.
 	if cfg.Region == "" {
-		t.logger.Trace("setting AWS region for client", "region", region)
-		cfg.Region = region
+		cfg.Region = configValueRegionDefault
 	}
 
 	// Attempt to pull access credentials for the AWS client from the user

--- a/plugins/builtin/target/aws-asg/plugin/aws_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws_test.go
@@ -2,14 +2,55 @@ package plugin
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils"
 	"github.com/hashicorp/nomad/api"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestTargetPlugin_SetConfig_NonAWS(t *testing.T) {
+	if os.Getenv("NOMAD_AUTOSCALER_AWS") != "" {
+		t.Skip("skipping aws-asg non-aws environment test, NOMAD_AUTOSCALER_AWS set")
+	}
+
+	testCases := []struct {
+		inputCfg          map[string]string
+		expectedOutputErr error
+		name              string
+	}{
+		{
+			inputCfg:          map[string]string{},
+			expectedOutputErr: nil,
+			name:              "empty input config",
+		},
+		{
+			inputCfg: map[string]string{
+				"aws_region": "ap-southeast-2",
+			},
+			expectedOutputErr: nil,
+			name:              "input config with region",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			awsPlugin := NewAWSASGPlugin(hclog.NewNullLogger())
+			actualOutputErr := awsPlugin.SetConfig(tc.inputCfg)
+			assert.Equal(t, tc.expectedOutputErr, actualOutputErr, tc.name)
+
+			region := tc.inputCfg["aws_region"]
+			if region == "" {
+				region = "us-east-1"
+			}
+			assert.Equal(t, region, awsPlugin.asg.Config.Region, tc.name)
+		})
+	}
+}
 
 func Test_instancesBelongToASG(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
A user specific region configuration option should take precedence
over other options. This change therefore updates the flow in
which the AWS config is populated. In situation where AWS and the
operator do not provide an option, the default is applied.

The change itself is hard to automatically test at the moment as
the behaviour changes depending whether you have the EC2 metadata
service available. The test added is aimed at situations where the
plugin is not running with the EC2 metadata service available.

#473 has been raised to track better testing where the EC2 metadata
service is available.

closes #472 