### PR TITLE
ci: fix nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -38,7 +38,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
-                await github.git.deleteRef({
+                await github.rest.git.deleteRef({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   ref: "tags/nightly"
@@ -46,7 +46,7 @@ jobs:
             } catch (e) {
               console.log("Warning: The nightly tag doesn't exist yet, so there's nothing to do. Trace: " + e)
             }
-            await github.git.createRef({
+            await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "refs/tags/nightly",


### PR DESCRIPTION
The GHA version pinning bot upgraded all action versions, which pulled several breaking changes from `actions/github-script`.

The one that affected us here is that the `git` context was moved to `rest` (https://github.com/actions/github-script/issues/328).

Failed run: https://github.com/hashicorp/nomad-autoscaler/actions/runs/4848130638

Successful run: https://github.com/hashicorp/nomad-autoscaler/actions/runs/4853454638