### PR TITLE
add ScalingPolicyOnErrorScale

### DIFF
--- a/policyeval/base_worker.go
+++ b/policyeval/base_worker.go
@@ -192,6 +192,7 @@ func (w *BaseWorker) handlePolicy(ctx context.Context, eval *sdk.ScalingEvaluati
 				continue
 			case sdk.ScalingPolicyOnErrorFail:
 				return err
+			case sdk.ScalingPolicyOnErrorScale:
 			default:
 				if eval.Policy.OnCheckError == sdk.ScalingPolicyOnErrorFail {
 					return err
@@ -420,7 +421,11 @@ func (h *checkHandler) start(ctx context.Context, currentStatus *sdk.TargetStatu
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to query source: %v", err)
+		if h.checkEval.Check.OnError != sdk.ScalingPolicyOnErrorScale {
+			h.logger.Error("failed to query source. Continuing with policy because on_error is '%s': %v", sdk.ScalingPolicyOnErrorScale, err)
+		} else {
+			return nil, fmt.Errorf("failed to query source: %v", err)
+		}
 	}
 
 	if h.checkEval.Metrics != nil {
@@ -428,8 +433,12 @@ func (h *checkHandler) start(ctx context.Context, currentStatus *sdk.TargetStatu
 		sort.Sort(h.checkEval.Metrics)
 
 		if len(h.checkEval.Metrics) == 0 {
-			h.logger.Warn("no metrics available")
-			return &sdk.ScalingAction{Direction: sdk.ScaleDirectionNone}, nil
+			if h.checkEval.Check.OnError == sdk.ScalingPolicyOnErrorScale {
+				h.logger.Warn("no metrics available, continuing with policy because on_error is '%s'", sdk.ScalingPolicyOnErrorScale)
+			} else {
+				h.logger.Warn("no metrics available, nothing to do.")
+				return &sdk.ScalingAction{Direction: sdk.ScaleDirectionNone}, nil
+			}
 		}
 
 		if h.logger.IsTrace() {

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -15,6 +15,7 @@ const (
 
 	ScalingPolicyOnErrorFail   = "fail"
 	ScalingPolicyOnErrorIgnore = "ignore"
+	ScalingPolicyOnErrorScale  = "scale"
 )
 
 // ScalingPolicy is the internal representation of a scaling document and
@@ -97,10 +98,10 @@ func (p *ScalingPolicy) Validate() error {
 		}
 
 		switch c.OnError {
-		case "", ScalingPolicyOnErrorFail, ScalingPolicyOnErrorIgnore:
+		case "", ScalingPolicyOnErrorFail, ScalingPolicyOnErrorIgnore, ScalingPolicyOnErrorScale:
 		default:
-			err := fmt.Errorf("invalid value for on_error in check %s: only %s and %s are allowed",
-				c.Name, ScalingPolicyOnErrorFail, ScalingPolicyOnErrorIgnore)
+			err := fmt.Errorf("invalid value for on_error in check %s: only %s, %s, and %s are allowed",
+				c.Name, ScalingPolicyOnErrorFail, ScalingPolicyOnErrorIgnore, ScalingPolicyOnErrorScale)
 			result = multierror.Append(result, err)
 		}
 	}


### PR DESCRIPTION
Addresses feature request #622 

Adds a new `on_error` value for scaling checks which allows `on_error = "scale"`. This value means that when metrics fail to be collected (syntax error, no metrics, [datadog downtime](https://status.datadoghq.com/)), we can specify a check that should fail-safe - ie: scale towards max.

Some context: Datadog outage occurred right around our scale-up time - a lack of metrics meant nomad-autoscaler did nothing. We'd like it to fail open and automatically scale towards max when something has gone wrong.