### PR TITLE
deps: update Nomad API to existing commit SHA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.5.2
 	github.com/hashicorp/hcl/v2 v2.18.0
-	github.com/hashicorp/nomad/api v0.0.0-20230915225027-b977c377888a
+	github.com/hashicorp/nomad/api v0.0.0-20231002174902-3d624388765f
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl/v2 v2.18.0 h1:wYnG7Lt31t2zYkcquwgKo6MWXzRUDIeIVU5naZwHLl8=
 github.com/hashicorp/hcl/v2 v2.18.0/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/nomad/api v0.0.0-20230915225027-b977c377888a h1:9dQOYwk/Eb+aBJ7qOk/LWvqNHxHPVVZ5txuLS1iRZ2I=
-github.com/hashicorp/nomad/api v0.0.0-20230915225027-b977c377888a/go.mod h1:glQSmiY2VCQDT0MBiWKr5YDU9PpwVNOcrovlDczoKoI=
+github.com/hashicorp/nomad/api v0.0.0-20231002174902-3d624388765f h1:8PjWyYMqO9xLuYctvFeBvohptBbbDM88I+utzWwknCQ=
+github.com/hashicorp/nomad/api v0.0.0-20231002174902-3d624388765f/go.mod h1:glQSmiY2VCQDT0MBiWKr5YDU9PpwVNOcrovlDczoKoI=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=


### PR DESCRIPTION
Current Nomad main:
```
$ git show b977c377888a
fatal: ambiguous argument 'b977c377888a': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

```
$ git --no-pager show 3d624388765f
commit 3d624388765f895a020d20a9767f2dced0b108c7 (HEAD -> main, origin/main, origin/HEAD)
Author: Piotr Kazmierczak <470696+pkazmierczak@users.noreply.github.com>
```