### PR TITLE
plugin/target/aws: fix credential chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ IMPROVEMENTS:
  * plugin/target/azure: Update Azure client dependency to v64.1.0 [[GH-585](https://github.com/hashicorp/nomad-autoscaler/pull/585)]
  * plugin/target/gcp: Update GCP client dependency to 0.80.0 [[GH-585](https://github.com/hashicorp/nomad-autoscaler/pull/585)]
 
+BUG FIXES:
+ * plugin/target/aws: Fixed a regression issue that broke the default AWS credential chain [[GH-586](https://github.com/hashicorp/nomad-autoscaler/pull/586)]
+
 ## 0.3.6 (February 18, 2022)
 
 IMPROVEMENTS:

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -22,15 +22,20 @@ const (
 
 	// configKeys represents the known configuration parameters required at
 	// varying points throughout the plugins lifecycle.
-	configKeyRegion       = "aws_region"
-	configKeyAccessID     = "aws_access_key_id"
-	configKeySecretKey    = "aws_secret_access_key"
-	configKeySessionToken = "aws_session_token"
-	configKeyASGName      = "aws_asg_name"
+	configKeyRegion             = "aws_region"
+	configKeyAccessID           = "aws_access_key_id"
+	configKeySecretKey          = "aws_secret_access_key"
+	configKeySessionToken       = "aws_session_token"
+	configKeyASGName            = "aws_asg_name"
+	configKeyCredentialProvider = "aws_credential_provider"
 
 	// configValues are the default values used when a configuration key is not
 	// supplied by the operator that are specific to the plugin.
 	configValueRegionDefault = "us-east-1"
+
+	// credentialProvider are the valid options for the aws_credential_provider
+	// configuration key.
+	credentialProviderEC2Role = "ec2_role"
 )
 
 var (


### PR DESCRIPTION
Make the use the EC2 instance role as the credential source opt-in, reverting the previous behaviour of using the default credencial chain unless specified otherwise.

To force the use of the EC2 instance role set the new config `aws_credential_provider` to `ec2_role`:

```hcl
target "aws-asg" {
  driver = "aws-asg"
  config = {
    # ...
    aws_credential_provider = "ec2_role"
  }
}

```

Closes #573
Closes #575