### PR TITLE
Allow setting Datadog site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
  * agent: Dispense `fixed-value`, `pass-through`, and `threshold` strategy plugins by default [[GH-536](https://github.com/hashicorp/nomad-autoscaler/pull/536)]
+ * plugins/apm/datadog: Add support for custom server site [[GH-548](https://github.com/hashicorp/nomad-autoscaler/pull/548)]
  * plugins/apm/prometheus: Add support for basic auth and custom headers [[GH-522](https://github.com/hashicorp/nomad-autoscaler/pull/522)]
  * plugins/target/nomad: Reduce log level for active deployments error messages [[GH-542](https://github.com/hashicorp/nomad-autoscaler/pull/542)]
  * policy: Prevent scaling cluster to zero when using the Nomad APM [[GH-534](https://github.com/hashicorp/nomad-autoscaler/pull/534)]

--- a/plugins/builtin/apm/datadog/plugin/plugin.go
+++ b/plugins/builtin/apm/datadog/plugin/plugin.go
@@ -19,6 +19,9 @@ const (
 	// pluginName is the name of the plugin
 	pluginName = "datadog"
 
+	// configKeySite is used to change the Datadog site
+	configKeySite = "site"
+
 	configKeyClientAPIKey = "dd_api_key"
 	configKeyClientAPPKey = "dd_app_key"
 
@@ -88,6 +91,16 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 			datadogAuthAPPKey: {Key: a.config[configKeyClientAPPKey]},
 		},
 	)
+
+	// set Datadog site if provided
+	if a.config[configKeySite] != "" {
+		ctx = context.WithValue(ctx,
+			datadog.ContextServerVariables,
+			map[string]string{
+				"site": a.config[configKeySite],
+			})
+	}
+
 	a.clientCtx = ctx
 	configuration := datadog.NewConfiguration()
 	client := datadog.NewAPIClient(configuration)

--- a/plugins/builtin/apm/datadog/plugin/plugin_test.go
+++ b/plugins/builtin/apm/datadog/plugin/plugin_test.go
@@ -16,6 +16,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 		keyEnvVar            string
 		appEnvVar            string
 		expectOutput         error
+		expectedContextKey   interface{}
 		expectedContextValue interface{}
 		name                 string
 	}{
@@ -45,10 +46,11 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 		},
 
 		{
-			inputConfig:  map[string]string{"dd_api_key": "fake-api-key", "dd_app_key": "some-app"},
-			keyEnvVar:    "",
-			appEnvVar:    "",
-			expectOutput: nil,
+			inputConfig:        map[string]string{"dd_api_key": "fake-api-key", "dd_app_key": "some-app"},
+			keyEnvVar:          "",
+			appEnvVar:          "",
+			expectOutput:       nil,
+			expectedContextKey: datadog.ContextAPIKeys,
 			expectedContextValue: map[string]datadog.APIKey{
 				"apiKeyAuth": {Key: "fake-api-key"},
 				"appKeyAuth": {Key: "some-app"},
@@ -56,10 +58,11 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			name: "all required config parameters set by config map",
 		},
 		{
-			inputConfig:  map[string]string{"dd_api_key": "fake-api-key", "dd_app_key": "some-app"},
-			keyEnvVar:    "env-var-fake-api-key",
-			appEnvVar:    "env-var-some-app",
-			expectOutput: nil,
+			inputConfig:        map[string]string{"dd_api_key": "fake-api-key", "dd_app_key": "some-app"},
+			keyEnvVar:          "env-var-fake-api-key",
+			appEnvVar:          "env-var-some-app",
+			expectOutput:       nil,
+			expectedContextKey: datadog.ContextAPIKeys,
 			expectedContextValue: map[string]datadog.APIKey{
 				"apiKeyAuth": {Key: "fake-api-key"},
 				"appKeyAuth": {Key: "some-app"},
@@ -67,10 +70,11 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			name: "all required config parameters set by both config map and env vars",
 		},
 		{
-			inputConfig:  map[string]string{},
-			keyEnvVar:    "env-var-fake-api-key",
-			appEnvVar:    "env-var-some-app",
-			expectOutput: nil,
+			inputConfig:        map[string]string{},
+			keyEnvVar:          "env-var-fake-api-key",
+			appEnvVar:          "env-var-some-app",
+			expectOutput:       nil,
+			expectedContextKey: datadog.ContextAPIKeys,
 			expectedContextValue: map[string]datadog.APIKey{
 				"apiKeyAuth": {Key: "env-var-fake-api-key"},
 				"appKeyAuth": {Key: "env-var-some-app"},
@@ -78,10 +82,11 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			name: "all required config parameters set by env vars",
 		},
 		{
-			inputConfig:  map[string]string{"dd_api_key": "fake-api-key"},
-			keyEnvVar:    "",
-			appEnvVar:    "env-var-some-app",
-			expectOutput: nil,
+			inputConfig:        map[string]string{"dd_api_key": "fake-api-key"},
+			keyEnvVar:          "",
+			appEnvVar:          "env-var-some-app",
+			expectOutput:       nil,
+			expectedContextKey: datadog.ContextAPIKeys,
 			expectedContextValue: map[string]datadog.APIKey{
 				"apiKeyAuth": {Key: "fake-api-key"},
 				"appKeyAuth": {Key: "env-var-some-app"},
@@ -89,15 +94,25 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			name: "key set by config map, app set by env var",
 		},
 		{
-			inputConfig:  map[string]string{"dd_app_key": "some-app"},
-			keyEnvVar:    "env-var-fake-api-key",
-			appEnvVar:    "",
-			expectOutput: nil,
+			inputConfig:        map[string]string{"dd_app_key": "some-app"},
+			keyEnvVar:          "env-var-fake-api-key",
+			appEnvVar:          "",
+			expectOutput:       nil,
+			expectedContextKey: datadog.ContextAPIKeys,
 			expectedContextValue: map[string]datadog.APIKey{
 				"apiKeyAuth": {Key: "env-var-fake-api-key"},
 				"appKeyAuth": {Key: "some-app"},
 			},
 			name: "app set by config map, key set by env var",
+		},
+		{
+			inputConfig:        map[string]string{"site": "app.datadoghq.eu"},
+			expectOutput:       nil,
+			expectedContextKey: datadog.ContextServerVariables,
+			expectedContextValue: map[string]string{
+				"site": "app.datadoghq.eu",
+			},
+			name: "site set by config map",
 		},
 	}
 
@@ -121,7 +136,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			// non-nil context then we should have a non-nil client and vice
 			// versa.
 			if tc.expectedContextValue != nil {
-				assert.Equal(t, tc.expectedContextValue, apmPlugin.clientCtx.Value(datadog.ContextAPIKeys), tc.name)
+				assert.Equal(t, tc.expectedContextValue, apmPlugin.clientCtx.Value(tc.expectedContextKey), tc.name)
 				assert.NotNil(t, apmPlugin.client, tc.name)
 			} else {
 				assert.Nil(t, apmPlugin.clientCtx, tc.name)


### PR DESCRIPTION
Following the instructions in https://github.com/DataDog/datadog-api-client-go#changing-server, this PR reads a new value called `site` from the plugin config and sets it in the Datadog client context.

Closes #498