### PR TITLE
Add grouped checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
  * plugins/target/aws-asg: Support EC2 role credentials [[GH-564](https://github.com/hashicorp/nomad-autoscaler/pull/564)]
+ * policy: Add `group` to `check` configuration [[GH-567](https://github.com/hashicorp/nomad-autoscaler/pull/567)]
  * policy: Add `on_check_error` and `on_error` configuration [[GH-566](https://github.com/hashicorp/nomad-autoscaler/pull/566)]
 
 ## 0.3.5 (January 20, 2022)

--- a/policy/file/parse_test.go
+++ b/policy/file/parse_test.go
@@ -30,6 +30,7 @@ func Test_decodeFile(t *testing.T) {
 					Checks: []*sdk.ScalingPolicyCheck{
 						{
 							Name:        "cpu_nomad",
+							Group:       "cpu",
 							Source:      "nomad_apm",
 							Query:       "cpu_high-memory",
 							QueryWindow: time.Minute,

--- a/policy/file/test-fixtures/full-cluster-policy.hcl
+++ b/policy/file/test-fixtures/full-cluster-policy.hcl
@@ -14,6 +14,7 @@ scaling "full-cluster-policy" {
       source       = "nomad_apm"
       query        = "cpu_high-memory"
       query_window = "1m"
+      group        = "cpu"
 
       strategy "target-value" {
         target = "80"

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -143,6 +143,7 @@ func parseCheck(c interface{}) *sdk.ScalingPolicyCheck {
 	query, _ := checkMap[keyQuery].(string)
 	source, _ := checkMap[keySource].(string)
 	on_error, _ := checkMap[keyOnError].(string)
+	group, _ := checkMap[keyGroup].(string)
 
 	// Parse query_window ignoring errors since we assume policy has been validated.
 	var queryWindow time.Duration
@@ -151,6 +152,7 @@ func parseCheck(c interface{}) *sdk.ScalingPolicyCheck {
 	}
 
 	return &sdk.ScalingPolicyCheck{
+		Group:       group,
 		Query:       query,
 		QueryWindow: queryWindow,
 		Source:      source,

--- a/policy/nomad/parser_test.go
+++ b/policy/nomad/parser_test.go
@@ -57,6 +57,7 @@ func Test_parsePolicy(t *testing.T) {
 					},
 					{
 						Name:   "check-2",
+						Group:  "group-2",
 						Source: "source-2",
 						Query:  "query-2",
 						Strategy: &sdk.ScalingPolicyStrategy{

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -27,6 +27,7 @@ const (
 	keyOnError            = "on_error"
 	keyTarget             = "target"
 	keyChecks             = "check"
+	keyGroup              = "group"
 	keyStrategy           = "strategy"
 	keyCooldown           = "cooldown"
 )

--- a/policy/nomad/test-fixtures/full-scaling.json.golden
+++ b/policy/nomad/test-fixtures/full-scaling.json.golden
@@ -5,17 +5,17 @@
     "Constraints": null,
     "ConsulNamespace": "",
     "ConsulToken": "",
-    "CreateIndex": 10,
+    "CreateIndex": 195,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "full-scaling",
-    "JobModifyIndex": 10,
+    "JobModifyIndex": 195,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 13,
+    "ModifyIndex": 199,
     "Multiregion": null,
     "Name": "full-scaling",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1644973915971036000,
+    "SubmitTime": 1645143603621529000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -65,22 +65,21 @@
           "Mode": "fail"
         },
         "Scaling": {
-          "CreateIndex": 10,
+          "CreateIndex": 195,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 2,
-          "ModifyIndex": 10,
+          "ModifyIndex": 195,
           "Namespace": "",
           "Policy": {
-            "on_check_error": "fail",
             "target": [
               {
                 "target": [
                   {
+                    "bool_config": true,
                     "int_config": 2,
-                    "str_config": "str",
-                    "bool_config": true
+                    "str_config": "str"
                   }
                 ]
               }
@@ -89,27 +88,29 @@
               {
                 "check-1": [
                   {
+                    "query_window": "1m",
                     "source": "source-1",
                     "strategy": [
                       {
                         "strategy-1": [
                           {
-                            "bool_config": true,
                             "int_config": 2,
-                            "str_config": "str"
+                            "str_config": "str",
+                            "bool_config": true
                           }
                         ]
                       }
                     ],
                     "on_error": "ignore",
-                    "query": "query-1",
-                    "query_window": "1m"
+                    "query": "query-1"
                   }
                 ]
               },
               {
                 "check-2": [
                   {
+                    "group": "group-2",
+                    "query": "query-2",
                     "source": "source-2",
                     "strategy": [
                       {
@@ -121,14 +122,14 @@
                           }
                         ]
                       }
-                    ],
-                    "query": "query-2"
+                    ]
                   }
                 ]
               }
             ],
             "cooldown": "5m",
-            "evaluation_interval": "5s"
+            "evaluation_interval": "5s",
+            "on_check_error": "fail"
           },
           "Target": {
             "Namespace": "default",

--- a/policy/nomad/test-fixtures/src/full-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/full-scaling.hcl
@@ -35,6 +35,7 @@ job "full-scaling" {
         check "check-2" {
           source = "source-2"
           query  = "query-2"
+          group  = "group-2"
 
           strategy "strategy-2" {
             int_config  = 2

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -116,6 +116,10 @@ type ScalingPolicyCheck struct {
 	// create clearly identified policy checks.
 	Name string
 
+	// Group is used to group related checks together. Their results will be
+	// consolidated into a single action.
+	Group string
+
 	// Source is the APM plugin that should be used to perform the query and
 	// obtain the metric that will be used to perform a calculation.
 	Source string
@@ -216,6 +220,7 @@ type FileDecodePolicyDoc struct {
 
 type FileDecodePolicyCheckDoc struct {
 	Name           string `hcl:"name,label"`
+	Group          string `hcl:"group,optional"`
 	Source         string `hcl:"source,optional"`
 	Query          string `hcl:"query,optional"`
 	QueryWindow    time.Duration
@@ -258,6 +263,7 @@ func (fpd *FileDecodeScalingPolicy) translateChecks(p *ScalingPolicy) {
 // check object.
 func (fdc *FileDecodePolicyCheckDoc) Translate(c *ScalingPolicyCheck) {
 	c.Name = fdc.Name
+	c.Group = fdc.Group
 	c.Source = fdc.Source
 	c.Query = fdc.Query
 	c.QueryWindow = fdc.QueryWindow


### PR DESCRIPTION
Grouped checks are checks that have the same value for the new `group`
configuration. Checks that are part of the same group have their results
compared to one another resulting in a single action representing all
checks. This final result is then compared to the rest of the checks.

Grouped checks should be used when multiple checks use the same or
correlated data as input. In these situations it's expected that only
one check (or a handful of them) will actually have enough data to make
a decistion.

For example, consider these two checks that monitore the percentage of
memory usage in a cluster:

```hcl
check "memory-low" {
  source = "prometheus"
  query  = "..."

  strategy "threshold" {
    upper_bound = 30
    delta       = -1
  }
}

check "memory-high" {
  source = "prometheus"
  query  = "..."

  strategy "threshold" {
    lower_bound = 70
    delta       = 1
  }
}
```

If memory usage is at 20% the `memory-low` check should be enacted and
reduce the cluster size by 1. But sice `memory-high` doesn't have enough
data within its range, it will return a `none` scaling action,
preventing the cluster from scaling in since `none` is a safer option
than `down`.

By grouping these two checks together (since they act based on the same
data), the `none` result is ignored and the `down` action is returned,
allowing the cluster to scale in.

The only time `none` should be considered in a group is if all checks in
the group return `none`. In the example above, if the memory usage was
at 50% both checks would return `none` since the cluster is in a good
spot.

In this scenario, the safe option should be to do nothing. Returning a
`none` for the group prevents an accidental scale in if a check from
another group return `down`.

If all checks return a `nil` action, the group is ignored.

Closes #565
Closes #560