### PR TITLE
always return file policy for same id

### DIFF
--- a/policy/file/source.go
+++ b/policy/file/source.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"reflect"
 	"sync"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -212,16 +211,6 @@ func (s *Source) handleIndividualPolicyRead(ID policy.PolicyID, path, name strin
 		s.policyProcessor.CanonicalizeCheck(c, newPolicy.Target)
 	}
 
-	val, ok := s.policyMap[ID]
-	if !ok || val.policy == nil {
-		return newPolicy, nil
-	}
-
-	// Check the new policy against the stored. If they are the same, and
-	// therefore the policy has not changed indicate that to the caller.
-	if reflect.DeepEqual(newPolicy, val.policy) {
-		return nil, nil
-	}
 	return newPolicy, nil
 }
 


### PR DESCRIPTION
Addresses #519 

I tried to reproduce the issue locally by setting up the autoscale and a local nomad agent running and connection each other. When restarting nomad the error message "failed to call the Nomad list policies" was shown as described in the issue and during debugging I noticed that the handler has no current policy anymore. I digged deeper and found the reason. The file source does not return a policy because the one that gets monitored is already registered in the policyMap and so no policy update is triggered which would set the currentPolicy at https://github.com/hashicorp/nomad-autoscaler/blob/main/policy/handler.go#L153
With this change the policy will be returned no matter what happened to the handler/source.