### PR TITLE
aws: add `scale_in_protection` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
  * agent: Add `BlockQueryWaitTime` config option for Nomad API connectivity [[GH-755](https://github.com/hashicorp/nomad-autoscaler/pull/755)]
  * metrics: Add `policy_id` and `target_name` labels to `scale.invoke.success_count` and `scale.invoke.error_count` metrics [[GH-814](https://github.com/hashicorp/nomad-autoscaler/pull/814)]
+ * plugin/target/aws: Add `scale_in_protection` configuration [[GH-807](https://github.com/hashicorp/nomad-autoscaler/pull/807)]
  * scaleutils: Add new node filter option `node_pool` to select nodes by their node pool value [[GH-810](https://github.com/hashicorp/nomad-autoscaler/pull/810)]
 
 BUG FIXES:

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -33,6 +33,7 @@ const (
 	configKeyASGName            = "aws_asg_name"
 	configKeyCredentialProvider = "aws_credential_provider"
 	configKeyRetryAttempts      = "retry_attempts"
+	configKeyScaleInProtection  = "scale_in_protection"
 
 	// configValues are the default values used when a configuration key is not
 	// supplied by the operator that are specific to the plugin.
@@ -67,6 +68,10 @@ type TargetPlugin struct {
 	// retryAttempts is the number of times operations such as wating for a
 	// given ASG state should be retried.
 	retryAttempts int
+
+	// scaleInProtectionEnabled is true when instance scale-in protection
+	// should be applied.
+	scaleInProtectionEnabled bool
 
 	// clusterUtils provides general cluster scaling utilities for querying the
 	// state of nodes pools and performing scaling tasks.
@@ -104,6 +109,12 @@ func (t *TargetPlugin) SetConfig(config map[string]string) error {
 		return err
 	}
 	t.retryAttempts = retryLimit
+
+	scaleInProtection, err := strconv.ParseBool(getConfigValue(config, configKeyScaleInProtection, "false"))
+	if err != nil {
+		return err
+	}
+	t.scaleInProtectionEnabled = scaleInProtection
 
 	return nil
 }


### PR DESCRIPTION
When `scale_in_protection` is enabled, the AWS target plugin skips instances that are protected from scale in operations[1].

Closes #650 

[1] https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html