### PR TITLE
deps: add Dependabot config file to control run

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+    labels:
+      - "theme/dependencies"


### PR DESCRIPTION
Once merged, I will update enterprise to only check on modules which are specific to that repo.