### PR TITLE
policy: log error messages using contextual params.

### DIFF
--- a/policy/handler.go
+++ b/policy/handler.go
@@ -136,7 +136,7 @@ func (h *Handler) Run(ctx context.Context, evalCh chan<- *sdk.ScalingEvaluation)
 				}
 				h.log.Error(errors[0], "errors", errors[1:])
 			} else {
-				h.log.Error(err.Error())
+				h.log.Error("encountered an error monitoring policy", "error", err)
 			}
 			continue
 

--- a/policy/manager.go
+++ b/policy/manager.go
@@ -74,7 +74,7 @@ LOOP:
 			return
 
 		case err := <-policyIDsErrCh:
-			m.log.Error(err.Error())
+			m.log.Error("encountered an error monitoring policy IDs", "error", err)
 			if isUnrecoverableError(err) {
 				break LOOP
 			}


### PR DESCRIPTION
This helps keeps consistency across error logging where error
messages can be groked or filtered using context.