### PR TITLE
Allow datacenter and node class filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
  * policy: Prevent scaling cluster to zero when using the Nomad APM [[GH-534](https://github.com/hashicorp/nomad-autoscaler/pull/534)]
+ * scaleutils: Add combined filter to allow filtering by node class and datacenter [[GH-535](https://github.com/hashicorp/nomad-autoscaler/pull/535)]
 
 BUG FIXES:
  * scaleutils: Fixed `least_busy` node selector on clusters running servers older than v1.0.0 [[GH-508](https://github.com/hashicorp/nomad-autoscaler/pull/508)]

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/plugins"
 	nomadAPM "github.com/hashicorp/nomad-autoscaler/plugins/builtin/apm/nomad/plugin"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
-	errHelper "github.com/hashicorp/nomad-autoscaler/sdk/helper/error"
 )
 
 // Processor helps process policies and perform common actions on them when
@@ -65,28 +64,7 @@ func (pr *Processor) ValidatePolicy(p *sdk.ScalingPolicy) error {
 		mErr = multierror.Append(mErr, errors.New("policy Min must not be greater Max"))
 	}
 
-	if err := pr.validateHorizontalClusterPolicy(p); err != nil {
-		mErr = multierror.Append(mErr, err)
-	}
-
 	return mErr.ErrorOrNil()
-}
-
-// validateHorizontalClusterPolicy validates that the target config for a
-// horizontal cluster scaling policy is valid. Calling this function is safe in
-// situations where it is not known whether the policy is a horizontal cluster
-// target or not.
-func (pr *Processor) validateHorizontalClusterPolicy(p *sdk.ScalingPolicy) error {
-
-	// Protect against the policy not targeting a horizontal cluster target so
-	// callers don't have to perform this.
-	if !p.Target.IsNodePoolTarget() {
-		return nil
-	}
-
-	// There are no extra validation needed at this point.
-	var mErr *multierror.Error
-	return errHelper.FormattedMultiError(mErr)
 }
 
 // CanonicalizeCheck sets standardised values on fields.

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -84,16 +84,8 @@ func (pr *Processor) validateHorizontalClusterPolicy(p *sdk.ScalingPolicy) error
 		return nil
 	}
 
+	// There are no extra validation needed at this point.
 	var mErr *multierror.Error
-
-	class := p.Target.Config[sdk.TargetConfigKeyClass]
-	dc := p.Target.Config[sdk.TargetConfigKeyDatacenter]
-
-	if class != "" && dc != "" {
-		mErr = multierror.Append(mErr, fmt.Errorf("target config must contain only one of %s",
-			strings.Join(sdk.TargetConfigConflictingClusterParams, ", ")))
-	}
-
 	return errHelper.FormattedMultiError(mErr)
 }
 

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -114,64 +114,6 @@ func TestProcessor_ValidatePolicy(t *testing.T) {
 	}
 }
 
-func TestProcessor_validateHorizontalClusterPolicy(t *testing.T) {
-	testCases := []struct {
-		inputPolicy       *sdk.ScalingPolicy
-		expectedOutputErr error
-		name              string
-	}{
-		{
-			inputPolicy: &sdk.ScalingPolicy{
-				Target: &sdk.ScalingPolicyTarget{
-					Config: map[string]string{"Job": "example", "Group": "cache"},
-				},
-			},
-			expectedOutputErr: nil,
-			name:              "non-horizontal cluster scaling policy target",
-		},
-		{
-			inputPolicy: &sdk.ScalingPolicy{
-				Target: &sdk.ScalingPolicyTarget{
-					Config: map[string]string{"node_class": "puppy"},
-				},
-			},
-			expectedOutputErr: nil,
-			name:              "node_class target policy",
-		},
-		{
-			inputPolicy: &sdk.ScalingPolicy{
-				Target: &sdk.ScalingPolicyTarget{
-					Config: map[string]string{"datacenter": "eu-west-13"},
-				},
-			},
-			expectedOutputErr: nil,
-			name:              "datacenter target policy",
-		},
-		{
-			inputPolicy: &sdk.ScalingPolicy{
-				Target: &sdk.ScalingPolicyTarget{
-					Config: map[string]string{"datacenter": "eu-west-13", "node_class": "puppy"},
-				},
-			},
-			expectedOutputErr: nil,
-			name:              "datacenter and node_class configured target policy",
-		},
-	}
-
-	pr := Processor{}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actualOutputErr := pr.validateHorizontalClusterPolicy(tc.inputPolicy)
-			if tc.expectedOutputErr != nil {
-				assert.EqualError(t, tc.expectedOutputErr, actualOutputErr.Error(), tc.name)
-			} else {
-				assert.Nil(t, actualOutputErr)
-			}
-		})
-	}
-}
-
 func TestProcessor_CanonicalizeAPMQuery(t *testing.T) {
 	testCases := []struct {
 		inputCheck          *sdk.ScalingPolicyCheck

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -102,22 +102,6 @@ func TestProcessor_ValidatePolicy(t *testing.T) {
 			expectedOutput: nil,
 			name:           "valid node_class horizontal cluster scaling policy",
 		},
-		{
-			inputPolicy: &sdk.ScalingPolicy{
-				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
-				Min: 1,
-				Max: 10,
-				Target: &sdk.ScalingPolicyTarget{
-					Config: map[string]string{"node_class": "puppy", "datacenter": "eu-east-17"},
-				},
-			},
-			expectedOutput: &multierror.Error{
-				Errors: []error{
-					errors.New("target config must contain only one of datacenter, node_class"),
-				},
-			},
-			name: "invalid horizontal cluster scaling policy target config",
-		},
 	}
 
 	pr := Processor{}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -169,7 +169,7 @@ func TestProcessor_validateHorizontalClusterPolicy(t *testing.T) {
 					Config: map[string]string{"datacenter": "eu-west-13", "node_class": "puppy"},
 				},
 			},
-			expectedOutputErr: errors.New(`target config must contain only one of datacenter, node_class`),
+			expectedOutputErr: nil,
 			name:              "datacenter and node_class configured target policy",
 		},
 	}

--- a/sdk/helper/scaleutils/nodepool/combined.go
+++ b/sdk/helper/scaleutils/nodepool/combined.go
@@ -63,7 +63,7 @@ func (c *combinedClusterPoolIdentifier) Key() string {
 func (c *combinedClusterPoolIdentifier) Value() string {
 	values := make([]string, 0, len(c.poolIdentifiers))
 	for _, identifier := range c.poolIdentifiers {
-		values = append(values, fmt.Sprintf("%s is %s", identifier.Key(), identifier.Value()))
+		values = append(values, fmt.Sprintf("%s:%s", identifier.Key(), identifier.Value()))
 	}
 	return strings.Join(values, fmt.Sprintf(" %s ", c.mode))
 }

--- a/sdk/helper/scaleutils/nodepool/combined.go
+++ b/sdk/helper/scaleutils/nodepool/combined.go
@@ -1,0 +1,69 @@
+package nodepool
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+const (
+	// CombinedClusterPoolIdentifierAnd requires all identifiers to return true.
+	CombinedClusterPoolIdentifierAnd CombinedClusterPoolIdentifierMode = "and"
+
+	// CombinedClusterPoolIdentifierOr requires at least one identifier to
+	// return true.
+	CombinedClusterPoolIdentifierOr CombinedClusterPoolIdentifierMode = "or"
+)
+
+// CombinedClusterPoolIdentifierMode defines how different
+// ClusterNodePoolIdentifiers are combined.
+type CombinedClusterPoolIdentifierMode string
+
+// combinedClusterPoolIdentifier is an implementation of the
+// ClusterNodePoolIdentifier interface that filters Nomad nodes by combining
+// multiple filters.
+type combinedClusterPoolIdentifier struct {
+	poolIdentifiers []ClusterNodePoolIdentifier
+	mode            CombinedClusterPoolIdentifierMode
+}
+
+// NewCombinedClusterPoolIdentifier returns a new combinedClusterPoolIdentifier.
+func NewCombinedClusterPoolIdentifier(poolIdentifiers []ClusterNodePoolIdentifier, mode CombinedClusterPoolIdentifierMode) ClusterNodePoolIdentifier {
+	return &combinedClusterPoolIdentifier{
+		poolIdentifiers: poolIdentifiers,
+		mode:            mode,
+	}
+}
+
+// IsPoolMember satisfies the IsPoolMember function on the
+// ClusterNodePoolIdentifier interface.
+func (c *combinedClusterPoolIdentifier) IsPoolMember(n *api.NodeListStub) bool {
+	// If mode is 'and' we assume the node is a member unless told otherwise.
+	isMember := c.mode == CombinedClusterPoolIdentifierAnd
+
+	for _, identifier := range c.poolIdentifiers {
+		switch c.mode {
+		case CombinedClusterPoolIdentifierAnd:
+			isMember = isMember && identifier.IsPoolMember(n)
+		case CombinedClusterPoolIdentifierOr:
+			isMember = isMember || identifier.IsPoolMember(n)
+		}
+	}
+	return isMember
+}
+
+// Key satisfies the Key function on the ClusterNodePoolIdentifier interface.
+func (c *combinedClusterPoolIdentifier) Key() string {
+	return "combined_identifier"
+}
+
+// Value satisfies the Value function on the ClusterNodePoolIdentifier
+// interface.
+func (c *combinedClusterPoolIdentifier) Value() string {
+	values := make([]string, 0, len(c.poolIdentifiers))
+	for _, identifier := range c.poolIdentifiers {
+		values = append(values, fmt.Sprintf("%s is %s", identifier.Key(), identifier.Value()))
+	}
+	return strings.Join(values, fmt.Sprintf(" %s ", c.mode))
+}

--- a/sdk/helper/scaleutils/nodepool/combined_test.go
+++ b/sdk/helper/scaleutils/nodepool/combined_test.go
@@ -1,0 +1,146 @@
+package nodepool
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockClusterPoolIdentifier struct{}
+
+func NewMockPoolIdentifier() ClusterNodePoolIdentifier                     { return &mockClusterPoolIdentifier{} }
+func (m *mockClusterPoolIdentifier) IsPoolMember(n *api.NodeListStub) bool { return true }
+func (m *mockClusterPoolIdentifier) Key() string                           { return "mock_identifier" }
+func (c *mockClusterPoolIdentifier) Value() string                         { return "mock_value" }
+
+func TestNewCombinedPoolIdentifier(t *testing.T) {
+	testCases := []struct {
+		name          string
+		identifier    ClusterNodePoolIdentifier
+		expectedValue string
+	}{
+		{
+			name: "single identifier",
+			identifier: NewCombinedClusterPoolIdentifier(
+				[]ClusterNodePoolIdentifier{
+					NewNodeClassPoolIdentifier("test-class"),
+				},
+				CombinedClusterPoolIdentifierAnd,
+			),
+			expectedValue: "node_class is test-class",
+		},
+		{
+			name: "multiple identifiers with and",
+			identifier: NewCombinedClusterPoolIdentifier(
+				[]ClusterNodePoolIdentifier{
+					NewNodeClassPoolIdentifier("test-class"),
+					NewNodeDatacenterPoolIdentifier("test-dc"),
+					NewMockPoolIdentifier(),
+				},
+				CombinedClusterPoolIdentifierAnd,
+			),
+			expectedValue: "node_class is test-class and datacenter is test-dc and mock_identifier is mock_value",
+		},
+		{
+			name: "multiple identifiers with or",
+			identifier: NewCombinedClusterPoolIdentifier(
+				[]ClusterNodePoolIdentifier{
+					NewNodeClassPoolIdentifier("test-class"),
+					NewNodeDatacenterPoolIdentifier("test-dc"),
+					NewMockPoolIdentifier(),
+				},
+				CombinedClusterPoolIdentifierOr,
+			),
+			expectedValue: "node_class is test-class or datacenter is test-dc or mock_identifier is mock_value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, "combined_identifier", tc.identifier.Key())
+			assert.Equal(t, tc.expectedValue, tc.identifier.Value())
+		})
+	}
+}
+
+func TestNewCombinedPoolIdentifier_NodeIsPoolMember(t *testing.T) {
+	testCases := []struct {
+		name       string
+		identifier ClusterNodePoolIdentifier
+		nodes      []*api.NodeListStub
+		expected   []bool
+	}{
+		{
+			name: "find node by class and datacenter",
+			identifier: NewCombinedClusterPoolIdentifier(
+				[]ClusterNodePoolIdentifier{
+					NewNodeClassPoolIdentifier("test-class"),
+					NewNodeDatacenterPoolIdentifier("test-dc"),
+				},
+				CombinedClusterPoolIdentifierAnd,
+			),
+			nodes: []*api.NodeListStub{
+				{
+					NodeClass:  "test-class",
+					Datacenter: "test-dc",
+				},
+				{
+					NodeClass: "test-class",
+				},
+				{
+					Datacenter: "test-dc",
+				},
+				{
+					NodeClass:  "test-wrong-class",
+					Datacenter: "test-dc",
+				},
+				{
+					NodeClass:  "test-wrong-class",
+					Datacenter: "test-wrong-dc",
+				},
+			},
+			expected: []bool{true, false, false, false, false},
+		},
+		{
+			name: "find node by class or datacenter",
+			identifier: NewCombinedClusterPoolIdentifier(
+				[]ClusterNodePoolIdentifier{
+					NewNodeClassPoolIdentifier("test-class"),
+					NewNodeDatacenterPoolIdentifier("test-dc"),
+				},
+				CombinedClusterPoolIdentifierOr,
+			),
+			nodes: []*api.NodeListStub{
+				{
+					NodeClass:  "test-class",
+					Datacenter: "test-dc",
+				},
+				{
+					NodeClass: "test-class",
+				},
+				{
+					Datacenter: "test-dc",
+				},
+				{
+					NodeClass:  "test-wrong-class",
+					Datacenter: "test-dc",
+				},
+				{
+					NodeClass:  "test-wrong-class",
+					Datacenter: "test-wrong-dc",
+				},
+			},
+			expected: []bool{true, true, true, true, false},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, node := range tc.nodes {
+				got := tc.identifier.IsPoolMember(node)
+				assert.Equal(t, tc.expected[i], got)
+			}
+		})
+	}
+}

--- a/sdk/helper/scaleutils/nodepool/combined_test.go
+++ b/sdk/helper/scaleutils/nodepool/combined_test.go
@@ -28,7 +28,7 @@ func TestNewCombinedPoolIdentifier(t *testing.T) {
 				},
 				CombinedClusterPoolIdentifierAnd,
 			),
-			expectedValue: "node_class is test-class",
+			expectedValue: "node_class:test-class",
 		},
 		{
 			name: "multiple identifiers with and",
@@ -40,7 +40,7 @@ func TestNewCombinedPoolIdentifier(t *testing.T) {
 				},
 				CombinedClusterPoolIdentifierAnd,
 			),
-			expectedValue: "node_class is test-class and datacenter is test-dc and mock_identifier is mock_value",
+			expectedValue: "node_class:test-class and datacenter:test-dc and mock_identifier:mock_value",
 		},
 		{
 			name: "multiple identifiers with or",
@@ -52,7 +52,7 @@ func TestNewCombinedPoolIdentifier(t *testing.T) {
 				},
 				CombinedClusterPoolIdentifierOr,
 			),
-			expectedValue: "node_class is test-class or datacenter is test-dc or mock_identifier is mock_value",
+			expectedValue: "node_class:test-class or datacenter:test-dc or mock_identifier:mock_value",
 		},
 	}
 

--- a/sdk/helper/scaleutils/nodepool/nodepool_test.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool_test.go
@@ -43,6 +43,13 @@ func Test_NewClusterNodePoolIdentifier(t *testing.T) {
 			expectedOutputErr:   nil,
 			name:                "node_class configured in config",
 		},
+		{
+			inputCfg:            map[string]string{"node_class": "high-memory", "datacenter": "dc1"},
+			expectedOutputKey:   "combined_identifier",
+			expectedOutputValue: "node_class is high-memory and datacenter is dc1",
+			expectedOutputErr:   nil,
+			name:                "node_class and datacenter are configured in config",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/sdk/helper/scaleutils/nodepool/nodepool_test.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool_test.go
@@ -46,7 +46,7 @@ func Test_NewClusterNodePoolIdentifier(t *testing.T) {
 		{
 			inputCfg:            map[string]string{"node_class": "high-memory", "datacenter": "dc1"},
 			expectedOutputKey:   "combined_identifier",
-			expectedOutputValue: "node_class is high-memory and datacenter is dc1",
+			expectedOutputValue: "node_class:high-memory and datacenter:dc1",
 			expectedOutputErr:   nil,
 			name:                "node_class and datacenter are configured in config",
 		},


### PR DESCRIPTION
The initial implementation for the node filtering would only take either node class or datacenter as the filter input. But as explained in #531, there are valid use cases where defining both is required in order to properly match Nomad clients with cloud instances.

This PR creates a new `ClusterNodePoolIdentifier` called `combinedClusterPoolIdentifier` that can be used to merge other identifiers, applying a simple `and` or `or` logic. 

When both `node_class` and `datacenter` are present in a scaling policy, the Autoscaler will use this combined identifier to merge the existing `NewNodeDatacenterPoolIdentifier` and `NewNodeDatacenterPoolIdentifier` logic with the `and` operator. 

In the future we may add an option to use the `or` operator, but it's not clear to me if there is any real benefit since it would increase the node pool instead of reducing it. Regardless, the capability is there if needed.

Closes #531 