### PR TITLE
Fix panic when first policy read timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+BUG FIXES:
+ * policy: Fixed an issue that could cause a panic if the policy content is not read in time [[GH-551](https://github.com/hashicorp/nomad-autoscaler/pull/551)]
+
 ## 0.3.4 (November 24, 2021)
 
 IMPROVEMENTS:

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -63,6 +63,10 @@ type ScalingPolicy struct {
 
 // Validate applies validation rules that are independent of policy source.
 func (p *ScalingPolicy) Validate() error {
+	if p == nil {
+		return nil
+	}
+
 	var result *multierror.Error
 
 	if p.Type == ScalingPolicyTypeCluster || p.Type == ScalingPolicyTypeHorizontal {

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -14,6 +14,11 @@ func TestScalingPolicy_Validate(t *testing.T) {
 		expectedError string
 	}{
 		{
+			name:          "nil policy",
+			policy:        nil,
+			expectedError: "",
+		},
+		{
 			name: "DAS plugin with non-vertical policy",
 			policy: &ScalingPolicy{
 				Type: "horizontal",


### PR DESCRIPTION
In rare cases, it's possible that the policy handler doesn't receive the initial policy content before the default timeout (3m). When this happens, the Autoscaler will `panic` since it will try to validate a `nil` policy without any safeguards.

This PR moves some of the logic from `generateEvaluation` to `handleTick` so a `nil` check is performed earlier and it also updates the policy `Validate` function to not panic on `nil`.