### PR TITLE
Dispense fixed-value, pass-through, and threshold strategy plugins by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 IMPROVEMENTS:
+ * agent: Dispense `fixed-value`, `pass-through`, and `threshold` strategy plugins by default [[GH-536](https://github.com/hashicorp/nomad-autoscaler/pull/536)]
  * policy: Prevent scaling cluster to zero when using the Nomad APM [[GH-534](https://github.com/hashicorp/nomad-autoscaler/pull/534)]
  * scaleutils: Add combined filter to allow filtering by node class and datacenter [[GH-535](https://github.com/hashicorp/nomad-autoscaler/pull/535)]
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -547,9 +547,14 @@ func Default() (*Agent, error) {
 			AckTimeout:    defaultPolicyEvalAckTimeout,
 			Workers:       defaultPolicyEvalWorkers,
 		},
-		APMs:       []*Plugin{{Name: plugins.InternalAPMNomad, Driver: plugins.InternalAPMNomad}},
-		Strategies: []*Plugin{{Name: plugins.InternalStrategyTargetValue, Driver: plugins.InternalStrategyTargetValue}},
-		Targets:    []*Plugin{{Name: plugins.InternalTargetNomad, Driver: plugins.InternalTargetNomad}},
+		APMs: []*Plugin{{Name: plugins.InternalAPMNomad, Driver: plugins.InternalAPMNomad}},
+		Strategies: []*Plugin{
+			{Name: plugins.InternalStrategyFixedValue, Driver: plugins.InternalStrategyFixedValue},
+			{Name: plugins.InternalStrategyPassThrough, Driver: plugins.InternalStrategyPassThrough},
+			{Name: plugins.InternalStrategyTargetValue, Driver: plugins.InternalStrategyTargetValue},
+			{Name: plugins.InternalStrategyThreshold, Driver: plugins.InternalStrategyThreshold},
+		},
+		Targets: []*Plugin{{Name: plugins.InternalTargetNomad, Driver: plugins.InternalTargetNomad}},
 	}, nil
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -28,7 +28,7 @@ func Test_Default(t *testing.T) {
 	assert.Equal(t, defaultPolicyEvalWorkers, def.PolicyEval.Workers)
 	assert.Len(t, def.APMs, 1)
 	assert.Len(t, def.Targets, 1)
-	assert.Len(t, def.Strategies, 1)
+	assert.Len(t, def.Strategies, 4)
 	assert.Equal(t, 1*time.Second, def.Telemetry.CollectionInterval)
 	assert.False(t, def.EnableDebug, "ensure debugging is disabled by default")
 }
@@ -248,8 +248,20 @@ func TestAgent_Merge(t *testing.T) {
 		},
 		Strategies: []*Plugin{
 			{
+				Name:   "fixed-value",
+				Driver: "fixed-value",
+			},
+			{
+				Name:   "pass-through",
+				Driver: "pass-through",
+			},
+			{
 				Name:   "target-value",
 				Driver: "target-value",
+			},
+			{
+				Name:   "threshold",
+				Driver: "threshold",
 			},
 			{
 				Name:   "pid",


### PR DESCRIPTION
When these new strategy plugins were added, we forgot to update the agent to auto-dispense them. 

I wonder if we should just auto-dispense _all_ builtin plugins and add a new flag to allow disabling specific ones if needed, but some of them require additional configuration (like `aws-asg`, `prometheus` etc), so the user would have to declare them anyway.

It would be cool if we could detect plugins that don't require additional config and auto-dispense them, but I couldn't think of a way to easily check this.

Closes #532