### PR TITLE
Allow setting additional headers in prometheus APM client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
  * agent: Dispense `fixed-value`, `pass-through`, and `threshold` strategy plugins by default [[GH-536](https://github.com/hashicorp/nomad-autoscaler/pull/536)]
+ * plugins/apm/prometheus: Add support for basic auth and custom headers [[GH-522](https://github.com/hashicorp/nomad-autoscaler/pull/522)]
  * plugins/target/nomad: Reduce log level for active deployments error messages [[GH-542](https://github.com/hashicorp/nomad-autoscaler/pull/542)]
  * policy: Prevent scaling cluster to zero when using the Nomad APM [[GH-534](https://github.com/hashicorp/nomad-autoscaler/pull/534)]
  * scaleutils: Add combined filter to allow filtering by node class and datacenter [[GH-535](https://github.com/hashicorp/nomad-autoscaler/pull/535)]

--- a/plugins/builtin/apm/prometheus/plugin/plugin.go
+++ b/plugins/builtin/apm/prometheus/plugin/plugin.go
@@ -30,6 +30,8 @@ const (
 	configKeyBasicAuthUser     = "basic_auth_user"
 	configKeyBasicAuthPassword = "basic_auth_password"
 
+	// configKeyHeadersPrefix is the prefix used to indicate that a
+	// configuration value should be set as an HTTP header.
 	configKeyHeadersPrefix = "header_"
 )
 

--- a/plugins/builtin/apm/prometheus/plugin/prometheus.go
+++ b/plugins/builtin/apm/prometheus/plugin/prometheus.go
@@ -1,0 +1,52 @@
+package plugin
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/prometheus/client_golang/api"
+)
+
+// pluginRoundTripper is used to configure the Prometheus HTTP client.
+type pluginRoundTripper struct {
+	headers           map[string]string
+	basicAuthUser     string
+	basicAuthPassword string
+
+	rt http.RoundTripper
+}
+
+// newPluginRoudTripper returns a new pluginRoundTripper configured based on
+// configuration values set for the plugin.
+func newPluginRoudTripper(config map[string]string) *pluginRoundTripper {
+	username := config[configKeyBasicAuthUser]
+	password := config[configKeyBasicAuthPassword]
+
+	headers := make(map[string]string)
+	for k, v := range config {
+		if strings.HasPrefix(k, configKeyHeadersPrefix) {
+			header := strings.TrimPrefix(k, configKeyHeadersPrefix)
+			headers[header] = v
+		}
+	}
+
+	return &pluginRoundTripper{
+		headers:           headers,
+		basicAuthUser:     username,
+		basicAuthPassword: password,
+		rt:                api.DefaultRoundTripper,
+	}
+}
+
+func (rt *pluginRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for header, value := range rt.headers {
+		req.Header.Add(header, value)
+	}
+
+	setAuth := (rt.basicAuthUser != "" || rt.basicAuthPassword != "") && req.Header.Get("Authorization") == ""
+	if setAuth {
+		req.SetBasicAuth(rt.basicAuthUser, rt.basicAuthPassword)
+	}
+
+	return rt.rt.RoundTrip(req)
+}

--- a/plugins/builtin/apm/prometheus/plugin/prometheus_test.go
+++ b/plugins/builtin/apm/prometheus/plugin/prometheus_test.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPMPlugin_roundTripper(t *testing.T) {
+	cfg := map[string]string{
+		"basic_auth_user":        "user",
+		"basic_auth_password":    "secret",
+		"header_X-Scope-OrgID":   "my-org",
+		"header_X-Custom-Header": "header value",
+	}
+
+	// Run tests inside the handler where we can check the values actually
+	// passed in the request.
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		username, password, _ := r.BasicAuth()
+		assert.Equal(t, "user", username)
+		assert.Equal(t, "secret", password)
+
+		assert.Equal(t, r.Header.Get("X-Scope-OrgID"), "my-org")
+		assert.Equal(t, r.Header.Get("X-Custom-Header"), "header value")
+	}
+
+	// Setup round tripper and an HTTP client to use for testing.
+	rt := newPluginRoudTripper(cfg)
+	client := &http.Client{Transport: rt}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	// Make a request to run the tests.
+	_, err := client.Get(server.URL)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR is a WIP to add the ability to set additional headers in the
prometheus APM client.  Right now I have the roundtripper adding a
suitable header for cortex, but obviously it cannot be hard coded.
The config type for this plugin is flat, and I'm trying to determine
the best way to include multiple header values in this type.  Guidance
is appreciated to make sure this fits in with the rest of the code
style in the repo.

Resolves #522 