### PR TITLE
nomad: specify namespace when querying group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ IMPROVEMENTS:
  * agent: Add `BlockQueryWaitTime` config option for Nomad API connectivity [[GH-755](https://github.com/hashicorp/nomad-autoscaler/pull/755)]
 
 BUG FIXES:
- * plugin/apm/nomad: Set proper namespace when querying group metrics [[GH-808](https://github.com/hashicorp/nomad-autoscaler/pull/808)]
+ * plugin/apm/nomad: Set correct namespace when querying group metrics [[GH-808](https://github.com/hashicorp/nomad-autoscaler/pull/808)]
 
 ## 0.4.0 (December 20, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 IMPROVEMENTS:
  * agent: Add `BlockQueryWaitTime` config option for Nomad API connectivity [[GH-755](https://github.com/hashicorp/nomad-autoscaler/pull/755)]
 
+BUG FIXES:
+ * plugin/apm/nomad: Set proper namespace when querying group metrics [[GH-808](https://github.com/hashicorp/nomad-autoscaler/pull/808)]
+
 ## 0.4.0 (December 20, 2023)
 
 FEATURES:

--- a/plugins/builtin/apm/nomad/plugin/job_test.go
+++ b/plugins/builtin/apm/nomad/plugin/job_test.go
@@ -59,9 +59,10 @@ func Test_parseTaskGroupQuery(t *testing.T) {
 	}{
 		{
 			name:  "avg_cpu",
-			input: "taskgroup_avg_cpu/group/job",
+			input: "taskgroup_avg_cpu/group/job@default",
 			expected: &taskGroupQuery{
 				metric:    "cpu",
+				namespace: "default",
 				job:       "job",
 				group:     "group",
 				operation: "avg",
@@ -70,9 +71,10 @@ func Test_parseTaskGroupQuery(t *testing.T) {
 		},
 		{
 			name:  "avg_cpu-allocated",
-			input: "taskgroup_avg_cpu-allocated/group/job",
+			input: "taskgroup_avg_cpu-allocated/group/job@ns",
 			expected: &taskGroupQuery{
 				metric:    "cpu-allocated",
+				namespace: "ns",
 				job:       "job",
 				group:     "group",
 				operation: "avg",
@@ -81,9 +83,10 @@ func Test_parseTaskGroupQuery(t *testing.T) {
 		},
 		{
 			name:  "avg_memory",
-			input: "taskgroup_avg_memory/group/job",
+			input: "taskgroup_avg_memory/group/job@dev",
 			expected: &taskGroupQuery{
 				metric:    "memory",
+				namespace: "dev",
 				job:       "job",
 				group:     "group",
 				operation: "avg",
@@ -92,9 +95,10 @@ func Test_parseTaskGroupQuery(t *testing.T) {
 		},
 		{
 			name:  "avg_memory-allocated",
-			input: "taskgroup_avg_memory-allocated/group/job",
+			input: "taskgroup_avg_memory-allocated/group/job@dev",
 			expected: &taskGroupQuery{
 				metric:    "memory-allocated",
+				namespace: "dev",
 				job:       "job",
 				group:     "group",
 				operation: "avg",
@@ -103,10 +107,23 @@ func Test_parseTaskGroupQuery(t *testing.T) {
 		},
 		{
 			name:  "job with fwd slashes",
-			input: "taskgroup_avg_cpu/group/my/super/job//",
+			input: "taskgroup_avg_cpu/group/my/super/job//@dev",
 			expected: &taskGroupQuery{
 				metric:    "cpu",
+				namespace: "dev",
 				job:       "my/super/job//",
+				group:     "group",
+				operation: "avg",
+			},
+			expectError: false,
+		},
+		{
+			name:  "job with at signs",
+			input: "taskgroup_avg_cpu/group/job@job@@dev",
+			expected: &taskGroupQuery{
+				metric:    "cpu",
+				namespace: "dev",
+				job:       "job@job@",
 				group:     "group",
 				operation: "avg",
 			},
@@ -121,6 +138,12 @@ func Test_parseTaskGroupQuery(t *testing.T) {
 		{
 			name:        "invalid query format",
 			input:       "invalid",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "missing namspace",
+			input:       "avg_cpu/group/job",
 			expected:    nil,
 			expectError: true,
 		},

--- a/policy/nomad/source_test.go
+++ b/policy/nomad/source_test.go
@@ -110,8 +110,9 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 			input: &sdk.ScalingPolicy{
 				Target: &sdk.ScalingPolicyTarget{
 					Config: map[string]string{
-						"Job":   "job",
-						"Group": "group",
+						"Namespace": "dev",
+						"Job":       "job",
+						"Group":     "group",
 					},
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
@@ -126,14 +127,15 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Target: &sdk.ScalingPolicyTarget{
 					Name: plugins.InternalTargetNomad,
 					Config: map[string]string{
-						"Job":   "job",
-						"Group": "group",
+						"Namespace": "dev",
+						"Job":       "job",
+						"Group":     "group",
 					},
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
 						Source:      plugins.InternalAPMNomad,
-						Query:       "taskgroup_avg_cpu/group/job",
+						Query:       "taskgroup_avg_cpu/group/job@dev",
 						QueryWindow: policy.DefaultQueryWindow,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Config: map[string]string{},
@@ -147,8 +149,9 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 			input: &sdk.ScalingPolicy{
 				Target: &sdk.ScalingPolicyTarget{
 					Config: map[string]string{
-						"Job":   "job",
-						"Group": "group",
+						"Namespace": "dev",
+						"Job":       "job",
+						"Group":     "group",
 					},
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
@@ -164,14 +167,15 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Target: &sdk.ScalingPolicyTarget{
 					Name: plugins.InternalTargetNomad,
 					Config: map[string]string{
-						"Job":   "job",
-						"Group": "group",
+						"Namespace": "dev",
+						"Job":       "job",
+						"Group":     "group",
 					},
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
 						Source:      plugins.InternalAPMNomad,
-						Query:       "taskgroup_avg_cpu/group/job",
+						Query:       "taskgroup_avg_cpu/group/job@dev",
 						QueryWindow: policy.DefaultQueryWindow,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Config: map[string]string{},
@@ -185,8 +189,9 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 			input: &sdk.ScalingPolicy{
 				Target: &sdk.ScalingPolicyTarget{
 					Config: map[string]string{
-						"Job":   "my_job",
-						"Group": "my_group",
+						"Namespace": "my_ns",
+						"Job":       "my_job",
+						"Group":     "my_group",
 					},
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
@@ -201,14 +206,15 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				Target: &sdk.ScalingPolicyTarget{
 					Name: plugins.InternalTargetNomad,
 					Config: map[string]string{
-						"Job":   "my_job",
-						"Group": "my_group",
+						"Namespace": "my_ns",
+						"Job":       "my_job",
+						"Group":     "my_group",
 					},
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
 						Source:      plugins.InternalAPMNomad,
-						Query:       "taskgroup_avg_cpu/my_group/my_job",
+						Query:       "taskgroup_avg_cpu/my_group/my_job@my_ns",
 						QueryWindow: policy.DefaultQueryWindow,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Config: map[string]string{},

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -108,8 +108,14 @@ func (pr *Processor) CanonicalizeAPMQuery(c *sdk.ScalingPolicyCheck, t *sdk.Scal
 	// If the target is a Nomad job task group, format the query in the
 	// expected manner.
 	if t.IsJobTaskGroupTarget() {
-		c.Query = fmt.Sprintf("%s_%s/%s/%s",
-			nomadAPM.QueryTypeTaskGroup, c.Query, t.Config[sdk.TargetConfigKeyTaskGroup], t.Config[sdk.TargetConfigKeyJob])
+		c.Query = fmt.Sprintf(
+			"%s_%s/%s/%s@%s",
+			nomadAPM.QueryTypeTaskGroup,
+			c.Query,
+			t.Config[sdk.TargetConfigKeyTaskGroup],
+			t.Config[sdk.TargetConfigKeyJob],
+			t.Config[sdk.TargetConfigKeyNamespace],
+		)
 		return
 	}
 

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -178,12 +178,16 @@ func TestProcessor_CanonicalizeAPMQuery(t *testing.T) {
 			},
 			inputAPMNames: []string{"nomad-apm"},
 			inputTarget: &sdk.ScalingPolicyTarget{
-				Config: map[string]string{"Job": "example", "Group": "cache"},
+				Config: map[string]string{
+					"Namespace": "dev",
+					"Job":       "example",
+					"Group":     "cache",
+				},
 			},
 			expectedOutputCheck: &sdk.ScalingPolicyCheck{
 				Name:   "random-check",
 				Source: "nomad-apm",
-				Query:  "taskgroup_avg_cpu/cache/example",
+				Query:  "taskgroup_avg_cpu/cache/example@dev",
 			},
 			name: "correctly formatted taskgroup target short query",
 		},

--- a/sdk/target.go
+++ b/sdk/target.go
@@ -54,6 +54,10 @@ const (
 	// cooldown where out-of-band scaling activities have been triggered.
 	TargetStatusMetaKeyLastEvent = "nomad_autoscaler.last_event"
 
+	// TargetConfigKeyNamespace is the config key used within horizontal app
+	// scaling to identify the Nomad namespace targeted for autoscaling.
+	TargetConfigKeyNamespace = "Namespace"
+
 	// TargetConfigKeyJob is the config key used within horizontal app scaling
 	// to identify the Nomad job targeted for autoscaling.
 	TargetConfigKeyJob = "Job"


### PR DESCRIPTION
The Nomad Autoscaler agent can only target a single namespace, but when using the wildcard (`*`) value it is possible to monitor policies for all namespaces.

With this configuration, the Nomad APM plugin must specify the job namespace when querying for information as the agent is configured with the wildcard.

Ref: https://github.com/hashicorp/nomad-autoscaler/issues/65#issuecomment-1620071860