### PR TITLE
func: add metadata for drained nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ IMPROVEMENTS:
  * plugin/target/aws: Prevent scaling if an instance refresh is in progress [[GH-597](https://github.com/hashicorp/nomad-autoscaler/pull/597)]
  * plugin/target/aws: Add new configuration `retry_attempts` to account for potentially slow ASG update operations [[GH-594](https://github.com/hashicorp/nomad-autoscaler/pull/594)
  * agent: Update Nomad API dependency to v1.5.5 [[GH-636](https://github.com/hashicorp/nomad-autoscaler/pull/636)]
+ * agent: Add specific metadata to drained nodes to allow for later identification [[GH-636](https://github.com/hashicorp/nomad-autoscaler/issues/627)]
+
 
 BUG FIXES:
  * plugin/apm/datadog: Fixed a panic when Datadog queries return `null` values [[GH-606](https://github.com/hashicorp/nomad-autoscaler/pull/606)]

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -269,19 +269,19 @@ func (a *Agent) handleSignals() {
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 
 	// Wait to receive a signal. This blocks until we are notified.
-WAIT:
-	sig := <-signalCh
+	for {
+		sig := <-signalCh
 
-	a.logger.Info("caught signal", "signal", sig.String())
+		a.logger.Info("caught signal", "signal", sig.String())
 
-	// Check the signal we received. If it was a SIGHUP perform the reload
-	// tasks and then continue to wait for another signal. Everything else
-	// means exit.
-	switch sig {
-	case syscall.SIGHUP:
-		a.reload()
-		goto WAIT
-	default:
-		return
+		// Check the signal we received. If it was a SIGHUP perform the reload
+		// tasks and then continue to wait for another signal. Everything else
+		// means exit.
+		switch sig {
+		case syscall.SIGHUP:
+			a.reload()
+		default:
+			break
+		}
 	}
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -281,7 +281,7 @@ func (a *Agent) handleSignals() {
 		case syscall.SIGHUP:
 			a.reload()
 		default:
-			break
+			return
 		}
 	}
 }

--- a/agent/http/health.go
+++ b/agent/http/health.go
@@ -18,8 +18,9 @@ func (s *Server) getHealth(_ http.ResponseWriter, r *http.Request) (interface{},
 		return nil, newCodedError(http.StatusMethodNotAllowed, errInvalidMethod)
 	}
 
-	if atomic.LoadInt32(&s.aliveness) == healthAlivenessReady {
-		return nil, nil
+	if atomic.LoadInt32(&s.aliveness) != healthAlivenessReady {
+		return nil, newCodedError(http.StatusServiceUnavailable, "Service unavailable")
+
 	}
-	return nil, newCodedError(http.StatusServiceUnavailable, "Service unavailable")
+	return nil, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/common v0.32.1
+	github.com/shoenig/test v0.6.3
 	github.com/stretchr/testify v1.8.1
 	google.golang.org/api v0.80.0
 	google.golang.org/grpc v1.46.0

--- a/go.sum
+++ b/go.sum
@@ -474,6 +474,7 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shoenig/test v0.6.3 h1:GVXWJFk9PiOjN0KoJ7VrJGH6uLPnqxR7/fe3HUPfE0c=
+github.com/shoenig/test v0.6.3/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -19,11 +19,12 @@ import (
 	"github.com/hashicorp/nomad/api"
 )
 
+// We use the node drainer interface in order to separate the nomad-autoscaler
+// node drain logic from the actual drain execution, which is executed using the
+// nomad API, allowing us to better define the boundary and write better tests.
 type nodeDrainer interface {
-	UpdateDrainOpts(nodeID string, opts *api.DrainOptions,
-		q *api.WriteOptions) (*api.NodeDrainUpdateResponse, error)
-	MonitorDrain(ctx context.Context, nodeID string, index uint64,
-		ignoreSys bool) <-chan *api.MonitorMessage
+	UpdateDrainOpts(nodeID string, opts *api.DrainOptions, q *api.WriteOptions) (*api.NodeDrainUpdateResponse, error)
+	MonitorDrain(ctx context.Context, nodeID string, index uint64, ignoreSys bool) <-chan *api.MonitorMessage
 }
 
 // ClusterScaleUtils provides common functionality when performing horizontal

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -19,6 +19,13 @@ import (
 	"github.com/hashicorp/nomad/api"
 )
 
+type nodeDrainer interface {
+	UpdateDrainOpts(nodeID string, opts *api.DrainOptions,
+		q *api.WriteOptions) (*api.NodeDrainUpdateResponse, error)
+	MonitorDrain(ctx context.Context, nodeID string, index uint64,
+		ignoreSys bool) <-chan *api.MonitorMessage
+}
+
 // ClusterScaleUtils provides common functionality when performing horizontal
 // cluster scaling evaluations and actions.
 type ClusterScaleUtils struct {
@@ -35,6 +42,8 @@ type ClusterScaleUtils struct {
 	// ClusterNodeIDLookupFunc is the callback function used to translate a
 	// Nomad nodes ID to the remote resource ID used by the target platform.
 	ClusterNodeIDLookupFunc ClusterNodeIDLookupFunc
+
+	drainer nodeDrainer
 }
 
 // NewClusterScaleUtils instantiates a new ClusterScaleUtils object for use.
@@ -56,6 +65,7 @@ func NewClusterScaleUtils(cfg *api.Config, log hclog.Logger) (*ClusterScaleUtils
 		log:       log,
 		client:    client,
 		curNodeID: id,
+		drainer:   client.Nodes(),
 	}, nil
 }
 

--- a/sdk/helper/scaleutils/node_drain.go
+++ b/sdk/helper/scaleutils/node_drain.go
@@ -19,6 +19,9 @@ import (
 const (
 	defaultNodeDrainDeadline    = 15 * time.Minute
 	defaultNodeIgnoreSystemJobs = false
+
+	NODE_DRAINED_META_KEY   = "drained_by"
+	NODE_DRAINED_META_VALUE = "nomad-autoscaler"
 )
 
 // DrainNodes iterates the provided nodeID list and performs a drain on each
@@ -128,7 +131,7 @@ func (c *ClusterScaleUtils) drainNode(ctx context.Context, nodeID string, spec *
 		DrainSpec:    spec,
 		MarkEligible: false,
 		Meta: map[string]string{
-			"drained_by": "nomad-autoscaler",
+			NODE_DRAINED_META_KEY: NODE_DRAINED_META_VALUE,
 		},
 	}
 

--- a/sdk/helper/scaleutils/node_drain.go
+++ b/sdk/helper/scaleutils/node_drain.go
@@ -124,8 +124,16 @@ func (c *ClusterScaleUtils) drainNode(ctx context.Context, nodeID string, spec *
 
 	c.log.Info("triggering drain on node", "node_id", nodeID, "deadline", spec.Deadline)
 
+	opts := &api.DrainOptions{
+		DrainSpec:    spec,
+		MarkEligible: false,
+		Meta: map[string]string{
+			"autoscaler": "true",
+			"timestamp":  time.Now().String(),
+		},
+	}
 	// Update the drain on the node.
-	resp, err := c.client.Nodes().UpdateDrain(nodeID, spec, false, nil)
+	resp, err := c.client.Nodes().UpdateDrainOpts(nodeID, opts, nil)
 	if err != nil {
 		return fmt.Errorf("failed to drain node: %v", err)
 	}

--- a/sdk/helper/scaleutils/node_drain.go
+++ b/sdk/helper/scaleutils/node_drain.go
@@ -131,7 +131,7 @@ func (c *ClusterScaleUtils) drainNode(ctx context.Context, nodeID string, spec *
 		DrainSpec:    spec,
 		MarkEligible: false,
 		Meta: map[string]string{
-			NODE_DRAINED_META_KEY: NODE_DRAINED_META_VALUE,
+			nodeDrainedMetaKey: nodeDrainedMetaValue,
 		},
 	}
 

--- a/sdk/helper/scaleutils/node_drain.go
+++ b/sdk/helper/scaleutils/node_drain.go
@@ -20,8 +20,8 @@ const (
 	defaultNodeDrainDeadline    = 15 * time.Minute
 	defaultNodeIgnoreSystemJobs = false
 
-	NODE_DRAINED_META_KEY   = "drained_by"
-	NODE_DRAINED_META_VALUE = "nomad-autoscaler"
+	nodeDrainedMetaKey   = "drained_by"
+	nodeDrainedMetaValue = "nomad-autoscaler"
 )
 
 // DrainNodes iterates the provided nodeID list and performs a drain on each

--- a/sdk/helper/scaleutils/node_drain.go
+++ b/sdk/helper/scaleutils/node_drain.go
@@ -128,7 +128,7 @@ func (c *ClusterScaleUtils) drainNode(ctx context.Context, nodeID string, spec *
 		DrainSpec:    spec,
 		MarkEligible: false,
 		Meta: map[string]string{
-			"DrainedBy": "Autoscaler",
+			"drained_by": "nomad-autoscaler",
 		},
 	}
 

--- a/sdk/helper/scaleutils/node_drain_test.go
+++ b/sdk/helper/scaleutils/node_drain_test.go
@@ -130,7 +130,7 @@ func Test_DrainNode(t *testing.T) {
 
 	md.drainerMockFunc = func(nodeID string, opts *api.DrainOptions, _ *api.WriteOptions) (*api.NodeDrainUpdateResponse, error) {
 		must.StrContains(t, testNodeID, nodeID)
-		must.StrContains(t, opts.Meta[NODE_DRAINED_META_KEY], NODE_DRAINED_META_VALUE)
+		must.StrContains(t, opts.Meta[nodeDrainedMetaKey], nodeDrainedMetaValue)
 
 		return &api.NodeDrainUpdateResponse{}, nil
 	}


### PR DESCRIPTION
Issue found [here](https://github.com/hashicorp/nomad-autoscaler/issues/627)

The nomad autoscaler should be able to set up specific metadata for nodes that are being drain, in order to pick up where it left off in case of a failure. This PR introduces the change. It also adds an interface to make decoupling from the nomad cluster easier for testing on this feature and maybe some more in the future. 