### PR TITLE
Add policy mutators to prevent cluster scaling to zero with the Nomad APM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+ * policy: Prevent scaling cluster to zero when using the Nomad APM [[GH-534](https://github.com/hashicorp/nomad-autoscaler/pull/534)]
+
 BUG FIXES:
  * scaleutils: Fixed `least_busy` node selector on clusters running servers older than v1.0.0 [[GH-508](https://github.com/hashicorp/nomad-autoscaler/pull/508)]
 

--- a/policy/mutators.go
+++ b/policy/mutators.go
@@ -1,0 +1,36 @@
+package policy
+
+import (
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+)
+
+// Mutations is a list of human-friendly descriptions of the changes performed
+// by a mutator.
+type Mutations []string
+
+// Mutator is an interface used to apply
+type Mutator interface {
+	MutatePolicy(*sdk.ScalingPolicy) Mutations
+}
+
+// NomadAPMMutator handles the special case for zero count cluster scaling
+// since it can't query nodes if there are none running.
+type NomadAPMMutator struct{}
+
+func (m NomadAPMMutator) MutatePolicy(p *sdk.ScalingPolicy) Mutations {
+	result := Mutations{}
+
+	if p.Type != sdk.ScalingPolicyTypeCluster || p.Min != 0 {
+		return result
+	}
+
+	for _, c := range p.Checks {
+		if c.Source == "nomad-apm" {
+			p.Min = 1
+			result = append(result, "min value set to 1 since scaling cluster to 0 is not supported by the Nomad APM")
+			break
+		}
+	}
+
+	return result
+}

--- a/policy/mutators.go
+++ b/policy/mutators.go
@@ -8,7 +8,7 @@ import (
 // by a mutator.
 type Mutations []string
 
-// Mutator is an interface used to apply
+// Mutator is an interface used to apply changes to a scaling policy.
 type Mutator interface {
 	MutatePolicy(*sdk.ScalingPolicy) Mutations
 }

--- a/policy/mutators_test.go
+++ b/policy/mutators_test.go
@@ -1,0 +1,64 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicyMutators_NomadAPMMUtator(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    *sdk.ScalingPolicy
+		expected Mutations
+	}{
+		{
+			name: "no mutation for app scaling",
+			input: &sdk.ScalingPolicy{
+				Min:  0,
+				Type: sdk.ScalingPolicyTypeHorizontal,
+				Checks: []*sdk.ScalingPolicyCheck{
+					{
+						Source: "nomad-apm",
+					},
+				},
+			},
+			expected: Mutations{},
+		},
+		{
+			name: "no mutation for non-zero cluster scaling",
+			input: &sdk.ScalingPolicy{
+				Min:  1,
+				Type: sdk.ScalingPolicyTypeCluster,
+				Checks: []*sdk.ScalingPolicyCheck{
+					{
+						Source: "nomad-apm",
+					},
+				},
+			},
+			expected: Mutations{},
+		},
+		{
+			name: "cluster scaling to zero",
+			input: &sdk.ScalingPolicy{
+				Min:  0,
+				Type: sdk.ScalingPolicyTypeCluster,
+				Checks: []*sdk.ScalingPolicyCheck{
+					{
+						Source: "nomad-apm",
+					},
+				},
+			},
+			expected: Mutations{"min value set to 1 since scaling cluster to 0 is not supported by the Nomad APM"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NomadAPMMutator{}
+			got := m.MutatePolicy(tc.input)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
The Nomad APM uses the Nomad API to retrieve information about allocations and nodes. Usually, the choice of metric source should not impact the choice of target defined in a policy, but when using the Nomad APM to perform cluster scaling to `0` presents there is a problem to scale back up since, once the cluster reaches zero clients, there's nothing to query for metrics. 

There is also no meaningful default value to return in this case. The metrics supported by the Nomad APM for cluster scaling are percentage of CPU and memory allocated. For zero clients these values are 0% and 100% at the same time, and different policy strategies would require interpreting in one or another. Or not mater at all!

For example, using the `target-value` strategy with `target = 70` (i.e., 70% CPU usage as target) would never scale back from zero since the next count to be calculated is also always zero (`next count = 0/70 * 0` or `next count = 100/70 * 0`)

The root of the problem is that the Nomad APM was never intended to be used in this scenario. Its goal is to provide a quick way to scale apps and clusters based on memory and CPU usage. More advanced scenarios, where these metrics are not useful, require a different APM. 

The [On-demand Batch Job Cluster Autoscaling tutorial](https://learn.hashicorp.com/tutorials/nomad/horizontal-cluster-scaling-on-demand-batch?in=nomad/autoscaler) provides an example on how to scale a Nomad cluster to zero and back up using the Prometheus APM.

There are a few possible solutions to avoid this problem.

### Validate policies for this condition

Policy validation is currently done by policy sources, but don't take plugin-specific aspects into consideration. Validating a policy to cover this scenario would be possible, but a failed validation would prevent the policy from being evaluated altogether. A log message is emitted in these situations, but a re easy to be missed by operators.

### Query servers for metrics

With no clients to be queried, servers present an option for metric source. But this setup requires significant additional logic since the `/v1/metrics` endpoint only returns values specific to the agent being queried. Iterating over all servers scraping their metrics using tools like Datadog or Prometheus is the recommended way to consume these values, and so in this scenario, a different APM plugin should be used.

Another potential problem is that, the Nomad Autoscaler, when running as an allocation within Nomad, may not have direct access to servers.

### Modify policies to never scale to zero

This option is similar to the validation approach, in which plugin-aware checks are performed in each policy, but with the advantage that, instead of never performing any evaluations at all, modifying the policy to change `min = 0` to `min = 1` would keep the policy active, but without ever reaching zero clients.

Given that expanding the Nomad APM plugin to query more metrics is not feasible, modifying the policies to prevent scaling to zero seems to be the best approach. 

This PR adds the concept of policy mutators that are used by policy handlers to modify incoming policies if necessary. If a policy is modified, a log line is emitted to notify operators:

```
2021-11-11T13:37:54.946-0500 [INFO]  file_policy_source: starting file policy monitor: file=bin/policies/cluster.hcl name=policy-test policy_id=9d121526-7660-dc19-463b-5b2fee1a6b6d
2021-11-11T13:37:54.946-0500 [INFO]  policy_manager.policy_handler: policy modified: policy_id=9d121526-7660-dc19-463b-5b2fee1a6b6d modification="min value set to 1 since scaling cluster to 0 is not supported by the Nomad APM"
```

Despite the potential for low visibility into catching this log line, mutators don't prevent the policy from being evaluated, so missing these lines should be safe.

Closes #530 #424