### PR TITLE
broker: prevent overlap of policy evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 IMPROVEMENTS:
  * agent: Add `BlockQueryWaitTime` config option for Nomad API connectivity [[GH-755](https://github.com/hashicorp/nomad-autoscaler/pull/755)]
 
+BUG FIXES:
+ * agent: Fixed a bug that could cause scaling policies to be evaluated concurrently [[GH-812](https://github.com/hashicorp/nomad-autoscaler/pull/812)]
+
 ## 0.4.0 (December 20, 2023)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ IMPROVEMENTS:
  * agent: Add `BlockQueryWaitTime` config option for Nomad API connectivity [[GH-755](https://github.com/hashicorp/nomad-autoscaler/pull/755)]
 
 BUG FIXES:
- * agent: Fixed a bug that could cause scaling policies to be evaluated concurrently [[GH-812](https://github.com/hashicorp/nomad-autoscaler/pull/812)]
+ * agent: Fixed a bug that could cause the same scaling policy to be evaluated multiple times concurrently [[GH-812](https://github.com/hashicorp/nomad-autoscaler/pull/812)]
 
 ## 0.4.0 (December 20, 2023)
 

--- a/policyeval/broker.go
+++ b/policyeval/broker.go
@@ -164,8 +164,8 @@ func (b *Broker) enqueueLocked(eval *sdk.ScalingEvaluation, token string) {
 				pending[i] = eval
 				heap.Fix(&pending, i)
 			}
-			return
 		}
+		return
 	}
 
 	heap.Push(&pending, eval)


### PR DESCRIPTION
When a policy is sent for evaluation by a handler, it is placed into the eval broker queue. If the queue already has an eval for the policy, it discards one of them, keeping the most recent one. This is used to guarantee that a policy is never processed in parallel by different workers.

The code had the `return` statement in the wrong scope, causing a duplicate eval to be enqueued even when the policy was already been processed, resulting in unexpected concurrent policy evaluations.

Closes https://github.com/hashicorp/nomad-autoscaler/issues/610