### PR TITLE
HA: add initial consistent hashring implementation.

### DIFF
--- a/sdk/helper/hash/ring.go
+++ b/sdk/helper/hash/ring.go
@@ -1,0 +1,159 @@
+package hash
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/hashicorp/nomad-autoscaler/policy"
+)
+
+// ConsistentRing is a basic implementation of a consistent hash ring providing
+// consistent assignment of keys to ring members.
+type ConsistentRing struct {
+	hasher Hasher
+
+	// mu should be used to ensure ring consistency when updating or
+	// identifying assignments. In the search for stronger consistency this is
+	// used to interact with all objects in this struct below this definition.
+	mu sync.RWMutex
+
+	// memberKeys is the sorted array of hashed member IDs. Whenever the array
+	// is updated, it should be sorted using sortMemberKeys and assignments
+	// re-calculated.
+	memberKeys []uint32
+
+	// ring maps the members hashed ID to the RingMember. This is used for
+	// informing callers of key assignment.
+	ring map[uint32]RingMember
+
+	// load tracks the number of policies assigned per member. The index is
+	// mirrored from the memberKeys, therefore the load[2] represent the load
+	// of member memberKeys[2] and ring[memberKeys[2]].
+	load []uint32
+}
+
+// NewConsistentRing returns an initialised ConsistentRing. It is safe to call
+// this with a nil/empty members array, using Update to add these at a later
+// time.
+func NewConsistentRing() *ConsistentRing {
+	return &ConsistentRing{
+		hasher: NewDefaultHasher(),
+	}
+}
+
+// Update is used to overwrite the current ring membership with an updated list
+// of members. This method is used currently in-place of singular add/remove
+// functions due to the way in which Consul allows us to get notified of
+// service catalog changes.
+func (cr *ConsistentRing) Update(members []RingMember) {
+
+	num := len(members)
+
+	if num < 1 {
+		return
+	}
+
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+
+	// This is a bulk update method, therefore init all the things.
+	cr.ring = make(map[uint32]RingMember, num)
+	cr.memberKeys = make([]uint32, num)
+	cr.load = make([]uint32, num)
+
+	// Iterate the members and insert them into the ring objects so we can
+	// correctly sort the ring and distribute work.
+	for i, mem := range members {
+		h := cr.hasher.Hash32(mem.Bytes())
+		cr.ring[h] = mem
+		cr.memberKeys[i] = h
+	}
+
+	// Don't forget to sort!
+	cr.sortMemberKeys()
+}
+
+func (cr *ConsistentRing) GetLoadStats() {
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+
+	// Implement me, please.
+}
+
+func (cr *ConsistentRing) GetAssignments(ids []policy.PolicyID, agentID string) []policy.PolicyID {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+
+	// Guard against attempting to assign policies where we do not have any
+	// members.
+	if len(cr.memberKeys) == 0 {
+		return nil
+	}
+
+	// This function bulk assigns work therefore we can overwrite the load
+	// tracking.
+	cr.load = make([]uint32, len(cr.memberKeys))
+
+	// The base length allows us to mutate the iteration loop depending whether
+	// we remove elements.
+	numIDs := len(ids)
+
+	for i := 0; i < numIDs; i++ {
+
+		// Grab the policy and identify which member this will be assigned to.
+		p := ids[i]
+		assignmentMem := cr.getMemberAssignmentWithLock(p.String())
+
+		if assignmentMem.String() != agentID {
+
+			// Remove the policy from the list if it isn't assigned to the
+			// local agent.
+			ids[numIDs-1], ids[i] = ids[i], ids[numIDs-1]
+			ids = ids[:numIDs-1]
+
+			// The array size has shrunk by one, therefore keep the iteration
+			// point static and reduce the effective end of the iteration.
+			i--
+			numIDs--
+		}
+	}
+
+	return ids
+}
+
+// getMemberAssignmentWithLock identifies which ring member the passed key
+// should be assigned to.
+func (cr *ConsistentRing) getMemberAssignmentWithLock(key string) RingMember {
+
+	// The fact we have to convert the policyID from a string to a byte array
+	// accounts for a large amount time comparable to the work being done. This
+	// is seen within the cpu profile for the benchmarks particularly when
+	// running GetAssignments().
+	hash := cr.hasher.Hash32([]byte(key))
+
+	// Perform a binary search to locate the appropriate member to handle the
+	// key.
+	idx := sort.Search(len(cr.memberKeys), func(i int) bool { return cr.memberKeys[i] >= hash })
+
+	// If the returned index matches the length of the key array, we have
+	// wrapped fully around and therefore should set the desired index to zero.
+	if idx == len(cr.memberKeys) {
+		idx = 0
+	}
+
+	// Update our load tracking. This is the most efficient place to do this,
+	// although it is not the most flexible. If we ever update the discovery
+	// method this will likely need re-thinking. That being said, for now,
+	// simple and easy.
+	cr.load[idx]++
+
+	// Grab the member from the Ring using the index and return.
+	return cr.ring[cr.memberKeys[idx]]
+}
+
+// sortMemberKeys ensures the memberKeys, and therefore our ring, is ordered so
+// we can provide consistent responses to assignment requests. This needs to be
+// called on every update to ConsistentRing membership.
+func (cr *ConsistentRing) sortMemberKeys() {
+	sort.Slice(cr.memberKeys, func(i int, j int) bool { return cr.memberKeys[i] < cr.memberKeys[j] })
+}

--- a/sdk/helper/hash/ring_benchmark_test.go
+++ b/sdk/helper/hash/ring_benchmark_test.go
@@ -1,0 +1,79 @@
+package hash
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad-autoscaler/policy"
+	"github.com/hashicorp/nomad-autoscaler/sdk/helper/uuid"
+)
+
+func BenchmarkConsistentRing_Update(b *testing.B) {
+	benches := []struct {
+		numMembers int
+		name       string
+	}{
+		{numMembers: 9, name: "3members"},
+		{numMembers: 9, name: "6members"},
+		{numMembers: 9, name: "9members"},
+		{numMembers: 9, name: "12members"},
+	}
+
+	for _, bench := range benches {
+
+		members := generateRingMembers(bench.numMembers)
+		ring := NewConsistentRing()
+
+		b.Run(bench.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ring.Update(members)
+			}
+		})
+	}
+}
+
+func BenchmarkConsistentRing_GetAssignments(b *testing.B) {
+	benches := []struct {
+		numMembers  int
+		numPolicies int
+		name        string
+	}{
+		{numMembers: 3, numPolicies: 100, name: "3members_100policies"},
+		{numMembers: 6, numPolicies: 100, name: "6members_100policies"},
+		{numMembers: 9, numPolicies: 100, name: "9members_100policies"},
+		{numMembers: 12, numPolicies: 100, name: "12members_100policies"},
+		{numMembers: 3, numPolicies: 1000, name: "3members_1000policies"},
+		{numMembers: 6, numPolicies: 1000, name: "6members_1000policies"},
+		{numMembers: 9, numPolicies: 1000, name: "9members_1000policies"},
+		{numMembers: 12, numPolicies: 1000, name: "12members_1000policies"},
+	}
+
+	rand.Seed(time.Now().Unix())
+
+	for _, bench := range benches {
+
+		inputMembers := generateRingMembers(bench.numMembers)
+		inputPolicies := generateTestPolicies(bench.numPolicies)
+
+		ring := NewConsistentRing()
+		ring.Update(inputMembers)
+
+		agentID := inputMembers[rand.Intn(len(inputMembers))]
+
+		b.Run(bench.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = ring.GetAssignments(inputPolicies, agentID.String())
+			}
+		})
+
+	}
+}
+
+func generateTestPolicies(num int) []policy.PolicyID {
+	out := make([]policy.PolicyID, num)
+	for i := 0; i < num; i++ {
+		out[i] = policy.PolicyID(uuid.Generate())
+	}
+	return out
+}

--- a/sdk/helper/hash/ring_test.go
+++ b/sdk/helper/hash/ring_test.go
@@ -1,0 +1,155 @@
+package hash
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad-autoscaler/policy"
+	"github.com/hashicorp/nomad-autoscaler/sdk/helper/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsistentRing_Update(t *testing.T) {
+	testCases := []struct {
+		inputConsistentRing *ConsistentRing
+		inputUpdateMembers  []RingMember
+		name                string
+	}{
+		{
+			inputConsistentRing: NewConsistentRing(),
+			inputUpdateMembers:  generateRingMembers(3),
+			name:                "empty ring",
+		},
+		{
+			inputConsistentRing: &ConsistentRing{
+				hasher:     NewDefaultHasher(),
+				memberKeys: []uint32{989091847, 3928713472, 1421016843},
+				ring: map[uint32]RingMember{
+					989091847:  NewRingMember("04a303cf-9cd2-8faf-02e3-2ad3a387cd55"),
+					3928713472: NewRingMember("8a52ccc4-6bc7-e73f-5624-e5da4a935632"),
+					1421016843: NewRingMember("68943bff-6b83-476e-a613-d4ef77bf500b"),
+				},
+			},
+			inputUpdateMembers: []RingMember{
+				NewRingMember("68943bff-6b83-476e-a613-d4ef77bf500b"),
+				NewRingMember("04a303cf-9cd2-8faf-02e3-2ad3a387cd55"),
+			},
+			name: "populated ring",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.inputConsistentRing.Update(tc.inputUpdateMembers)
+			assert.Len(t, tc.inputConsistentRing.memberKeys, len(tc.inputUpdateMembers), tc.name)
+			assert.Len(t, tc.inputConsistentRing.ring, len(tc.inputUpdateMembers), tc.name)
+
+			for _, member := range tc.inputUpdateMembers {
+				h := tc.inputConsistentRing.hasher.Hash32(member.Bytes())
+				mem, ok := tc.inputConsistentRing.ring[h]
+				assert.True(t, ok, tc.name)
+				assert.Equal(t, member.String(), mem.String(), tc.name)
+			}
+		})
+	}
+}
+
+func TestConsistentRing_GetAssignments(t *testing.T) {
+	testCases := []struct {
+		inputConsistentRing    *ConsistentRing
+		inputPolicies          []policy.PolicyID
+		inputAgentID           string
+		expectedOutputPolicies []policy.PolicyID
+		name                   string
+	}{
+		{
+			inputConsistentRing: &ConsistentRing{
+				hasher:     NewDefaultHasher(),
+				memberKeys: []uint32{989091847, 3928713472, 1421016843},
+				ring: map[uint32]RingMember{
+					989091847:  NewRingMember("04a303cf-9cd2-8faf-02e3-2ad3a387cd55"),
+					3928713472: NewRingMember("8a52ccc4-6bc7-e73f-5624-e5da4a935632"),
+					1421016843: NewRingMember("68943bff-6b83-476e-a613-d4ef77bf500b"),
+				},
+			},
+			inputPolicies: []policy.PolicyID{
+				"8a23e6f6-c392-4f2a-a724-c2fbb4cf4a6c",
+				"dcff1218-590d-244d-1673-1e306f14339f",
+				"e05c6e65-99cf-5249-c391-9624c23abecc",
+				"3ec6d512-01c1-8f7b-beae-95155d03edf1",
+				"edc00b7d-9e25-8257-fd53-dd8b238ba8d6",
+				"ca775496-7f82-8cb6-460b-a1d19c423770",
+				"d49c57a4-b700-6ceb-6a99-44384439f58e",
+				"8c4738e6-6382-ae12-8181-877a7ba8403e",
+				"2d197c48-094c-54c2-9885-7ba6879c8b55",
+				"ef62b605-1eab-6b20-27e8-f1965c42992e",
+			},
+			inputAgentID: "8a52ccc4-6bc7-e73f-5624-e5da4a935632",
+			expectedOutputPolicies: []policy.PolicyID{
+				"8a23e6f6-c392-4f2a-a724-c2fbb4cf4a6c",
+				"ef62b605-1eab-6b20-27e8-f1965c42992e",
+				"e05c6e65-99cf-5249-c391-9624c23abecc",
+				"2d197c48-094c-54c2-9885-7ba6879c8b55",
+				"8c4738e6-6382-ae12-8181-877a7ba8403e",
+				"d49c57a4-b700-6ceb-6a99-44384439f58e",
+			},
+			name: "general test 1",
+		},
+		{
+			inputConsistentRing: &ConsistentRing{
+				hasher:     NewDefaultHasher(),
+				memberKeys: []uint32{989091847, 3928713472, 1421016843},
+				ring: map[uint32]RingMember{
+					989091847:  NewRingMember("04a303cf-9cd2-8faf-02e3-2ad3a387cd55"),
+					3928713472: NewRingMember("8a52ccc4-6bc7-e73f-5624-e5da4a935632"),
+					1421016843: NewRingMember("68943bff-6b83-476e-a613-d4ef77bf500b"),
+				},
+			},
+			inputPolicies: []policy.PolicyID{
+				"8a23e6f6-c392-4f2a-a724-c2fbb4cf4a6c",
+				"dcff1218-590d-244d-1673-1e306f14339f",
+				"e05c6e65-99cf-5249-c391-9624c23abecc",
+				"3ec6d512-01c1-8f7b-beae-95155d03edf1",
+				"edc00b7d-9e25-8257-fd53-dd8b238ba8d6",
+				"ca775496-7f82-8cb6-460b-a1d19c423770",
+				"d49c57a4-b700-6ceb-6a99-44384439f58e",
+				"8c4738e6-6382-ae12-8181-877a7ba8403e",
+				"2d197c48-094c-54c2-9885-7ba6879c8b55",
+				"ef62b605-1eab-6b20-27e8-f1965c42992e",
+			},
+			inputAgentID: "04a303cf-9cd2-8faf-02e3-2ad3a387cd55",
+			expectedOutputPolicies: []policy.PolicyID{
+				"dcff1218-590d-244d-1673-1e306f14339f",
+				"3ec6d512-01c1-8f7b-beae-95155d03edf1",
+				"edc00b7d-9e25-8257-fd53-dd8b238ba8d6",
+				"ca775496-7f82-8cb6-460b-a1d19c423770",
+			},
+			name: "general test 2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := tc.inputConsistentRing.GetAssignments(tc.inputPolicies, tc.inputAgentID)
+			assert.ElementsMatch(t, tc.expectedOutputPolicies, actualOutput, tc.name)
+
+			// Test the internal load measure is correct for the local agent.
+			m := &defaultRingMember{tc.inputAgentID}
+			h := tc.inputConsistentRing.hasher.Hash32(m.Bytes())
+
+			for i, memberHash := range tc.inputConsistentRing.memberKeys {
+				if memberHash == h {
+					assert.Equal(t, uint32(len(tc.expectedOutputPolicies)), tc.inputConsistentRing.load[i], tc.name)
+					break
+				}
+			}
+		})
+	}
+}
+
+func generateRingMembers(num int) []RingMember {
+	out := make([]RingMember, num)
+	for i := 0; i < num; i++ {
+		out[i] = NewRingMember(uuid.Generate())
+	}
+	return out
+}


### PR DESCRIPTION
The ring focusses on consistency and doesn't include functionality
such as load balancing.

The consistent hashring is used for partitioning policies between
autoscaler agents. It keeps an internal tracking of load
distribution across known members, allowing telemetry to identify
inconsistency.

The current implementation is specific to Consul and the manner in
which agents are discovered. If we ever moved to an alternative
discovery mechanism, we would need some additional functions but
the logic is sound.