### PR TITLE
Prevent the Nomad target plugin from being blocked

### DIFF
--- a/plugins/builtin/target/nomad/plugin/plugin.go
+++ b/plugins/builtin/target/nomad/plugin/plugin.go
@@ -51,7 +51,7 @@ var (
 
 	// statusHandlerInitTimeout is the time limit a status handler must
 	// initialize before considering the operation a failure.
-	// Declare it as a var instead of a const so we can overwrite in tests.
+	// Declare it as a var instead of a const so we can overwrite it in tests.
 	statusHandlerInitTimeout = 30 * time.Second
 )
 

--- a/plugins/builtin/target/nomad/plugin/plugin.go
+++ b/plugins/builtin/target/nomad/plugin/plugin.go
@@ -211,6 +211,7 @@ func (t *TargetPlugin) garbageCollect() {
 
 	// Iterate all the handlers, ensuring we lock for safety.
 	t.statusHandlersLock.Lock()
+	defer t.statusHandlersLock.Unlock()
 
 	for jobID, handle := range t.statusHandlers {
 
@@ -226,6 +227,4 @@ func (t *TargetPlugin) garbageCollect() {
 			t.logger.Debug("removed inactive job status handler", "job_id", jobID)
 		}
 	}
-
-	t.statusHandlersLock.Unlock()
 }

--- a/plugins/builtin/target/nomad/plugin/plugin_test.go
+++ b/plugins/builtin/target/nomad/plugin/plugin_test.go
@@ -1,10 +1,13 @@
 package nomad
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/sdk"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,12 +20,12 @@ func TestTargetPlugin_garbageCollect(t *testing.T) {
 	targetPlugin := TargetPlugin{
 		logger: hclog.NewNullLogger(),
 		statusHandlers: map[namespacedJobID]*jobScaleStatusHandler{
-			namespacedJobID{"default", "running"}:               {isRunning: true, lastUpdated: curTime},
-			namespacedJobID{"default", "recently-stopped"}:      {isRunning: false, lastUpdated: curTime - 1800000000000},
-			namespacedJobID{"default", "stopped-long-time-ago"}: {isRunning: false, lastUpdated: curTime - 18000000000000},
-			namespacedJobID{"special", "running"}:               {isRunning: true, lastUpdated: curTime},
-			namespacedJobID{"special", "recently-stopped"}:      {isRunning: false, lastUpdated: curTime - 1800000000000},
-			namespacedJobID{"special", "stopped-long-time-ago"}: {isRunning: false, lastUpdated: curTime - 18000000000000},
+			{"default", "running"}:               {isRunning: true, lastUpdated: curTime},
+			{"default", "recently-stopped"}:      {isRunning: false, lastUpdated: curTime - 1800000000000},
+			{"default", "stopped-long-time-ago"}: {isRunning: false, lastUpdated: curTime - 18000000000000},
+			{"special", "running"}:               {isRunning: true, lastUpdated: curTime},
+			{"special", "recently-stopped"}:      {isRunning: false, lastUpdated: curTime - 1800000000000},
+			{"special", "stopped-long-time-ago"}: {isRunning: false, lastUpdated: curTime - 18000000000000},
 		},
 	}
 
@@ -38,4 +41,41 @@ func TestTargetPlugin_garbageCollect(t *testing.T) {
 		assert.NotNil(t, targetPlugin.statusHandlers[namespacedJobID{"special", "recently-stopped"}], testName)
 		assert.Len(t, targetPlugin.statusHandlers, 4, testName)
 	})
+}
+
+func TestTargetPlugin_statusTimeout(t *testing.T) {
+	nomadMock := httptest.NewServer(http.HandlerFunc(scaleStatusHandler))
+	defer nomadMock.Close()
+
+	statusHandlerInitTimeout = 3 * time.Second
+
+	plugin := PluginConfig.Factory(hclog.NewNullLogger()).(*TargetPlugin)
+	plugin.SetConfig(map[string]string{
+		"nomad_address": nomadMock.URL,
+	})
+
+	var statusErr error
+	var status *sdk.TargetStatus
+	doneCh := make(chan struct{})
+	go func() {
+		status, statusErr = plugin.Status(map[string]string{
+			"Job":       "example",
+			"Group":     "cache",
+			"Namespace": "default",
+		})
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+	case <-time.After(2 * statusHandlerInitTimeout):
+		t.Fatalf("status call blocked")
+	}
+
+	assert.Error(t, statusErr)
+	assert.Nil(t, status)
+}
+
+func scaleStatusHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
 }

--- a/plugins/builtin/target/nomad/plugin/state.go
+++ b/plugins/builtin/target/nomad/plugin/state.go
@@ -74,7 +74,7 @@ func newJobScaleStatusHandler(client *api.Client, ns, jobID string, logger hclog
 	go jsh.start()
 
 	// Wait for initial status data to be loaded.
-	// Set a timeout to make sure callers are not blocked indefinetely.
+	// Set a timeout to make sure callers are not blocked indefinitely.
 	select {
 	case <-jsh.initialDone:
 	case <-time.After(statusHandlerInitTimeout):

--- a/plugins/builtin/target/nomad/plugin/state_test.go
+++ b/plugins/builtin/target/nomad/plugin/state_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/sdk"
 	"github.com/hashicorp/nomad/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_newJobStateHandler(t *testing.T) {
@@ -17,7 +18,9 @@ func Test_newJobStateHandler(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Create the new handler and perform assertions.
-	jsh := newJobScaleStatusHandler(c, "default", "test", hclog.NewNullLogger())
+	jsh, err := newJobScaleStatusHandler(c, "default", "test", hclog.NewNullLogger())
+	require.NoError(t, err)
+
 	assert.NotNil(t, jsh.client)
 	assert.Equal(t, "test", jsh.jobID)
 	assert.NotNil(t, jsh.initialDone)
@@ -111,10 +114,8 @@ func Test_jobStateHandler_status(t *testing.T) {
 }
 
 func Test_jobStateHandler_updateStatusState(t *testing.T) {
-	c, err := api.NewClient(api.DefaultConfig())
-	assert.Nil(t, err)
-
-	jsh := newJobScaleStatusHandler(c, "", "", hclog.NewNullLogger())
+	jsh := &jobScaleStatusHandler{}
+	jsh.initialDone = make(chan bool)
 
 	// Assert that the lastUpdated timestamp is default. This helps confirm it
 	// gets updated later in the test.

--- a/plugins/builtin/target/nomad/plugin/state_test.go
+++ b/plugins/builtin/target/nomad/plugin/state_test.go
@@ -111,7 +111,10 @@ func Test_jobStateHandler_status(t *testing.T) {
 }
 
 func Test_jobStateHandler_updateStatusState(t *testing.T) {
-	jsh := &jobScaleStatusHandler{}
+	c, err := api.NewClient(api.DefaultConfig())
+	assert.Nil(t, err)
+
+	jsh := newJobScaleStatusHandler(c, "", "", hclog.NewNullLogger())
 
 	// Assert that the lastUpdated timestamp is default. This helps confirm it
 	// gets updated later in the test.

--- a/policy/handler.go
+++ b/policy/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"sync"
 	"time"
@@ -309,6 +310,12 @@ func (h *Handler) updateHandler(current, next *sdk.ScalingPolicy) {
 	// policy's evaluation interval has changed.
 	if current == nil || current.EvaluationInterval != next.EvaluationInterval {
 		h.ticker.Stop()
+
+		// Add a small random delay to spread the first evaluation of policies
+		// that are evaluated at the same time.
+		splayNs := rand.Intn(30) * 100 * 1000 * 1000
+		time.Sleep(time.Duration(splayNs))
+
 		h.ticker = time.NewTicker(next.EvaluationInterval)
 	}
 }

--- a/policy/handler.go
+++ b/policy/handler.go
@@ -311,8 +311,8 @@ func (h *Handler) updateHandler(current, next *sdk.ScalingPolicy) {
 	if current == nil || current.EvaluationInterval != next.EvaluationInterval {
 		h.ticker.Stop()
 
-		// Add a small random delay to spread the first evaluation of policies
-		// that are evaluated at the same time.
+		// Add a small random delay between 0 and 300ms to spread the first
+		// evaluation of policies that are loaded at the same time.
 		splayNs := rand.Intn(30) * 100 * 1000 * 1000
 		time.Sleep(time.Duration(splayNs))
 


### PR DESCRIPTION
The Nomad target plugin caches job and group status locally to avoid querying the Nomad API every time a policy is evaluated. This is done by having background gorotuines that use blocking queries to update the local state whenever the job scale status changes.

The current implementation has a bug that can be triggered when the Nomad API returns an error at the first run. The blocking query look gets stuck in [this loop](https://github.com/hashicorp/nomad-autoscaler/blob/v0.3.3/plugins/builtin/target/nomad/plugin/state.go#L135-L157) causing [`jsh.handleFirstRun()`](https://github.com/hashicorp/nomad-autoscaler/blob/v0.3.3/plugins/builtin/target/nomad/plugin/state.go#L172) to never be called. This, in turn, blocks the entire plugin since the plugin `Status` call would be waiting indefinitely for the [channel signal](https://github.com/hashicorp/nomad-autoscaler/blob/v0.3.3/plugins/builtin/target/nomad/plugin/plugin.go#L182) whilst [holding the `statusHandlersLock`](https://github.com/hashicorp/nomad-autoscaler/blob/v0.3.3/plugins/builtin/target/nomad/plugin/plugin.go#L170).

This PR makes a few changes to avoid this situation.

#### Add a timeout to limit how long handlers can take to start

Once a handler starts, it never stops unless it receives a `404` from the API, meaning the job being monitored doesn't exist anymore. But in order for the plugin to work properly, it must return the target status at least once. If the API calls fails continually at first run, we should consider the handler as invalid and return an error. The target can then checked again in the next policy evaluation.

With this timeout, the plugin is guarantee to unblock and release the lock even if an error occurs in the first run.

#### Internalize access to internal handler state

The handlers internal state was being accessed directly by the plugin in some cases, such as calls to `Status` and the garbage collector. Since calls to the plugin are made concurrently by the policy workers, without any synchronization mechanism there were a high potential for data races to happen. 

This PR internalizes the state of handlers, such that they are only accessed via methods that must acquire an internal mutex lock beforehand.

#### Reducing thundering herd problems

Policies are evaluated at an interval set by their own properties. The starting time that the evaluations happen are set when they are first read. When multiple policies are read at the same time, and have the same `evaluation_interval`, they would all be evaluated at the same time, every time, causing a spike in load on the Autoscaler.

This PR adds a small random delay to distribute evaluations of policies registered at the same time.

Closes #514 