### PR TITLE
Recover file policies after manager soft-restarts (from Nomad API errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ IMPROVEMENTS:
 BUG FIXES:
  * plugin/apm/datadog: Fixed a panic when Datadog queries return `null` values [[GH-606](https://github.com/hashicorp/nomad-autoscaler/pull/606)]
  * agent: Re-start monitoring a job's scale info when a job is deleted then re-created [[GH-724](https://github.com/hashicorp/nomad-autoscaler/pull/724)]
+ * agent: File policy sources now resume working after recovering from Nomad API errors [[GH-733](https://github.com/hashicorp/nomad-autoscaler/pull/733)]
 
 ## 0.3.7 (June 10, 2022)
 

--- a/policy/file/source.go
+++ b/policy/file/source.go
@@ -133,7 +133,8 @@ func (s *Source) MonitorPolicy(ctx context.Context, req policy.MonitorPolicyReq)
 
 		p, _, err := s.handleIndividualPolicyRead(req.ID, file, name)
 		if err != nil {
-			policy.HandleSourceError(s.Name(), fmt.Errorf("failed to get policy %s", req.ID), req.ErrCh)
+			policy.HandleSourceError(s.Name(), fmt.Errorf("failed to get policy %s: %w", req.ID, err), req.ErrCh)
+			return
 		}
 		s.policyMap[req.ID] = &filePolicy{file: file, name: name, policy: p}
 		// We must send to ResultCh each time a Handler invokes this method,

--- a/policy/file/source.go
+++ b/policy/file/source.go
@@ -131,14 +131,14 @@ func (s *Source) MonitorPolicy(ctx context.Context, req policy.MonitorPolicyReq)
 		file = val.file
 		name = val.name
 
-		p, err := s.handleIndividualPolicyRead(req.ID, file, name)
+		p, _, err := s.handleIndividualPolicyRead(req.ID, file, name)
 		if err != nil {
 			policy.HandleSourceError(s.Name(), fmt.Errorf("failed to get policy %s", req.ID), req.ErrCh)
 		}
-		if p != nil {
-			req.ResultCh <- *p
-			s.policyMap[req.ID] = &filePolicy{file: file, name: name, policy: p}
-		}
+		s.policyMap[req.ID] = &filePolicy{file: file, name: name, policy: p}
+		// We must send to ResultCh each time a Handler invokes this method,
+		// or the Handler will error "failed to read policy in time"
+		req.ResultCh <- *p
 	}
 	s.policyMapLock.Unlock()
 
@@ -159,7 +159,7 @@ func (s *Source) MonitorPolicy(ctx context.Context, req policy.MonitorPolicyReq)
 
 			// Grab a lock as required by the function and the call.
 			s.policyMapLock.Lock()
-			newPolicy, err := s.handleIndividualPolicyRead(req.ID, file, name)
+			p, changed, err := s.handleIndividualPolicyRead(req.ID, file, name)
 			s.policyMapLock.Unlock()
 
 			// An error indicates the policy failed to be decoded properly. It
@@ -170,22 +170,22 @@ func (s *Source) MonitorPolicy(ctx context.Context, req policy.MonitorPolicyReq)
 				continue
 			}
 
-			// A non-nil policy indicates a change, therefore we send this to
-			// the handler.
-			if newPolicy != nil {
-				s.log.Info("file policy content has changed")
-				req.ResultCh <- *newPolicy
+			if changed {
+				log.Info("file policy content has changed")
+				req.ResultCh <- *p
+			} else {
+				log.Debug("no change in file policy")
 			}
 		}
 	}
 }
 
 // handleIndividualPolicyRead reads the policy from disk and compares it to the
-// stored version if there is one. If there is a difference the new policy will
-// be returned, otherwise we return nil to indicate no reload is required. This
-// function is not thread safe, so the caller should obtain at least a read
-// lock on policyMapLock.
-func (s *Source) handleIndividualPolicyRead(ID policy.PolicyID, path, name string) (*sdk.ScalingPolicy, error) {
+// stored version if there is one. If there is a difference, `changed` will be
+// true to indicate that reload is required.
+// This function is not thread safe, so the caller should obtain at least
+// a read lock on policyMapLock.
+func (s *Source) handleIndividualPolicyRead(ID policy.PolicyID, path, name string) (policy *sdk.ScalingPolicy, changed bool, err error) {
 
 	// Decode the file into a new policy to allow comparison to our stored
 	// policy. Make sure to add the ID string and defaults, we are responsible
@@ -193,19 +193,19 @@ func (s *Source) handleIndividualPolicyRead(ID policy.PolicyID, path, name strin
 	// difference.
 	policies, err := decodeFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode file %s: %v", path, err)
+		return nil, false, fmt.Errorf("failed to decode file %s: %v", path, err)
 	}
 
 	newPolicy, ok := policies[name]
 	if !ok {
-		return nil, fmt.Errorf("policy %q doesn't exist in file %s", name, path)
+		return nil, false, fmt.Errorf("policy %q doesn't exist in file %s", name, path)
 	}
 
 	newPolicy.ID = ID.String()
 	s.policyProcessor.ApplyPolicyDefaults(newPolicy)
 
 	if err := s.policyProcessor.ValidatePolicy(newPolicy); err != nil {
-		return nil, fmt.Errorf("failed to validate file %s: %v", path, err)
+		return nil, false, fmt.Errorf("failed to validate file %s: %v", path, err)
 	}
 
 	for _, c := range newPolicy.Checks {
@@ -214,15 +214,15 @@ func (s *Source) handleIndividualPolicyRead(ID policy.PolicyID, path, name strin
 
 	val, ok := s.policyMap[ID]
 	if !ok || val.policy == nil {
-		return newPolicy, nil
+		return newPolicy, true, nil
 	}
 
 	// Check the new policy against the stored. If they are the same, and
 	// therefore the policy has not changed indicate that to the caller.
 	if reflect.DeepEqual(newPolicy, val.policy) {
-		return nil, nil
+		return newPolicy, false, nil
 	}
-	return newPolicy, nil
+	return newPolicy, true, nil
 }
 
 // identifyPolicyIDs iterates the configured directory, identifying the

--- a/policy/file/source.go
+++ b/policy/file/source.go
@@ -186,7 +186,8 @@ func (s *Source) MonitorPolicy(ctx context.Context, req policy.MonitorPolicyReq)
 // true to indicate that reload is required.
 // This function is not thread safe, so the caller should obtain at least
 // a read lock on policyMapLock.
-func (s *Source) handleIndividualPolicyRead(ID policy.PolicyID, path, name string) (policy *sdk.ScalingPolicy, changed bool, err error) {
+func (s *Source) handleIndividualPolicyRead(ID policy.PolicyID, path, name string) (
+	policy *sdk.ScalingPolicy, changed bool, err error) {
 
 	// Decode the file into a new policy to allow comparison to our stored
 	// policy. Make sure to add the ID string and defaults, we are responsible
@@ -220,10 +221,9 @@ func (s *Source) handleIndividualPolicyRead(ID policy.PolicyID, path, name strin
 
 	// Check the new policy against the stored. If they are the same, and
 	// therefore the policy has not changed indicate that to the caller.
-	if reflect.DeepEqual(newPolicy, val.policy) {
-		return newPolicy, false, nil
-	}
-	return newPolicy, true, nil
+	changed = !reflect.DeepEqual(newPolicy, val.policy)
+
+	return newPolicy, changed, nil
 }
 
 // identifyPolicyIDs iterates the configured directory, identifying the

--- a/policy/file/source_test.go
+++ b/policy/file/source_test.go
@@ -105,7 +105,7 @@ func TestSource_MonitorPolicy(t *testing.T) {
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-		// cancel called at the bottom
+		t.Cleanup(cancel)
 
 		// method under test
 		go s.MonitorPolicy(ctx, req)
@@ -183,7 +183,7 @@ func TestSource_MonitorPolicy_ContinueOnError(t *testing.T) {
 	done := make(chan struct{})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	go func() {
 		src.MonitorPolicy(ctx, req)


### PR DESCRIPTION
Fixes #519 "failed to read policy in time" errors, at least those which occur due to Handlers getting re-started, but then not receiving file policies, because they already exist from the point of view of the file policy Source.

When the policy Manager creates and runs new Handlers, the new Handler needs to receive a policy on its h.ch, or h.handleTick() will have a nil currentPolicy, which results in "timeout: failed to read policy in time"

So, each time Handler asks a Source to MonitorPolicy(), the Source needs to send a policy back to the Handler (via MonitorPolicyReq.ResultCh: h.ch), even if the Source already knows the policy from a previous run.

---

I want to acknowledge that, after I banged my head against it for awhile, I found that @Seros totally had a handle (heh) on it already in #625, but here I am anyway, having addressed the bug in a slightly different way.

The only real difference in behavior here is to retain the changed-or-not distinction when a reload signal is issued, which is probably trivial performance-wise, but I think nice to have in the logs.

Regardless, I've added @Seros as a co-author, since they also fixed it, months ago. :yum:  Also feel free to verify this change, if you'd like, and let me know how it goes!