### PR TITLE
Fix error message when job scale request fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 BUG FIXES:
  * scaleutils: Fixed `least_busy` node selector on clusters running servers older than v1.0.0 [[GH-508](https://github.com/hashicorp/nomad-autoscaler/pull/508)]
  * plugins/strategy/threshold: Fixed an issue where the wrong scaling action was taken even when the threshold was no met [[GH-537](https://github.com/hashicorp/nomad-autoscaler/pull/537)]
+ * plugins/target/nomad: Fixed an issue where a particular error message would not display the proper policy information [[GH-538](https://github.com/hashicorp/nomad-autoscaler/pull/538)]
 
 ## 0.3.3 (May 03, 2021)
 

--- a/plugins/builtin/target/nomad/plugin/plugin.go
+++ b/plugins/builtin/target/nomad/plugin/plugin.go
@@ -135,7 +135,7 @@ func (t *TargetPlugin) Scale(action sdk.ScalingAction, config map[string]string)
 		&q)
 
 	if err != nil {
-		return fmt.Errorf("failed to scale group %s/%s: %v", config["job_id"], config["group"], err)
+		return fmt.Errorf("failed to scale group %s/%s: %v", config[configKeyJobID], config[configKeyGroup], err)
 	}
 	return nil
 }


### PR DESCRIPTION
Read the right config key when logging the error message.