### PR TITLE
Handle jobs being deleted and re-created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
  * plugin/apm/datadog: Fixed a panic when Datadog queries return `null` values [[GH-606](https://github.com/hashicorp/nomad-autoscaler/pull/606)]
+ * agent: Re-start monitoring a job's scale info when a job is deleted then re-created [[GH-724](https://github.com/hashicorp/nomad-autoscaler/pull/724)]
 
 ## 0.3.7 (June 10, 2022)
 

--- a/plugins/builtin/target/nomad/plugin/plugin.go
+++ b/plugins/builtin/target/nomad/plugin/plugin.go
@@ -189,8 +189,9 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 	t.statusHandlersLock.Lock()
 	defer t.statusHandlersLock.Unlock()
 
-	// Create a handler for the job if one does not currently exist.
-	if _, ok := t.statusHandlers[nsID]; !ok {
+	// Create a handler for the job if one does not currently exist,
+	// or if an existing one has stopped running but is not yet GC'd.
+	if h, ok := t.statusHandlers[nsID]; !ok || !h.running() {
 		jsh, err := newJobScaleStatusHandler(t.client, namespace, jobID, t.logger)
 		if err != nil {
 			return nil, err

--- a/plugins/builtin/target/nomad/plugin/state.go
+++ b/plugins/builtin/target/nomad/plugin/state.go
@@ -88,6 +88,13 @@ func newJobScaleStatusHandler(client *api.Client, ns, jobID string, logger hclog
 	return jsh, nil
 }
 
+// running returns whether the start() loop is actively running.
+func (jsh *jobScaleStatusHandler) running() bool {
+	jsh.lock.RLock()
+	defer jsh.lock.RUnlock()
+	return jsh.isRunning
+}
+
 // status returns the cached scaling status of the passed group.
 func (jsh *jobScaleStatusHandler) status(group string) (*sdk.TargetStatus, error) {
 	jsh.lock.RLock()


### PR DESCRIPTION
I noticed while working on another issue that `/v1/scaling/policy/{policy-id}` got started again after job purge/re-create, but `/v1/job/{job-id}/scale` did not.  I was surprised not to find an open issue for this, but maybe I missed it.

Instead of trying to un-stop the existing handler, I opted to just start a new one.  Let me know if this is horribly inefficient in some way that I'm not anticipating.