### PR TITLE
Allow enabling and disabling policy sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 IMPROVEMENTS:
+ * agent: Allow disabling specific policy sources [[GH-544](https://github.com/hashicorp/nomad-autoscaler/pull/544)]
  * agent: Dispense `fixed-value`, `pass-through`, and `threshold` strategy plugins by default [[GH-536](https://github.com/hashicorp/nomad-autoscaler/pull/536)]
  * policy: Prevent scaling cluster to zero when using the Nomad APM [[GH-534](https://github.com/hashicorp/nomad-autoscaler/pull/534)]
  * scaleutils: Add combined filter to allow filtering by node class and datacenter [[GH-535](https://github.com/hashicorp/nomad-autoscaler/pull/535)]

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -148,7 +148,7 @@ func (a *Agent) setupPolicyManager() (chan *sdk.ScalingEvaluation, error) {
 	// Setup our initial default policy source which is Nomad.
 	sources := map[policy.SourceName]policy.Source{}
 	for _, s := range a.config.Policy.Sources {
-		if !s.Enabled {
+		if s.Enabled == nil || !*s.Enabled {
 			continue
 		}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -147,7 +147,7 @@ func (a *Agent) setupPolicyManager() (chan *sdk.ScalingEvaluation, error) {
 
 	// Setup our initial default policy source which is Nomad.
 	sources := map[policy.SourceName]policy.Source{}
-	for _, s := range a.config.PolicySources {
+	for _, s := range a.config.Policy.Sources {
 		if !s.Enabled {
 			continue
 		}

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -59,9 +59,8 @@ func TestAgent_Merge(t *testing.T) {
 		Policy: &Policy{
 			Sources: []*PolicySource{
 				{
-					Name:       "nomad",
-					EnabledPtr: ptr.BoolToPtr(false),
-					Enabled:    false,
+					Name:    "nomad",
+					Enabled: ptr.BoolToPtr(false),
 				},
 			},
 		},
@@ -112,14 +111,12 @@ func TestAgent_Merge(t *testing.T) {
 			DefaultEvaluationInterval: 10 * time.Second,
 			Sources: []*PolicySource{
 				{
-					Name:       "file",
-					EnabledPtr: ptr.BoolToPtr(false),
-					Enabled:    false,
+					Name:    "file",
+					Enabled: ptr.BoolToPtr(false),
 				},
 				{
-					Name:       "nomad",
-					EnabledPtr: ptr.BoolToPtr(true),
-					Enabled:    true,
+					Name:    "nomad",
+					Enabled: ptr.BoolToPtr(true),
 				},
 			},
 		},
@@ -214,14 +211,12 @@ func TestAgent_Merge(t *testing.T) {
 			DefaultEvaluationInterval: 10 * time.Second,
 			Sources: []*PolicySource{
 				{
-					Name:       "file",
-					EnabledPtr: ptr.BoolToPtr(false),
-					Enabled:    false,
+					Name:    "file",
+					Enabled: ptr.BoolToPtr(false),
 				},
 				{
-					Name:       "nomad",
-					EnabledPtr: ptr.BoolToPtr(true),
-					Enabled:    true,
+					Name:    "nomad",
+					Enabled: ptr.BoolToPtr(true),
 				},
 			},
 		},
@@ -455,9 +450,8 @@ policy {
 
 	expected := []*PolicySource{
 		{
-			Name:       "nomad",
-			EnabledPtr: nil,
-			Enabled:    true,
+			Name:    "nomad",
+			Enabled: ptr.BoolToPtr(true),
 		},
 	}
 	assert.ElementsMatch(t, expected, cfg.Policy.Sources)
@@ -485,14 +479,12 @@ policy {
 	result := defaultConfig.Merge(cfg)
 	expected = []*PolicySource{
 		{
-			Name:       "file",
-			EnabledPtr: nil,
-			Enabled:    true,
+			Name:    "file",
+			Enabled: ptr.BoolToPtr(true),
 		},
 		{
-			Name:       "nomad",
-			EnabledPtr: ptr.BoolToPtr(false),
-			Enabled:    false,
+			Name:    "nomad",
+			Enabled: ptr.BoolToPtr(false),
 		},
 	}
 	assert.ElementsMatch(t, expected, result.Policy.Sources)
@@ -520,14 +512,12 @@ policy {
 	result = defaultConfig.Merge(cfg)
 	expected = []*PolicySource{
 		{
-			Name:       "file",
-			EnabledPtr: ptr.BoolToPtr(false),
-			Enabled:    false,
+			Name:    "file",
+			Enabled: ptr.BoolToPtr(false),
 		},
 		{
-			Name:       "nomad",
-			EnabledPtr: nil,
-			Enabled:    true,
+			Name:    "nomad",
+			Enabled: ptr.BoolToPtr(true),
 		},
 	}
 	assert.ElementsMatch(t, expected, result.Policy.Sources)

--- a/command/agent.go
+++ b/command/agent.go
@@ -483,14 +483,14 @@ func (c *AgentCommand) readConfig() (*config.Agent, []string) {
 
 	if disableFileSource {
 		cmdConfig.Policy.Sources = append(cmdConfig.Policy.Sources, &config.PolicySource{
-			Name:       string(policy.SourceNameFile),
-			EnabledPtr: ptr.BoolToPtr(false),
+			Name:    string(policy.SourceNameFile),
+			Enabled: ptr.BoolToPtr(false),
 		})
 	}
 	if disableNomadSource {
 		cmdConfig.Policy.Sources = append(cmdConfig.Policy.Sources, &config.PolicySource{
-			Name:       string(policy.SourceNameNomad),
-			EnabledPtr: ptr.BoolToPtr(false),
+			Name:    string(policy.SourceNameNomad),
+			Enabled: ptr.BoolToPtr(false),
 		})
 	}
 

--- a/command/agent.go
+++ b/command/agent.go
@@ -345,10 +345,11 @@ func (c *AgentCommand) readConfig() (*config.Agent, []string) {
 		DynamicApplicationSizing: &config.DynamicApplicationSizing{},
 		HTTP:                     &config.HTTP{},
 		Nomad:                    &config.Nomad{},
-		Policy:                   &config.Policy{},
-		PolicyEval:               &config.PolicyEval{},
-		Telemetry:                &config.Telemetry{},
-		PolicySources:            []*config.PolicySource{},
+		Policy: &config.Policy{
+			Sources: []*config.PolicySource{},
+		},
+		PolicyEval: &config.PolicyEval{},
+		Telemetry:  &config.Telemetry{},
 	}
 
 	var disableFileSource bool
@@ -481,13 +482,13 @@ func (c *AgentCommand) readConfig() (*config.Agent, []string) {
 	}
 
 	if disableFileSource {
-		cmdConfig.PolicySources = append(cmdConfig.PolicySources, &config.PolicySource{
+		cmdConfig.Policy.Sources = append(cmdConfig.Policy.Sources, &config.PolicySource{
 			Name:       string(policy.SourceNameFile),
 			EnabledPtr: ptr.BoolToPtr(false),
 		})
 	}
 	if disableNomadSource {
-		cmdConfig.PolicySources = append(cmdConfig.PolicySources, &config.PolicySource{
+		cmdConfig.Policy.Sources = append(cmdConfig.Policy.Sources, &config.PolicySource{
 			Name:       string(policy.SourceNameNomad),
 			EnabledPtr: ptr.BoolToPtr(false),
 		})

--- a/command/agent.go
+++ b/command/agent.go
@@ -11,7 +11,9 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/agent"
 	"github.com/hashicorp/nomad-autoscaler/agent/config"
 	agentHTTP "github.com/hashicorp/nomad-autoscaler/agent/http"
+	"github.com/hashicorp/nomad-autoscaler/policy"
 	flaghelper "github.com/hashicorp/nomad-autoscaler/sdk/helper/flag"
+	"github.com/hashicorp/nomad-autoscaler/sdk/helper/ptr"
 	"github.com/hashicorp/nomad-autoscaler/version"
 )
 
@@ -162,6 +164,14 @@ Policy Evaluation Options:
     <queue1>:<num>,<queue2>:<num>. Nomad Autoscaler supports "cluster" and
 	"horizontal" queues. Nomad Autoscaler Enterprise supports additional
 	"vertical_mem" and "vertical_cpu" queues.
+
+Policy Source Options:
+
+  -policy-source-disable-file
+    Disable the sourcing of policies from disk.
+
+  -policy-source-disable-nomad
+    Disable the sourcing of policies from the Nomad API.
 
 Telemetry Options:
 
@@ -338,7 +348,11 @@ func (c *AgentCommand) readConfig() (*config.Agent, []string) {
 		Policy:                   &config.Policy{},
 		PolicyEval:               &config.PolicyEval{},
 		Telemetry:                &config.Telemetry{},
+		PolicySources:            []*config.PolicySource{},
 	}
+
+	var disableFileSource bool
+	var disableNomadSource bool
 
 	modeChecker := config.NewModeChecker()
 
@@ -423,6 +437,10 @@ func (c *AgentCommand) readConfig() (*config.Agent, []string) {
 		return nil
 	}), "policy-eval-workers", "")
 
+	// Specify our Policy Sources flags.
+	flags.BoolVar(&disableFileSource, "policy-source-disable-file", false, "")
+	flags.BoolVar(&disableNomadSource, "policy-source-disable-nomad", false, "")
+
 	// Specify our Telemetry CLI flags.
 	flags.BoolVar(&cmdConfig.Telemetry.DisableHostname, "telemetry-disable-hostname", false, "")
 	flags.BoolVar(&cmdConfig.Telemetry.EnableHostnameLabel, "telemetry-enable-hostname-label", false, "")
@@ -460,6 +478,19 @@ func (c *AgentCommand) readConfig() (*config.Agent, []string) {
 	if err := modeChecker.ValidateFlags(flags); err != nil {
 		fmt.Printf("%s\n", err)
 		return nil, configPath
+	}
+
+	if disableFileSource {
+		cmdConfig.PolicySources = append(cmdConfig.PolicySources, &config.PolicySource{
+			Name:       string(policy.SourceNameFile),
+			EnabledPtr: ptr.BoolToPtr(false),
+		})
+	}
+	if disableNomadSource {
+		cmdConfig.PolicySources = append(cmdConfig.PolicySources, &config.PolicySource{
+			Name:       string(policy.SourceNameNomad),
+			EnabledPtr: ptr.BoolToPtr(false),
+		})
 	}
 
 	// Validate config values from flags.

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -122,9 +122,11 @@ func TestCommandAgent_readConfig(t *testing.T) {
 				"-policy-source-disable-nomad",
 			},
 			want: defaultConfig.Merge(&config.Agent{
-				PolicySources: []*config.PolicySource{
-					{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
-					{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+				Policy: &config.Policy{
+					Sources: []*config.PolicySource{
+						{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+						{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+					},
 				},
 			}),
 		},
@@ -226,6 +228,10 @@ func TestCommandAgent_readConfig(t *testing.T) {
 					Dir:                       "./policy-dir-from-file",
 					DefaultCooldown:           12 * time.Second,
 					DefaultEvaluationInterval: 50 * time.Minute,
+					Sources: []*config.PolicySource{
+						{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+						{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+					},
 				},
 				PolicyEval: &config.PolicyEval{
 					DeliveryLimit:    10,
@@ -235,10 +241,6 @@ func TestCommandAgent_readConfig(t *testing.T) {
 						"cluster":    3,
 						"horizontal": 1,
 					},
-				},
-				PolicySources: []*config.PolicySource{
-					{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
-					{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
 				},
 			}),
 		},
@@ -318,6 +320,10 @@ func TestCommandAgent_readConfig(t *testing.T) {
 					Dir:                       "./policy-dir-from-file",
 					DefaultCooldown:           12 * time.Second,
 					DefaultEvaluationInterval: 50 * time.Minute,
+					Sources: []*config.PolicySource{
+						{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+						{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+					},
 				},
 				PolicyEval: &config.PolicyEval{
 					DeliveryLimit:    10,
@@ -327,10 +333,6 @@ func TestCommandAgent_readConfig(t *testing.T) {
 						"cluster":    3,
 						"horizontal": 1,
 					},
-				},
-				PolicySources: []*config.PolicySource{
-					{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
-					{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
 				},
 			}),
 		},

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -116,6 +116,19 @@ func TestCommandAgent_readConfig(t *testing.T) {
 			}),
 		},
 		{
+			name: "policy source flags",
+			args: []string{
+				"-policy-source-disable-file",
+				"-policy-source-disable-nomad",
+			},
+			want: defaultConfig.Merge(&config.Agent{
+				PolicySources: []*config.PolicySource{
+					{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+					{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+				},
+			}),
+		},
+		{
 			name: "telemetry flags",
 			args: []string{
 				"-telemetry-disable-hostname",
@@ -223,6 +236,10 @@ func TestCommandAgent_readConfig(t *testing.T) {
 						"horizontal": 1,
 					},
 				},
+				PolicySources: []*config.PolicySource{
+					{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+					{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+				},
 			}),
 		},
 		{
@@ -311,6 +328,10 @@ func TestCommandAgent_readConfig(t *testing.T) {
 						"horizontal": 1,
 					},
 				},
+				PolicySources: []*config.PolicySource{
+					{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+					{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+				},
 			}),
 		},
 	}
@@ -321,11 +342,16 @@ func TestCommandAgent_readConfig(t *testing.T) {
 			got, _ := c.readConfig()
 
 			// Sort the list of plugins to avoid flakiness.
-			sortOpt := cmpopts.SortSlices(func(x, y *config.Plugin) bool {
+			pluginsSortOpt := cmpopts.SortSlices(func(x, y *config.Plugin) bool {
 				return x.Name < y.Name
 			})
 
-			if diff := cmp.Diff(tc.want, got, sortOpt); diff != "" {
+			// Sort the list of policy sources to avoid flakiness.
+			policySourcesSortOpt := cmpopts.SortSlices(func(x, y *config.PolicySource) bool {
+				return x.Name < y.Name
+			})
+
+			if diff := cmp.Diff(tc.want, got, pluginsSortOpt, policySourcesSortOpt); diff != "" {
 				t.Errorf("readConfig() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -124,8 +124,8 @@ func TestCommandAgent_readConfig(t *testing.T) {
 			want: defaultConfig.Merge(&config.Agent{
 				Policy: &config.Policy{
 					Sources: []*config.PolicySource{
-						{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
-						{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+						{Name: "file", Enabled: ptr.BoolToPtr(false)},
+						{Name: "nomad", Enabled: ptr.BoolToPtr(false)},
 					},
 				},
 			}),
@@ -229,8 +229,8 @@ func TestCommandAgent_readConfig(t *testing.T) {
 					DefaultCooldown:           12 * time.Second,
 					DefaultEvaluationInterval: 50 * time.Minute,
 					Sources: []*config.PolicySource{
-						{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
-						{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+						{Name: "file", Enabled: ptr.BoolToPtr(false)},
+						{Name: "nomad", Enabled: ptr.BoolToPtr(false)},
 					},
 				},
 				PolicyEval: &config.PolicyEval{
@@ -321,8 +321,8 @@ func TestCommandAgent_readConfig(t *testing.T) {
 					DefaultCooldown:           12 * time.Second,
 					DefaultEvaluationInterval: 50 * time.Minute,
 					Sources: []*config.PolicySource{
-						{Name: "file", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
-						{Name: "nomad", EnabledPtr: ptr.BoolToPtr(false), Enabled: false},
+						{Name: "file", Enabled: ptr.BoolToPtr(false)},
+						{Name: "nomad", Enabled: ptr.BoolToPtr(false)},
 					},
 				},
 				PolicyEval: &config.PolicyEval{

--- a/command/test-fixtures/agent_config_full.hcl
+++ b/command/test-fixtures/agent_config_full.hcl
@@ -40,6 +40,14 @@ policy {
   dir                         = "./policy-dir-from-file"
   default_cooldown            = "12s"
   default_evaluation_interval = "50m"
+
+  source "file" {
+    enabled = false
+  }
+
+  source "nomad" {
+    enabled = false
+  }
 }
 
 policy_eval {
@@ -50,12 +58,4 @@ policy_eval {
     cluster    = 3
     horizontal = 1
   }
-}
-
-source "file" {
-  enabled = false
-}
-
-source "nomad" {
-  enabled = false
 }

--- a/command/test-fixtures/agent_config_full.hcl
+++ b/command/test-fixtures/agent_config_full.hcl
@@ -23,21 +23,21 @@ nomad {
 }
 
 consul {
-  address = "https://consul_from_file.example.com:8500"
-  timeout = "2m"
-  token = "TOKEN_FROM_FILE"
-  auth = "user:file"
-  ssl =  true
+  address    = "https://consul_from_file.example.com:8500"
+  timeout    = "2m"
+  token      = "TOKEN_FROM_FILE"
+  auth       = "user:file"
+  ssl        = true
   verify_ssl = true
-  ca_file = "./ca-from-file.pem"
-  cert_file = "./cert-from-file.pem"
-  key_file = "./key-from-file.pem"
-  namespace = "namespace-from-file"
+  ca_file    = "./ca-from-file.pem"
+  cert_file  = "./cert-from-file.pem"
+  key_file   = "./key-from-file.pem"
+  namespace  = "namespace-from-file"
   datacenter = "datacenter-from-file"
 }
 
 policy {
-dir                         = "./policy-dir-from-file"
+  dir                         = "./policy-dir-from-file"
   default_cooldown            = "12s"
   default_evaluation_interval = "50m"
 }
@@ -50,4 +50,12 @@ policy_eval {
     cluster    = 3
     horizontal = 1
   }
+}
+
+source "file" {
+  enabled = false
+}
+
+source "nomad" {
+  enabled = false
 }

--- a/policy/manager.go
+++ b/policy/manager.go
@@ -62,6 +62,7 @@ func (m *Manager) Run(ctx context.Context, evalCh chan<- *sdk.ScalingEvaluation)
 
 	// Start the policy source and listen for changes in the list of policy IDs
 	for _, s := range m.policySource {
+		m.log.Info("starting policy source", "source", s.Name())
 		req := MonitorIDsReq{ErrCh: policyIDsErrCh, ResultCh: policyIDsCh}
 		go s.MonitorIDs(monitorCtx, req)
 	}


### PR DESCRIPTION
This PR builds on top of the approach taken in #525 but allows a more flexible way to define which policy sources should be enabled.

It introduces a new configuration block called `source` that can be placed within the existing `policy` block. Currently this block takes only a label that specifies which source it controls and a boolean attribute to enable or disable it:

```hcl
policy {
  source "nomad" {
    enabled = false
  }
}
```

Both `file` and `nomad` sources are initially enabled by default, with `file` requiring that `policy -> dir` is also defined to be fully enabled, so everything remains backwards compatible.

The CLI flag parsing is a bit different than others, and it special cases the existing policy sources. This seems fine to me, as all policy sources are internal and having CLI flags to disable them sounds pretty useful.

If no policy source is enabled, the Autoscaler agent will fail and exit, since it won't be able to do any work without policies. In the future, we may want to implement a full reload of policy sources via `SIGHUP` so that sources can be enabled/disabled dynamically.

### Possible future enhancements

This approach allows further customization of policy sources, such as moving the current `policy -> dir` into a new `config` map inside the `file` source:

```hcl
source "file" {
  # Possible future enhancement.
  config = {
    dir = "./policies"
  }
}
```

With this, we could start supporting multiple configurations for the same policy source, such as reading policies from multiple paths:

```hcl
source "file" "aws" {
  # Possible future enhancement.
  config = {
    dir = "./policies/aws"
  }
}

source "file" "gcp" {
  # Possible future enhancement.
  config = {
    dir = "./policies/gcp"
  }
}
```

Another possibility would be to start supporting external policy source plugins:

```hcl
source "my-plugin" {
  # Possible future enhancement.
  driver = "my_source_plugin"
  config = {
    key = "value"
  }
}
```

This pattern of disabling internal components via a `enabled` attribute could also be used for plugins:

```hcl
strategy "target-value" {
  driver  = "target-value"
  # Possible future enhancement.
  enabled = false
}
```

Closes #524 