### PR TITLE
Perform remote service filtering before selecting nodes when scaling in cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
  * agent: Dispense `fixed-value`, `pass-through`, and `threshold` strategy plugins by default [[GH-536](https://github.com/hashicorp/nomad-autoscaler/pull/536)]
  * policy: Prevent scaling cluster to zero when using the Nomad APM [[GH-534](https://github.com/hashicorp/nomad-autoscaler/pull/534)]
  * scaleutils: Add combined filter to allow filtering by node class and datacenter [[GH-535](https://github.com/hashicorp/nomad-autoscaler/pull/535)]
+ * scaleutils: Improve node selection on scale in actions to avoid errors due to invalid nodes [[GH-539](https://github.com/hashicorp/nomad-autoscaler/pull/539)]
 
 BUG FIXES:
  * scaleutils: Fixed `least_busy` node selector on clusters running servers older than v1.0.0 [[GH-508](https://github.com/hashicorp/nomad-autoscaler/pull/508)]

--- a/plugins/builtin/target/aws-asg/plugin/aws_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws_test.go
@@ -5,10 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils"
 	"github.com/hashicorp/nomad/api"
 	"github.com/stretchr/testify/assert"
 )
@@ -48,68 +45,6 @@ func TestTargetPlugin_SetConfig_NonAWS(t *testing.T) {
 				region = "us-east-1"
 			}
 			assert.Equal(t, region, awsPlugin.asg.Config.Region, tc.name)
-		})
-	}
-}
-
-func Test_instancesBelongToASG(t *testing.T) {
-	testCases := []struct {
-		inputASG            *autoscaling.AutoScalingGroup
-		inputIDs            []scaleutils.NodeResourceID
-		expectedOutputList  []string
-		expectedOutputError error
-		name                string
-	}{
-		{
-			inputASG: &autoscaling.AutoScalingGroup{
-				AutoScalingGroupName: aws.String("test"),
-				Instances: []autoscaling.Instance{
-					{InstanceId: aws.String("i-08d2c60605d210f51")},
-					{InstanceId: aws.String("i-08d2c60605d210f52")},
-					{InstanceId: aws.String("i-08d2c60605d210f53")},
-					{InstanceId: aws.String("i-08d2c60605d210f54")},
-					{InstanceId: aws.String("i-08d2c60605d210f55")},
-				},
-			},
-			inputIDs: []scaleutils.NodeResourceID{
-				{RemoteResourceID: "i-08d2c60605d210f51"},
-				{RemoteResourceID: "i-08d2c60605d210f54"},
-			},
-			expectedOutputList: []string{
-				"i-08d2c60605d210f51",
-				"i-08d2c60605d210f54",
-			},
-			expectedOutputError: nil,
-			name:                "multiple matches with zero failure",
-		},
-		{
-			inputASG: &autoscaling.AutoScalingGroup{
-				AutoScalingGroupName: aws.String("test"),
-				Instances: []autoscaling.Instance{
-					{InstanceId: aws.String("i-08d2c60605d210f51")},
-					{InstanceId: aws.String("i-08d2c60605d210f52")},
-					{InstanceId: aws.String("i-08d2c60605d210f53")},
-					{InstanceId: aws.String("i-08d2c60605d210f54")},
-					{InstanceId: aws.String("i-08d2c60605d210f55")},
-				},
-			},
-			inputIDs: []scaleutils.NodeResourceID{
-				{RemoteResourceID: "i-08d2c60605d210f51"},
-				{RemoteResourceID: "i-08d2c60605d210f54"},
-				{RemoteResourceID: "i-08d2c60605d210f58"},
-			},
-			expectedOutputList:  nil,
-			expectedOutputError: errors.New("1 selected nodes are not found within ASG"),
-			name:                "multiple matches with zero failure",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			p := NewAWSASGPlugin(hclog.NewNullLogger())
-			actualList, actualErr := p.instancesBelongToASG(tc.inputASG, tc.inputIDs)
-			assert.Equal(t, tc.expectedOutputList, actualList, tc.name)
-			assert.Equal(t, tc.expectedOutputError, actualErr, tc.name)
 		})
 	}
 }

--- a/plugins/builtin/target/azure-vmss/plugin/plugin.go
+++ b/plugins/builtin/target/azure-vmss/plugin/plugin.go
@@ -47,9 +47,10 @@ var _ target.Target = (*TargetPlugin)(nil)
 
 // TargetPlugin is the Azure VMSS implementation of the target.Target interface.
 type TargetPlugin struct {
-	config       map[string]string
-	logger       hclog.Logger
-	vmss         compute.VirtualMachineScaleSetsClient
+	config  map[string]string
+	logger  hclog.Logger
+	vmss    compute.VirtualMachineScaleSetsClient
+	vmssVMs compute.VirtualMachineScaleSetVMsClient
 
 	// clusterUtils provides general cluster scaling utilities for querying the
 	// state of nodes pools and performing scaling tasks.

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -149,6 +149,8 @@ func (c *ClusterScaleUtils) RunPreScaleInTasksWithRemoteCheck(ctx context.Contex
 			"requested", num, "available", len(filteredNodes))
 	}
 
+	// Select which nodes to drain and terminate based on the policy's
+	// node selector strategy.
 	selectedNodes, err := c.SelectScaleInNodes(filteredNodes, cfg, num)
 	selectedResourceIDs := []NodeResourceID{}
 	for _, n := range selectedNodes {

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -152,6 +152,10 @@ func (c *ClusterScaleUtils) RunPreScaleInTasksWithRemoteCheck(ctx context.Contex
 	// Select which nodes to drain and terminate based on the policy's
 	// node selector strategy.
 	selectedNodes, err := c.SelectScaleInNodes(filteredNodes, cfg, num)
+	if err != nil {
+		return nil, err
+	}
+
 	selectedResourceIDs := []NodeResourceID{}
 	for _, n := range selectedNodes {
 		c.log.Debug("node selected for removal", "node_id", n.ID, "remote_id", nodesResourceIDsMap[n.ID].RemoteResourceID)

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -215,7 +215,6 @@ func (c *ClusterScaleUtils) IdentifyScaleInNodes(cfg map[string]string, num int)
 	if num > len(filteredNodes) {
 		c.log.Warn("can only identify portion of requested nodes for removal",
 			"requested", num, "available", len(filteredNodes))
-		num = len(filteredNodes)
 	}
 
 	return filteredNodes, nil

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -135,6 +135,19 @@ func (c *ClusterScaleUtils) RunPreScaleInTasksWithRemoteCheck(ctx context.Contex
 		}
 	}
 
+	// Ensure we have not filtered out all the available nodes.
+	if len(filteredNodes) == 0 {
+		return nil, fmt.Errorf("no nodes identified for scaling in action")
+	}
+
+	// If the caller has requested more nodes than we have available once
+	// filtered, adjust the value. This shouldn't cause the whole scaling
+	// action to fail, but we should warn.
+	if num > len(filteredNodes) {
+		c.log.Warn("can only identify portion of requested nodes for removal",
+			"requested", num, "available", len(filteredNodes))
+	}
+
 	selectedNodes, err := c.SelectScaleInNodes(filteredNodes, cfg, num)
 	selectedResourceIDs := []NodeResourceID{}
 	for _, n := range selectedNodes {

--- a/sdk/helper/scaleutils/node_identifier_test.go
+++ b/sdk/helper/scaleutils/node_identifier_test.go
@@ -190,31 +190,6 @@ func Test_FilterNodes(t *testing.T) {
 				{
 					ID:                    "node1",
 					NodeClass:             "lionel",
-					Drain:                 false,
-					SchedulingEligibility: api.NodeSchedulingEligible,
-					Status:                api.NodeStatusReady,
-				},
-				{
-					ID:                    "node2",
-					NodeClass:             "lionel",
-					Drain:                 false,
-					SchedulingEligibility: api.NodeSchedulingIneligible,
-					Status:                api.NodeStatusReady,
-				},
-			},
-			inputIDCfg:          map[string]string{"node_class": "lionel"},
-			expectedOutputNodes: nil,
-			expectedOutputError: &multierror.Error{
-				Errors:      []error{errors.New("node node2 is ineligible")},
-				ErrorFormat: errHelper.MultiErrorFunc,
-			},
-			name: "filter of single class input for named class with ineligible error",
-		},
-		{
-			inputNodeList: []*api.NodeListStub{
-				{
-					ID:                    "node1",
-					NodeClass:             "lionel",
 					Drain:                 true,
 					SchedulingEligibility: api.NodeSchedulingIneligible,
 					Status:                api.NodeStatusReady,

--- a/sdk/helper/scaleutils/node_identifier_test.go
+++ b/sdk/helper/scaleutils/node_identifier_test.go
@@ -138,6 +138,57 @@ func Test_FilterNodes(t *testing.T) {
 		{
 			inputNodeList: []*api.NodeListStub{
 				{
+					ID:                    "node-ready-eligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "node-ready-ineligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "node-down-eligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusDown,
+				},
+				{
+					ID:                    "node-down-ineligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusDown,
+				},
+			},
+			inputIDCfg: map[string]string{"node_class": "lionel"},
+			expectedOutputNodes: []*api.NodeListStub{
+				{
+					ID:                    "node-ready-eligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "node-ready-ineligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			expectedOutputError: nil,
+			name:                "filter of nodes that are ready",
+		},
+		{
+			inputNodeList: []*api.NodeListStub{
+				{
 					ID:                    "node1",
 					NodeClass:             "lionel",
 					Drain:                 false,


### PR DESCRIPTION
This PR makes a few changes in the way nodes are selected for cluster scale in action.

### Match instances in target before selecting which nodes to remove

When scaling in a cluster, we must find a set of clients that meet two criteria:
- They match the filtering criteria specified in the policy (`node_class` and/or `datacenter`).
- They belong to the remote service being targeted.

Selecting which nodes to remove can only be reliably executed once both filters are applied since clients in different remote services can have matching filtering criteria (for example, clients with the same `node_class` but in different AWS ASGs).

Currently, the list of nodes that match the filtering criteria is being reduced prematurely to the number of next count, which increases the odds of nodes that don't belong to the remote service being picked. These nodes will cause the scaling action to fail since they won't exist in the remote service target.

This PR refactors `RunPreScaleInTasks` to apply both filters before reducing the pool of selected nodes by the desired amount. 

This refactoring is done in a new function (`RunPreScaleInTasksWithRemoteCheck`) to not break external plugins and to maintain our SDK backwards compatible. In a future release, a breaking change to rename these functions should be done.

### Don't skip ineligible nodes

Originally, the Autoscaler would fail a scaling action unless the cluster nodes were stable: no node could be draining or set as ineligible. This was done to prevent multiple scaling actions over the same set of clients from interfering with each other, or for the Autoscaler to override manual actions by operators.

But in real life, this turned out to be a very restrictive requirement, specially if the Autoscaler happens to crash or fail during a scaling action, leaving behind ineligible nodes and never being able to perform a scaling action again. 

Being an automated system that is supposed to fully manage the lifecycle of clients, it's expected that the Autoscaler will do what ever is necessary to meet policy requirements. If the Autoscaler actions impact operator manual interventions, those policies must be changed or temporarily disabled. 

This PR changes the node filtering logic to not skip ineligible nodes. If a node is ineligible it may not receive more workloads, but it's still present and active in the cluster. If a policy evaluation requires that nodes be removed, they should also be considered. 

### Check for node readiness instead of scheduling eligibility

The original flow only checked for scheduling eligibility, which may be `true` even if the node is `down`, so the Autoscaler could pick nodes that were already removed, so non-existing in the remote service, but not pruned, still registered in Nomad. This would cause scaling actions to fail repeatedly and indefinitely until those nodes are removed.

This PR changes the logic to check for readiness instead.

### Log scale in filtering process

There are several steps required to select which nodes, out of all registered in Nomad, should be selected for termination. It's hard to follow which nodes are being considered and which ones have been dropped and why.

This PR adds more log lines at the `DEBUG` level to provide more visibility during this process. Sample output:

```
2021-11-16T18:56:04.822-0500 [DEBUG] policy_eval.worker.check_handler: calculating new count: check=mem_allocated_percentage id=42a1af42-ec06-85a2-663b-ebf73884784e policy_id=b783aa68-ac68-6aea-a0a0-f18f33b9cbcc queue=cluster source=prometheus strategy=target-value target=gce-mig count=2
2021-11-16T18:56:04.822-0500 [TRACE] internal_plugin.target-value: calculated scaling strategy results: check_name=mem_allocated_percentage current_count=2 new_count=1 metric_value=28.225806451612904 metric_time="2021-11-16 18:56:04 -0500 EST" factor=0.40322580645161293 direction=down
2021-11-16T18:56:04.823-0500 [TRACE] policy_eval.worker: check cpu_allocated_percentage selected: id=42a1af42-ec06-85a2-663b-ebf73884784e policy_id=b783aa68-ac68-6aea-a0a0-f18f33b9cbcc queue=cluster target=gce-mig direction=down count=1
2021-11-16T18:56:04.823-0500 [INFO]  policy_eval.worker: scaling target: id=42a1af42-ec06-85a2-663b-ebf73884784e policy_id=b783aa68-ac68-6aea-a0a0-f18f33b9cbcc queue=cluster target=gce-mig from=2 to=1 reason="scaling down because factor is 0.194879" meta=map[nomad_policy_id:b783aa68-ac68-6aea-a0a0-f18f33b9cbcc]
2021-11-16T18:56:05.311-0500 [DEBUG] internal_plugin.gce-mig: found healthy instance: action=scale_in instance_group=hashistack-nomad-client instance_id=3573983942526237328 instance=https://www.googleapis.com/compute/v1/projects/hashistack-integral-grouse/zones/us-central1-a/instances/hashistack-nomad-client-bwvg
2021-11-16T18:56:05.311-0500 [DEBUG] internal_plugin.gce-mig: found healthy instance: action=scale_in instance_group=hashistack-nomad-client instance_id=2973413554515448488 instance=https://www.googleapis.com/compute/v1/projects/hashistack-integral-grouse/zones/us-central1-a/instances/hashistack-nomad-client-lq2j
2021-11-16T18:56:05.311-0500 [DEBUG] internal_plugin.gce-mig: performing node pool filtering: node_class=hashistack
2021-11-16T18:56:05.361-0500 [DEBUG] internal_plugin.gce-mig: found node: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff datacenter=dc1 node_class=hashistack status=ready eligibility=eligible draining=false
2021-11-16T18:56:05.361-0500 [DEBUG] internal_plugin.gce-mig: found node: node_id=32acccdc-1762-02ac-5786-8d11d668075a datacenter=dc1 node_class=hashistack status=down eligibility=ineligible draining=false
2021-11-16T18:56:05.361-0500 [DEBUG] internal_plugin.gce-mig: found node: node_id=9c25dc22-795f-f848-22e5-3602f1529182 datacenter=dc1 node_class=hashistack status=down eligibility=ineligible draining=false
2021-11-16T18:56:05.361-0500 [DEBUG] internal_plugin.gce-mig: found node: node_id=aa24d314-c1a1-c525-60e9-e05c8cce8880 datacenter=dc1 node_class=hashistack status=down eligibility=ineligible draining=false
2021-11-16T18:56:05.361-0500 [DEBUG] internal_plugin.gce-mig: found node: node_id=9d8f1719-2b61-64ae-bf26-6ecae654bf16 datacenter=dc1 node_class=hashistack status=ready eligibility=eligible draining=false
2021-11-16T18:56:05.361-0500 [DEBUG] internal_plugin.gce-mig: node passed filter criteria: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff
2021-11-16T18:56:05.361-0500 [DEBUG] internal_plugin.gce-mig: node passed filter criteria: node_id=9d8f1719-2b61-64ae-bf26-6ecae654bf16
2021-11-16T18:56:05.428-0500 [DEBUG] internal_plugin.gce-mig: identified remote provider ID for node: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff remote_id=zones/us-central1-a/instances/hashistack-nomad-client-bwvg
2021-11-16T18:56:05.476-0500 [DEBUG] internal_plugin.gce-mig: identified remote provider ID for node: node_id=9d8f1719-2b61-64ae-bf26-6ecae654bf16 remote_id=zones/us-central1-a/instances/hashistack-nomad-client-lq2j
2021-11-16T18:56:05.476-0500 [DEBUG] internal_plugin.gce-mig: node is part of the policy target: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff remote_id=zones/us-central1-a/instances/hashistack-nomad-client-bwvg
2021-11-16T18:56:05.476-0500 [DEBUG] internal_plugin.gce-mig: node is part of the policy target: node_id=9d8f1719-2b61-64ae-bf26-6ecae654bf16 remote_id=zones/us-central1-a/instances/hashistack-nomad-client-lq2j
2021-11-16T18:56:05.476-0500 [DEBUG] internal_plugin.gce-mig: performing node selection: selector_strategy=least_busy
2021-11-16T18:56:05.601-0500 [DEBUG] internal_plugin.gce-mig: node selected for removal: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff remote_id=zones/us-central1-a/instances/hashistack-nomad-client-bwvg
2021-11-16T18:56:05.602-0500 [INFO]  internal_plugin.gce-mig: triggering drain on node: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff deadline=5m0s
2021-11-16T18:56:05.736-0500 [INFO]  internal_plugin.gce-mig: received node drain message: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff msg="Drain complete for node b11b215a-64f4-e9f4-4b07-0a5a0f7533ff"
2021-11-16T18:56:05.886-0500 [DEBUG] internal_plugin.gce-mig: received node drain message: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff msg="Alloc "1276d3f6-cd42-a908-dc6e-5723a4481162" status running -> complete"
2021-11-16T18:56:05.886-0500 [INFO]  internal_plugin.gce-mig: received node drain message: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff msg="All allocations on node "b11b215a-64f4-e9f4-4b07-0a5a0f7533ff" have stopped"
2021-11-16T18:56:05.886-0500 [DEBUG] internal_plugin.gce-mig: node drain complete: node_id=b11b215a-64f4-e9f4-4b07-0a5a0f7533ff
2021-11-16T18:56:05.886-0500 [DEBUG] internal_plugin.gce-mig: pre scale-in tasks now complete
2021-11-16T18:56:05.886-0500 [DEBUG] internal_plugin.gce-mig: deleting GCE MIG instances: action=scale_in instance_group=hashistack-nomad-client instances=["{b11b215a-64f4-e9f4-4b07-0a5a0f7533ff zones/us-central1-a/instances/hashistack-nomad-client-bwvg}"]
2021-11-16T18:56:06.463-0500 [INFO]  internal_plugin.gce-mig: successfully deleted GCE MIG instances: action=scale_in instance_group=hashistack-nomad-client
```

Maybe they should be at the `TRACE` level since some clusters may have thousands of nodes? I'm not sure, but they are useful for debugging in general.

Closes #477 #511