### PR TITLE
Fix to return `nil` instead of `none` action from strategies

### DIFF
--- a/plugins/builtin/strategy/pass-through/plugin/plugin.go
+++ b/plugins/builtin/strategy/pass-through/plugin/plugin.go
@@ -62,8 +62,7 @@ func (s *StrategyPlugin) PluginInfo() (*base.PluginInfo, error) {
 // Run satisfies the Run function on the strategy.Strategy interface.
 func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sdk.ScalingCheckEvaluation, error) {
 	if len(eval.Metrics) == 0 {
-		eval.Action.Direction = sdk.ScaleDirectionNone
-		return eval, nil
+		return nil, nil
 	}
 
 	// Use only the latest value for now.

--- a/plugins/builtin/strategy/pass-through/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/pass-through/plugin/plugin_test.go
@@ -121,18 +121,8 @@ func TestStrategyPlugin_Run(t *testing.T) {
 				},
 				Action: &sdk.ScalingAction{},
 			},
-			inputCount: 10,
-			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metrics: sdk.TimestampedMetrics{},
-				Check: &sdk.ScalingPolicyCheck{
-					Strategy: &sdk.ScalingPolicyStrategy{
-						Config: map[string]string{},
-					},
-				},
-				Action: &sdk.ScalingAction{
-					Direction: sdk.ScaleDirectionNone,
-				},
-			},
+			inputCount:    10,
+			expectedResp:  nil,
 			expectedError: nil,
 			name:          "no scaling - empty metric timeseries",
 		},

--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -75,8 +75,7 @@ func (s *StrategyPlugin) PluginInfo() (*base.PluginInfo, error) {
 // Run satisfies the Run function on the strategy.Strategy interface.
 func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sdk.ScalingCheckEvaluation, error) {
 	if len(eval.Metrics) == 0 {
-		eval.Action.Direction = sdk.ScaleDirectionNone
-		return eval, nil
+		return nil, nil
 	}
 
 	// Read and parse target value from req.Config.

--- a/plugins/builtin/strategy/target-value/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin_test.go
@@ -84,18 +84,8 @@ func TestStrategyPlugin_Run(t *testing.T) {
 				},
 				Action: &sdk.ScalingAction{},
 			},
-			inputCount: 2,
-			expectedResp: &sdk.ScalingCheckEvaluation{
-				Metrics: sdk.TimestampedMetrics{},
-				Check: &sdk.ScalingPolicyCheck{
-					Strategy: &sdk.ScalingPolicyStrategy{
-						Config: map[string]string{"target": "13"},
-					},
-				},
-				Action: &sdk.ScalingAction{
-					Direction: sdk.ScaleDirectionNone,
-				},
-			},
+			inputCount:    2,
+			expectedResp:  nil,
 			expectedError: nil,
 			name:          "empty metrics",
 		},

--- a/policyeval/base_worker.go
+++ b/policyeval/base_worker.go
@@ -339,6 +339,10 @@ func (h *checkHandler) start(ctx context.Context, currentStatus *sdk.TargetStatu
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute strategy: %v", err)
 	}
+	if runResp == nil {
+		return nil, nil
+	}
+
 	h.checkEval = runResp
 
 	if h.checkEval.Action.Direction == sdk.ScaleDirectionNone {


### PR DESCRIPTION
There is a small difference between a strategy determining that the count value shouldn't change as opposed to the strategy not being able to compute it.

In the first case, the new count is successfully calculated but it happens to be equal the current count. In the second case, the strategy is unable to determine what to do.

This difference is important because a `none` scaling direction takes precedence over a `down` action. Return `none` instead of `nil` can cause a `down` check to be ignored.