### PR TITLE
[APM Datadog] return 429 specific error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 BUG FIXES:
+ * plugins/apm/datadog: Log the correct rate limit error message [[GH-552](https://github.com/hashicorp/nomad-autoscaler/pull/552)]
  * plugins/target/nomad: Reload status handlers on SIGHUP [[GH-554](https://github.com/hashicorp/nomad-autoscaler/pull/554)]
  * policy: Fixed an issue that could cause a panic if the policy content is not read in time [[GH-551](https://github.com/hashicorp/nomad-autoscaler/pull/551)]
 

--- a/plugins/builtin/apm/datadog/plugin/plugin.go
+++ b/plugins/builtin/apm/datadog/plugin/plugin.go
@@ -141,13 +141,12 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 		Query(q).
 		Execute()
 	if err != nil {
+		if res.StatusCode == http.StatusTooManyRequests {
+			return nil,
+				fmt.Errorf("metric queries are ratelimited in current time period by datadog, resets in %s sec",
+					res.Header.Get(ratelimitResetHdr))
+		}
 		return nil, fmt.Errorf("error querying metrics from datadog: %v", err)
-	}
-
-	if res.StatusCode == http.StatusTooManyRequests {
-		return nil,
-			fmt.Errorf("metric queries are ratelimited in current time period by datadog, resets in %s sec",
-				res.Header.Get(ratelimitResetHdr))
 	}
 
 	series := queryResult.GetSeries()


### PR DESCRIPTION
err is != nil for 429s too so the code will never return the specific 429 error msg