### PR TITLE
Add `on_error` and `on_check_error` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
  * plugins/target/aws-asg: Support EC2 role credentials [[GH-564](https://github.com/hashicorp/nomad-autoscaler/pull/564)]
+ * policy: Add `on_check_error` and `on_error` configuration [[GH-566](https://github.com/hashicorp/nomad-autoscaler/pull/566)]
 
 ## 0.3.5 (January 20, 2022)
 

--- a/policy/file/parse_test.go
+++ b/policy/file/parse_test.go
@@ -26,6 +26,7 @@ func Test_decodeFile(t *testing.T) {
 					Max:                100,
 					Cooldown:           10 * time.Minute,
 					EvaluationInterval: 1 * time.Minute,
+					OnCheckError:       "error",
 					Checks: []*sdk.ScalingPolicyCheck{
 						{
 							Name:        "cpu_nomad",
@@ -40,9 +41,10 @@ func Test_decodeFile(t *testing.T) {
 							},
 						},
 						{
-							Name:   "memory_prom",
-							Source: "prometheus",
-							Query:  "nomad_client_allocated_memory*100/(nomad_client_allocated_memory+nomad_client_unallocated_memory)",
+							Name:    "memory_prom",
+							OnError: "ignore",
+							Source:  "prometheus",
+							Query:   "nomad_client_allocated_memory*100/(nomad_client_allocated_memory+nomad_client_unallocated_memory)",
 							Strategy: &sdk.ScalingPolicyStrategy{
 								Name: "target-value",
 								Config: map[string]string{

--- a/policy/file/test-fixtures/full-cluster-policy.hcl
+++ b/policy/file/test-fixtures/full-cluster-policy.hcl
@@ -8,6 +8,7 @@ scaling "full-cluster-policy" {
 
     cooldown            = "10m"
     evaluation_interval = "1m"
+    on_check_error      = "error"
 
     check "cpu_nomad" {
       source       = "nomad_apm"
@@ -20,8 +21,9 @@ scaling "full-cluster-policy" {
     }
 
     check "memory_prom" {
-      source = "prometheus"
-      query  = "nomad_client_allocated_memory*100/(nomad_client_allocated_memory+nomad_client_unallocated_memory)"
+      source   = "prometheus"
+      query    = "nomad_client_allocated_memory*100/(nomad_client_allocated_memory+nomad_client_unallocated_memory)"
+      on_error = "ignore"
 
       strategy "target-value" {
         target = "80"

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -48,6 +48,11 @@ func parsePolicy(p *api.ScalingPolicy) sdk.ScalingPolicy {
 		to.Cooldown, _ = time.ParseDuration(cooldown)
 	}
 
+	// Parse on_check_error.
+	if onCheckError, ok := p.Policy[keyOnCheckError].(string); ok {
+		to.OnCheckError = onCheckError
+	}
+
 	// Parse target block.
 	var target *sdk.ScalingPolicyTarget
 
@@ -137,6 +142,7 @@ func parseCheck(c interface{}) *sdk.ScalingPolicyCheck {
 	// Parse query and source with _ to avoid panics.
 	query, _ := checkMap[keyQuery].(string)
 	source, _ := checkMap[keySource].(string)
+	on_error, _ := checkMap[keyOnError].(string)
 
 	// Parse query_window ignoring errors since we assume policy has been validated.
 	var queryWindow time.Duration
@@ -149,6 +155,7 @@ func parseCheck(c interface{}) *sdk.ScalingPolicyCheck {
 		QueryWindow: queryWindow,
 		Source:      source,
 		Strategy:    strategy,
+		OnError:     on_error,
 	}
 }
 

--- a/policy/nomad/parser_test.go
+++ b/policy/nomad/parser_test.go
@@ -27,6 +27,7 @@ func Test_parsePolicy(t *testing.T) {
 				EvaluationInterval: 5 * time.Second,
 				Cooldown:           5 * time.Minute,
 				Type:               "horizontal",
+				OnCheckError:       "fail",
 				Target: &sdk.ScalingPolicyTarget{
 					Name: "target",
 					Config: map[string]string{
@@ -44,6 +45,7 @@ func Test_parsePolicy(t *testing.T) {
 						Source:      "source-1",
 						Query:       "query-1",
 						QueryWindow: time.Minute,
+						OnError:     "ignore",
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Name: "strategy-1",
 							Config: map[string]string{

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -23,6 +23,8 @@ const (
 	keyQuery              = "query"
 	keyQueryWindow        = "query_window"
 	keyEvaluationInterval = "evaluation_interval"
+	keyOnCheckError       = "on_check_error"
+	keyOnError            = "on_error"
 	keyTarget             = "target"
 	keyChecks             = "check"
 	keyStrategy           = "strategy"

--- a/policy/nomad/test-fixtures/full-scaling.json.golden
+++ b/policy/nomad/test-fixtures/full-scaling.json.golden
@@ -3,17 +3,19 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
+    "ConsulNamespace": "",
     "ConsulToken": "",
-    "CreateIndex": 256,
+    "CreateIndex": 10,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "full-scaling",
-    "JobModifyIndex": 256,
+    "JobModifyIndex": 10,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 260,
+    "ModifyIndex": 13,
     "Multiregion": null,
     "Name": "full-scaling",
     "Namespace": "default",
@@ -30,11 +32,14 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724429980309000,
+    "SubmitTime": 1644973915971036000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": {
+          "Namespace": ""
+        },
         "Count": 2,
         "EphemeralDisk": {
           "Migrate": false,
@@ -60,57 +65,15 @@
           "Mode": "fail"
         },
         "Scaling": {
-          "CreateIndex": 256,
+          "CreateIndex": 10,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 2,
-          "ModifyIndex": 256,
+          "ModifyIndex": 10,
           "Namespace": "",
           "Policy": {
-            "check": [
-              {
-                "check-1": [
-                  {
-                    "source": "source-1",
-                    "strategy": [
-                      {
-                        "strategy-1": [
-                          {
-                            "str_config": "str",
-                            "bool_config": true,
-                            "int_config": 2
-                          }
-                        ]
-                      }
-                    ],
-                    "query": "query-1",
-                    "query_window": "1m"
-                  }
-                ]
-              },
-              {
-                "check-2": [
-                  {
-                    "query": "query-2",
-                    "source": "source-2",
-                    "strategy": [
-                      {
-                        "strategy-2": [
-                          {
-                            "bool_config": true,
-                            "int_config": 2,
-                            "str_config": "str"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "cooldown": "5m",
-            "evaluation_interval": "5s",
+            "on_check_error": "fail",
             "target": [
               {
                 "target": [
@@ -121,7 +84,51 @@
                   }
                 ]
               }
-            ]
+            ],
+            "check": [
+              {
+                "check-1": [
+                  {
+                    "source": "source-1",
+                    "strategy": [
+                      {
+                        "strategy-1": [
+                          {
+                            "bool_config": true,
+                            "int_config": 2,
+                            "str_config": "str"
+                          }
+                        ]
+                      }
+                    ],
+                    "on_error": "ignore",
+                    "query": "query-1",
+                    "query_window": "1m"
+                  }
+                ]
+              },
+              {
+                "check-2": [
+                  {
+                    "source": "source-2",
+                    "strategy": [
+                      {
+                        "strategy-2": [
+                          {
+                            "str_config": "str",
+                            "bool_config": true,
+                            "int_config": 2
+                          }
+                        ]
+                      }
+                    ],
+                    "query": "query-2"
+                  }
+                ]
+              }
+            ],
+            "cooldown": "5m",
+            "evaluation_interval": "5s"
           },
           "Target": {
             "Namespace": "default",
@@ -139,10 +146,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "DispatchPayload": null,
@@ -161,10 +168,12 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
+              "MemoryMaxMB": 0,
               "Networks": null
             },
             "RestartPolicy": {

--- a/policy/nomad/test-fixtures/src/full-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/full-scaling.hcl
@@ -11,6 +11,7 @@ job "full-scaling" {
       policy {
         evaluation_interval = "5s"
         cooldown            = "5m"
+        on_check_error      = "fail"
 
         target "target" {
           int_config  = 2
@@ -22,6 +23,7 @@ job "full-scaling" {
           source       = "source-1"
           query        = "query-1"
           query_window = "1m"
+          on_error     = "ignore"
 
           strategy "strategy-1" {
             int_config  = 2

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -83,7 +83,7 @@ func (p *ScalingPolicy) Validate() error {
 	switch p.OnCheckError {
 	case "", ScalingPolicyOnErrorFail, ScalingPolicyOnErrorIgnore:
 	default:
-		err := fmt.Errorf("invalid value for on_check_error: only %s and %s are allowed.",
+		err := fmt.Errorf("invalid value for on_check_error: only %s and %s are allowed",
 			ScalingPolicyOnErrorFail, ScalingPolicyOnErrorIgnore)
 		result = multierror.Append(result, err)
 	}
@@ -99,7 +99,7 @@ func (p *ScalingPolicy) Validate() error {
 		switch c.OnError {
 		case "", ScalingPolicyOnErrorFail, ScalingPolicyOnErrorIgnore:
 		default:
-			err := fmt.Errorf("invalid value for on_error in check %s: only %s and %s are allowed.",
+			err := fmt.Errorf("invalid value for on_error in check %s: only %s and %s are allowed",
 				c.Name, ScalingPolicyOnErrorFail, ScalingPolicyOnErrorIgnore)
 			result = multierror.Append(result, err)
 		}

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -19,6 +19,37 @@ func TestScalingPolicy_Validate(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name: "invalid on_check_error",
+			policy: &ScalingPolicy{
+				Type:         "horizontal",
+				OnCheckError: "not-valid",
+			},
+			expectedError: "invalid value for on_check_error",
+		},
+		{
+			name: "invalid on_error",
+			policy: &ScalingPolicy{
+				Type: "horizontal",
+				Checks: []*ScalingPolicyCheck{
+					{
+						Name:    "invalid",
+						OnError: "non-valid",
+						Strategy: &ScalingPolicyStrategy{
+							Name: "target-value",
+						},
+					},
+					{
+						Name:    "valid",
+						OnError: "ignore",
+						Strategy: &ScalingPolicyStrategy{
+							Name: "target-value",
+						},
+					},
+				},
+			},
+			expectedError: "invalid value for on_error in check",
+		},
+		{
 			name: "DAS plugin with non-vertical policy",
 			policy: &ScalingPolicy{
 				Type: "horizontal",
@@ -42,10 +73,12 @@ func TestScalingPolicy_Validate(t *testing.T) {
 		{
 			name: "valid policy",
 			policy: &ScalingPolicy{
-				Type: "horizontal",
+				Type:         "horizontal",
+				OnCheckError: "ignore",
 				Checks: []*ScalingPolicyCheck{
 					{
-						Name: "valid",
+						Name:    "valid",
+						OnError: "fail",
 						Strategy: &ScalingPolicyStrategy{
 							Name: "target-value",
 						},


### PR DESCRIPTION
Introduce two new configuration options (`on_error` and `on_check_error`) to allow operators fine-grain control on how to handle errors when checks are being evaluated.

`on_check_error` is set at policy level and is applied to all `check` by default. Each `check` may override this setting using `on_error`.

For example, this policy will fail its evaluation if _any_ `check` fails:

```hcl
scaling "batch" {
  enabled = true
  min     = 0
  max     = 5

  policy {
    cooldown            = "1m"
    evaluation_interval = "10s"
    on_check_error      = "fail"

    check "batch_jobs_in_progess" {
      source = "datadog"
      query  = "avg:proxy.backend.response.time{proxy-service:web-app}"

      strategy "noop-strategy" {}
    }

    check "noop" {
      source = "noop-apm"
      query  = "fixed:5"

      strategy "noop-strategy" {}
    }

    target "noop-target" {}
  }
}
```

But we can also set a fine-grained behaviour per `check`:

```hcl
scaling "batch" {
  enabled = true
  min     = 0
  max     = 5

  policy {
    cooldown            = "1m"
    evaluation_interval = "10s"
    on_check_error      = "fail"

    check "batch_jobs_in_progess" {
      source = "datadog"
      query  = "avg:proxy.backend.response.time{proxy-service:web-app}"

      strategy "noop-strategy" {}
    }

    check "noop" {
      source   = "noop-apm"
      query    = "fixed:5"
      on_error = "ignore"

      strategy "noop-strategy" {}
    }

    target "noop-target" {}
  }
}
```

Closes #562