### PR TITLE
Fix threhold plugin logic when there are not enough metrics within bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
  * scaleutils: Fixed `least_busy` node selector on clusters running servers older than v1.0.0 [[GH-508](https://github.com/hashicorp/nomad-autoscaler/pull/508)]
+ * plugins/strategy/threshold: Fixed an issue where the wrong scaling action was taken even when the threshold was no met [[GH-537](https://github.com/hashicorp/nomad-autoscaler/pull/537)]
 
 ## 0.3.3 (May 03, 2021)
 

--- a/plugins/builtin/strategy/threshold/plugin/plugin.go
+++ b/plugins/builtin/strategy/threshold/plugin/plugin.go
@@ -102,7 +102,8 @@ func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sd
 	// Check if we have enough data points within bounds.
 	if !withinBounds(logger, eval.Metrics, config) {
 		logger.Trace("not enough data points within bounds")
-		return nil, nil
+		eval.Action.Direction = sdk.ScaleDirectionNone
+		return eval, nil
 	}
 
 	// Calculate new count.

--- a/plugins/builtin/strategy/threshold/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/threshold/plugin/plugin_test.go
@@ -143,7 +143,9 @@ func TestThresholdPlugin(t *testing.T) {
 				"upper_bound": "20",
 				"delta":       "1",
 			},
-			expectedAction: nil,
+			expectedAction: &sdk.ScalingAction{
+				Direction: sdk.ScaleDirectionNone,
+			},
 		},
 		{
 			name:    "custom trigger value",


### PR DESCRIPTION
When there aren't enough metric values within the bound values, the Autoscaler should emit a `none` scaling action since the query values are not enough to cause a change.

Closes #529