### PR TITLE
Add support for TLS CA certificate on Prometheus APM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
  * agent: Dispense `fixed-value`, `pass-through`, and `threshold` strategy plugins by default [[GH-536](https://github.com/hashicorp/nomad-autoscaler/pull/536)]
  * plugins/apm/prometheus: Add support for basic auth and custom headers [[GH-522](https://github.com/hashicorp/nomad-autoscaler/pull/522)]
+ * plugins/apm/prometheus: Add support for TLS CA certificates [[GH-547](https://github.com/hashicorp/nomad-autoscaler/pull/547)]
  * plugins/target/nomad: Reduce log level for active deployments error messages [[GH-542](https://github.com/hashicorp/nomad-autoscaler/pull/542)]
  * policy: Prevent scaling cluster to zero when using the Nomad APM [[GH-534](https://github.com/hashicorp/nomad-autoscaler/pull/534)]
  * scaleutils: Add combined filter to allow filtering by node class and datacenter [[GH-535](https://github.com/hashicorp/nomad-autoscaler/pull/535)]

--- a/plugins/builtin/apm/prometheus/plugin/plugin.go
+++ b/plugins/builtin/apm/prometheus/plugin/plugin.go
@@ -168,7 +168,6 @@ func generateTLSConfig(config map[string]string) (*tls.Config, error) {
 
 	// Load the CA certificate if present.
 	caCertPath := config[configKeyCACert]
-	fmt.Println(caCertPath)
 	if caCertPath != "" {
 		caCert, err := ioutil.ReadFile(caCertPath)
 		if err != nil {

--- a/plugins/builtin/apm/prometheus/plugin/prometheus.go
+++ b/plugins/builtin/apm/prometheus/plugin/prometheus.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"crypto/tls"
 	"net/http"
 	"strings"
 
@@ -18,7 +19,7 @@ type pluginRoundTripper struct {
 
 // newPluginRoudTripper returns a new pluginRoundTripper configured based on
 // configuration values set for the plugin.
-func newPluginRoudTripper(config map[string]string) *pluginRoundTripper {
+func newPluginRoudTripper(config map[string]string, tlsConfig *tls.Config) *pluginRoundTripper {
 	username := config[configKeyBasicAuthUser]
 	password := config[configKeyBasicAuthPassword]
 
@@ -30,11 +31,14 @@ func newPluginRoudTripper(config map[string]string) *pluginRoundTripper {
 		}
 	}
 
+	defaultRoudTripper := api.DefaultRoundTripper.(*http.Transport)
+	defaultRoudTripper.TLSClientConfig = tlsConfig
+
 	return &pluginRoundTripper{
 		headers:           headers,
 		basicAuthUser:     username,
 		basicAuthPassword: password,
-		rt:                api.DefaultRoundTripper,
+		rt:                defaultRoudTripper,
 	}
 }
 

--- a/plugins/builtin/apm/prometheus/plugin/prometheus_test.go
+++ b/plugins/builtin/apm/prometheus/plugin/prometheus_test.go
@@ -1,8 +1,11 @@
 package plugin
 
 import (
+	"encoding/pem"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +32,7 @@ func TestAPMPlugin_roundTripper(t *testing.T) {
 	}
 
 	// Setup round tripper and an HTTP client to use for testing.
-	rt := newPluginRoudTripper(cfg)
+	rt := newPluginRoudTripper(cfg, nil)
 	client := &http.Client{Transport: rt}
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
@@ -37,4 +40,102 @@ func TestAPMPlugin_roundTripper(t *testing.T) {
 	// Make a request to run the tests.
 	_, err := client.Get(server.URL)
 	require.NoError(t, err)
+}
+
+func TestAPMPlugin_roundTripperTLS(t *testing.T) {
+	// Setup test HTTPS server.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello"))
+	}))
+	defer server.Close()
+
+	// Write CA cert into a temporary file.
+	caCertFile, err := ioutil.TempFile("", "ca_cert*.pem")
+	require.NoError(t, err)
+	defer os.RemoveAll(caCertFile.Name())
+
+	err = pem.Encode(caCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	require.NoError(t, err)
+
+	// Write invalid CA cert into a temporary file.
+	invalidcaCertFile, err := ioutil.TempFile("", "ca_cert*.pem")
+	require.NoError(t, err)
+	defer os.RemoveAll(invalidcaCertFile.Name())
+
+	invalidcaCertFile.Write([]byte("not a cert"))
+
+	testCases := []struct {
+		name                  string
+		cfg                   map[string]string
+		expectConnError       bool
+		expectValidationError bool
+	}{
+		{
+			name:                  "no tls",
+			cfg:                   map[string]string{},
+			expectConnError:       true,
+			expectValidationError: false,
+		},
+		{
+			name: "skip verify",
+			cfg: map[string]string{
+				"skip_verify": "true",
+			},
+			expectConnError:       false,
+			expectValidationError: false,
+		},
+		{
+			name: "set CA cert",
+			cfg: map[string]string{
+				"ca_cert": caCertFile.Name(),
+			},
+			expectConnError:       false,
+			expectValidationError: false,
+		},
+		{
+			name: "invalid skip verify",
+			cfg: map[string]string{
+				"skip_verify": "not-valid",
+			},
+			expectValidationError: true,
+		},
+		{
+			name: "invalid CA path",
+			cfg: map[string]string{
+				"ca_cert": "not-valid",
+			},
+			expectValidationError: true,
+		},
+		{
+			name: "invalid CA cert",
+			cfg: map[string]string{
+				"ca_cert": invalidcaCertFile.Name(),
+			},
+			expectValidationError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup round tripper and an HTTP client to use for testing.
+			tlsConfig, err := generateTLSConfig(tc.cfg)
+			if tc.expectValidationError {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			rt := newPluginRoudTripper(tc.cfg, tlsConfig)
+			client := &http.Client{Transport: rt}
+
+			// Make a request to run the tests.
+			_, err = client.Get(server.URL)
+			if tc.expectConnError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Manually testes using the instructions in https://prometheus.io/docs/guides/tls-encryption/ but using [these steps](https://gist.github.com/croxton/ebfb5f3ac143cd86542788f972434c96) to generate the certificate, otherwise I would get this error from the Prometheus client:

```
2021-11-24T10:07:53.393-0500 [WARN]  policy_eval.worker: failed to run check: id=377a4f0d-834f-e87c-9cbe-8a05d4e91b57 policy_id=7fe5c606-3d3b-ecd0-ed70-06566acd04bb queue=horizontal target=nomad-target error="failed to query source: failed to query: Post "https://example.com:55001/api/v1/query_range": x509: certificate relies on legacy Common Name field, use SANs instead"
```

Closes #497