### PR TITLE
feat(aws-asg): add `retry_attempts` configuration to customize the maximum waiting time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+  * plugin/target/aws: Add new configuration `retry_attempts` to account for potentially slow ASG update operations [[GH-594](https://github.com/hashicorp/nomad-autoscaler/pull/594)]
+
 ## 0.3.7 (June 10, 2022)
 
 IMPROVEMENTS:

--- a/plugins/builtin/target/aws-asg/plugin/aws.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -21,15 +20,6 @@ const (
 	defaultRetryInterval  = 10 * time.Second
 	nodeAttrAWSInstanceID = "unique.platform.aws.instance-id"
 )
-
-func getConfigValue(config map[string]string, key string, defaultValue string) string {
-	value, ok := config[key]
-	if !ok {
-		return defaultValue
-	}
-
-	return value
-}
 
 // setupAWSClients takes the passed config mapping and instantiates the
 // required AWS service clients.
@@ -309,12 +299,7 @@ func (t *TargetPlugin) ensureActivitiesComplete(ctx context.Context, asg string,
 		return false, fmt.Errorf("waiting for %v activities to finish", len(ids))
 	}
 
-	retryLimit, err := strconv.Atoi(getConfigValue(t.config, configKeyRetryAttempts, configValueRetryAttemptsDefault))
-	if err != nil {
-		return err
-	}
-
-	return retry(ctx, defaultRetryInterval, retryLimit, f)
+	return retry(ctx, defaultRetryInterval, t.retryAttempts, f)
 }
 
 func (t *TargetPlugin) ensureASGInstancesCount(ctx context.Context, desired int64, asgName string) error {
@@ -331,12 +316,7 @@ func (t *TargetPlugin) ensureASGInstancesCount(ctx context.Context, desired int6
 		return false, fmt.Errorf("AutoScaling Group at %v instances of desired %v", asg.Instances, desired)
 	}
 
-	retryLimit, err := strconv.Atoi(getConfigValue(t.config, configKeyRetryAttempts, configValueRetryAttemptsDefault))
-	if err != nil {
-		return err
-	}
-
-	return retry(ctx, defaultRetryInterval, retryLimit, f)
+	return retry(ctx, defaultRetryInterval, t.retryAttempts, f)
 }
 
 // awsNodeIDMap is used to identify the AWS InstanceID of a Nomad node using

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -28,10 +28,12 @@ const (
 	configKeySessionToken       = "aws_session_token"
 	configKeyASGName            = "aws_asg_name"
 	configKeyCredentialProvider = "aws_credential_provider"
+	configKeyRetryAttempts      = "retry_attempts"
 
 	// configValues are the default values used when a configuration key is not
 	// supplied by the operator that are specific to the plugin.
-	configValueRegionDefault = "us-east-1"
+	configValueRegionDefault        = "us-east-1"
+	configValueRetryAttemptsDefault = "15"
 
 	// credentialProvider are the valid options for the aws_credential_provider
 	// configuration key.


### PR DESCRIPTION
The maximum waiting time for checking the status of the ASG is 2 minutes, which is not configurable.
When using the ASG target plugin and downscaling, the ELB connection draining could take more
than 2 minutes. If this happens, Nomad will purge the nodes without waiting for the ASG to remove
the instances.

Logs:
```
2022-07-28T15:48:51.939Z [ERROR] internal_plugin.aws-asg: failed to ensure all activities completed: action=scale_in asg_name=preproduction/nomad error="reached retry limit"
2022-07-28T15:48:52.123Z [INFO]  internal_plugin.aws-asg: successfully purged Nomad node: node_id=34862212-f89a-b107-903d-f4036a44543d nomad_evals=["88a3c562-31e6-f303-cae3-1289bd924958", "b0b08d76-0c2c-e5f3-1b8d-d6f032cd89aa"]
```

So, this commit adds a new config property called `retry_attempts`, which is the maximum number
of attempts the plugin will make to ensure that the ASG has completed all its actions.

Apart from that, if this PR is accepted, I will update the [documentation](https://www.nomadproject.io/tools/autoscaling/plugins/target/aws-asg#policy-configuration-options) accordingly.

Resolves #518