### PR TITLE
feat(aws-asg) Prevent scaling in case of ongoing InstanceRefresh

### DIFF
--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -121,6 +121,34 @@ func (t *TargetPlugin) Scale(action sdk.ScalingAction, config map[string]string)
 		return fmt.Errorf("failed to describe AWS Autoscaling Group: %v", err)
 	}
 
+	// Autoscaling can interfere with a running instance refresh so we
+	// prevent any scaling action while a refresh is Pending or InProgress
+	var maxRecords int32 = 1
+	input := autoscaling.DescribeInstanceRefreshesInput{
+		AutoScalingGroupName: &asgName,
+		InstanceRefreshIds:   []string{},
+		MaxRecords:           &maxRecords,
+		NextToken:            nil,
+	}
+
+	refreshes, err := t.asg.DescribeInstanceRefreshes(ctx, &input)
+	if err != nil {
+		return fmt.Errorf("failed to describe AWS InstanceRefresh: %v", err)
+	}
+
+	// We might get 0 results if no InstanceRefreshes were ever run on the ASG
+	if len(refreshes.InstanceRefreshes) == 1 {
+		refreshID := refreshes.InstanceRefreshes[0].InstanceRefreshId
+		status := refreshes.InstanceRefreshes[0].Status
+		if status == types.InstanceRefreshStatusInProgress ||
+			status == types.InstanceRefreshStatusPending {
+			t.logger.Warn("scaling will not take place due to InstanceRefresh",
+				"asg_name", asgName,
+				"refresh_id", refreshID)
+			return nil
+		}
+	}
+
 	// The AWS ASG target requires different details depending on which
 	// direction we want to scale. Therefore calculate the direction and the
 	// relevant number so we can correctly perform the AWS work.


### PR DESCRIPTION
As of version 0.3.7, the nomad-autoscaler does not take into account pending or currently running AWS ASG Instance Refresh events. See #596

This has lead to us having the autoscaler constantly try to adjust as the instance refresh was also spinning nodes up and down.

To avoid such problems, this PR extends the Scale action to also check the last Instance Refresh event on the ASG and not go ahead with scaling if it has a status of Pending or InProgress.

Happy to get any feedback you can provide :)