### PR TITLE
fix(aws-asg): fix aws creds chain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/armon/go-metrics v0.3.7
 	github.com/aws/aws-sdk-go-v2 v1.13.0
 	github.com/aws/aws-sdk-go-v2/config v1.13.1
+	github.com/aws/aws-sdk-go-v2/credentials v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.19.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.6
@@ -59,7 +60,6 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.8.0
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect

--- a/plugins/builtin/target/aws-asg/plugin/aws.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils"
@@ -60,8 +59,10 @@ func (t *TargetPlugin) setupAWSClients(config map[string]string) error {
 		t.logger.Trace("setting AWS access credentials from config map")
 		cfg.Credentials = credentials.NewStaticCredentialsProvider(keyID, secretKey, session)
 	} else {
-		t.logger.Trace("AWS access credentials empty - using EC2 instance role credentials instead")
-		cfg.Credentials = aws.NewCredentialsCache(ec2rolecreds.New())
+		// Using AWS default credential chain rather then directly use ec2role
+		// to support web identity / shared configuration / ec2 role / etc
+		// https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials
+		t.logger.Trace("using AWS default credential chain")
 	}
 
 	// Set up our AWS client.


### PR DESCRIPTION
- fix aws creds chain directly use ec2role, rather than following best practice https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials

Close: #573