### PR TITLE
log something useful when dry-running cluster scaling policies

### DIFF
--- a/plugins/builtin/apm/datadog/plugin/plugin.go
+++ b/plugins/builtin/apm/datadog/plugin/plugin.go
@@ -156,7 +156,7 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 
 	series := queryResult.GetSeries()
 	if len(series) == 0 {
-		a.logger.Warn("empty time series response from datadog, try a wider query window")
+		a.logger.Warn("empty time series response from datadog, try a wider query window", "query", q)
 		return nil, nil
 	}
 
@@ -188,7 +188,7 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 	}
 
 	if len(results) == 0 {
-		a.logger.Warn("no data points found in time series response from datadog, try a wider query window")
+		a.logger.Warn("no data points found in time series response from datadog, try a wider query window", "query", q)
 	}
 
 	return results, nil

--- a/plugins/builtin/strategy/fixed-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/fixed-value/plugin/plugin.go
@@ -85,10 +85,7 @@ func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sd
 		return eval, nil
 	}
 
-	// Log at trace level the details of the strategy calculation. This is
-	// helpful in ultra-debugging situations when there is a need to understand
-	// all the calculations made.
-	s.logger.Trace("calculated scaling strategy results",
+	s.logger.Info("calculated scaling strategy results",
 		"check_name", eval.Check.Name, "current_count", count, "new_count", value,
 		"direction", eval.Action.Direction)
 

--- a/plugins/builtin/strategy/target-value/plugin/plugin.go
+++ b/plugins/builtin/strategy/target-value/plugin/plugin.go
@@ -133,10 +133,7 @@ func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sd
 		newCount = int64(math.Ceil(float64(count) * factor))
 	}
 
-	// Log at trace level the details of the strategy calculation. This is
-	// helpful in ultra-debugging situations when there is a need to understand
-	// all the calculations made.
-	s.logger.Trace("calculated scaling strategy results",
+	s.logger.Info("calculated scaling strategy results",
 		"check_name", eval.Check.Name, "current_count", count, "new_count", newCount,
 		"metric_value", metric.Value, "metric_time", metric.Timestamp, "factor", factor,
 		"direction", eval.Action.Direction)

--- a/plugins/builtin/strategy/threshold/plugin/plugin.go
+++ b/plugins/builtin/strategy/threshold/plugin/plugin.go
@@ -125,7 +125,7 @@ func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sd
 		return eval, nil
 	}
 
-	logger.Trace("calculated scaling strategy results",
+	logger.Info("calculated scaling strategy results",
 		"new_count", newCount, "direction", eval.Action.Direction)
 
 	eval.Action.Count = newCount

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -113,11 +113,6 @@ func (t *TargetPlugin) PluginInfo() (*base.PluginInfo, error) {
 // Scale satisfies the Scale function on the target.Target interface.
 func (t *TargetPlugin) Scale(action sdk.ScalingAction, config map[string]string) error {
 
-	// AWS can't support dry-run like Nomad, so just exit.
-	if action.Count == sdk.StrategyActionMetaValueDryRunCount {
-		return nil
-	}
-
 	// We cannot scale an ASG without knowing the ASG name.
 	asgName, ok := config[configKeyASGName]
 	if !ok {
@@ -157,6 +152,13 @@ func (t *TargetPlugin) Scale(action sdk.ScalingAction, config map[string]string)
 				"refresh_status", refresh.Status)
 			return nil
 		}
+	}
+
+	// AWS can't support dry-run like Nomad, so just exit.
+	if action.Count == sdk.StrategyActionMetaValueDryRunCount {
+		t.logger.Info("dry-run action", "asg_name", asgName,
+			"current_count", *curASG.DesiredCapacity, "strategy_count", action.Count)
+		return nil
 	}
 
 	// The AWS ASG target requires different details depending on which

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -154,17 +154,17 @@ func (t *TargetPlugin) Scale(action sdk.ScalingAction, config map[string]string)
 		}
 	}
 
-	// AWS can't support dry-run like Nomad, so just exit.
-	if action.Count == sdk.StrategyActionMetaValueDryRunCount {
-		t.logger.Info("dry-run action", "asg_name", asgName,
-			"current_count", *curASG.DesiredCapacity, "strategy_count", action.Count)
-		return nil
-	}
-
 	// The AWS ASG target requires different details depending on which
 	// direction we want to scale. Therefore calculate the direction and the
 	// relevant number so we can correctly perform the AWS work.
 	num, direction := t.calculateDirection(int64(*curASG.DesiredCapacity), action.Count)
+
+	// AWS can't support dry-run like Nomad, so just exit.
+	if action.Count == sdk.StrategyActionMetaValueDryRunCount {
+		t.logger.Info("dry-run action", "asg_name", asgName,
+			"current_desired", *curASG.DesiredCapacity, "num", num, "direction", direction)
+		return nil
+	}
 
 	switch direction {
 	case "in":


### PR DESCRIPTION
When using `dry-run` for cluster autoscaling, it's easy to get a bit confused because we see no output whatsoever!

The change means that AWS/GKE/Azure cluster autoscaling will print an INFO log letting us know what *would* have happened.