### PR TITLE
aws: add experimental configuration

### DIFF
--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -34,6 +34,10 @@ const (
 	configKeyCredentialProvider = "aws_credential_provider"
 	configKeyRetryAttempts      = "retry_attempts"
 
+	// EXPERIMENTAL
+	// The configKeys below are considered experimental and should not be used.
+	xConfigKeyIgnoreASGEvents = "ignore_asg_events"
+
 	// configValues are the default values used when a configuration key is not
 	// supplied by the operator that are specific to the plugin.
 	configValueRegionDefault        = "us-east-1"
@@ -223,6 +227,17 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 		Ready: asg.Status == nil,
 		Count: int64(*asg.DesiredCapacity),
 		Meta:  make(map[string]string),
+	}
+
+	// Return early if policy is configured to ignore ASG events.
+	if str, ok := config[xConfigKeyIgnoreASGEvents]; ok {
+		ignoreEvents, err := strconv.ParseBool(str)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse config %s: %v", xConfigKeyIgnoreASGEvents, err)
+		}
+		if ignoreEvents {
+			return &resp, nil
+		}
 	}
 
 	// If we have previous activities then process the last.

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -210,7 +210,12 @@ func (c *ClusterScaleUtils) IdentifyScaleInNodes(cfg map[string]string, num int)
 	}
 
 	// Filter our nodes to select only those within our identified pool.
-	filteredNodes, err := FilterNodes(nodes, poolID.IsPoolMember)
+	filterOpts, err := NewNodeFilterOptions(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	filteredNodes, err := FilterNodesWithOptions(nodes, poolID.IsPoolMember, filterOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +372,11 @@ func (c *ClusterScaleUtils) IsPoolReady(cfg map[string]string) (bool, error) {
 		return false, fmt.Errorf("failed to list Nomad nodes: %v", err)
 	}
 
-	if _, err := FilterNodes(nodes, poolID.IsPoolMember); err != nil {
+	filterOpts, err := NewNodeFilterOptions(cfg)
+	if err != nil {
+		return false, err
+	}
+	if _, err := FilterNodesWithOptions(nodes, poolID.IsPoolMember, filterOpts); err != nil {
 		c.log.Warn("node pool status readiness check failed", "error", err)
 		return false, nil
 	}

--- a/sdk/helper/scaleutils/node_identifier.go
+++ b/sdk/helper/scaleutils/node_identifier.go
@@ -49,7 +49,7 @@ func FilterNodes(n []*api.NodeListStub, idFn func(*api.NodeListStub) bool) ([]*a
 	return FilterNodesWithOptions(n, idFn, nil)
 }
 
-// FilterNodesWithOptions is an experimental function.Use FilterNodes instead.
+// FilterNodesWithOptions is an experimental function. Use FilterNodes instead.
 func FilterNodesWithOptions(n []*api.NodeListStub, idFn func(*api.NodeListStub) bool, opts *NodeFilterOptions) ([]*api.NodeListStub, error) {
 
 	// Create our output list object.


### PR DESCRIPTION
Add experimental configuration values to the AWS ASG plugin to allow cluster operators to bypass some of the safety checks enforced by the Autoscaler.

I'm still unsure about these changes, so I'm open to suggestions, but letting users experiment with them could generate useful information about the assumptions we make.

Ref: https://github.com/hashicorp/nomad-autoscaler/issues/672