### PR TITLE
agent: standardize high availability config options.

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -280,17 +280,17 @@ type HighAvailability struct {
 
 	// LockPath defines the path of the variable that will be used to sync the
 	// leader when running on high availability mode.
-	LockPath string `hcl:"path,optional" json:"-"`
+	LockPath string `hcl:"lock_path,optional" json:"-"`
 
 	// Lock ttl defines the lease period or ttl of the lock used to sync the
 	// leader when running on high availability mode.
-	LockTTLHCL string `hcl:"ttl,optional" json:"-"`
+	LockTTLHCL string `hcl:"lock_ttl,optional" json:"-"`
 	LockTTL    time.Duration
 
 	// Lock delay defines the period the lock used used to sync the
 	// leader when running on high availability mode will be unattainable if its
 	// not renewed or release properly.
-	LockDelayHCL string `hcl:"delay,optional" json:"-"`
+	LockDelayHCL string `hcl:"lock_delay,optional" json:"-"`
 	LockDelay    time.Duration
 }
 

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -249,6 +249,12 @@ func TestCommandAgent_readConfig(t *testing.T) {
 						"horizontal": 1,
 					},
 				},
+				HighAvailability: &config.HighAvailability{
+					Enabled:   ptr.BoolToPtr(true),
+					LockPath:  "my/custom/path",
+					LockTTL:   30 * time.Second,
+					LockDelay: 15 * time.Second,
+				},
 			}),
 		},
 		{
@@ -327,6 +333,12 @@ func TestCommandAgent_readConfig(t *testing.T) {
 						"cluster":    3,
 						"horizontal": 1,
 					},
+				},
+				HighAvailability: &config.HighAvailability{
+					Enabled:   ptr.BoolToPtr(true),
+					LockPath:  "my/custom/path",
+					LockTTL:   30 * time.Second,
+					LockDelay: 15 * time.Second,
 				},
 			}),
 		},

--- a/command/test-fixtures/agent_config_full.hcl
+++ b/command/test-fixtures/agent_config_full.hcl
@@ -48,3 +48,10 @@ policy_eval {
     horizontal = 1
   }
 }
+
+high_availability {
+  enabled    = true
+  lock_path  = "my/custom/path"
+  lock_ttl   = "30s"
+  lock_delay = "15s"
+}


### PR DESCRIPTION
This change ensures the CLI flags and config file options use the same naming. It means switching between either has a lower overhead and ensures a better UX.