### PR TITLE
policy: validate missing strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
  * agent: Fixed a bug that could cause the same scaling policy to be evaluated multiple times concurrently [[GH-812](https://github.com/hashicorp/nomad-autoscaler/pull/812)]
+ * agent: Fixed a bug that caused the agent to panic when trying to evaluate a policy with a missing `check.strategy` block [[GH-813](https://github.com/hashicorp/nomad-autoscaler/pull/813)]
  * plugin/apm/nomad: Set correct namespace when querying group metrics [[GH-808](https://github.com/hashicorp/nomad-autoscaler/pull/808)]
 
 ## 0.4.0 (December 20, 2023)

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -92,6 +92,11 @@ func (p *ScalingPolicy) Validate() error {
 	}
 
 	for _, c := range p.Checks {
+		if c.Strategy == nil || c.Strategy.Name == "" {
+			result = multierror.Append(result, fmt.Errorf("invalid check %s: missing strategy value", c.Name))
+			continue
+		}
+
 		if p.Type == ScalingPolicyTypeCluster || p.Type == ScalingPolicyTypeHorizontal {
 			if strings.HasPrefix(c.Strategy.Name, "app-sizing") {
 				err := fmt.Errorf("invalid strategy in check %s: plugin %s can only be used with Dynamic Application Sizing", c.Name, c.Strategy.Name)

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -74,6 +74,18 @@ func TestScalingPolicy_Validate(t *testing.T) {
 			expectedError: "can only be used with Dynamic Application Sizing",
 		},
 		{
+			name: "invalid check without strategy",
+			policy: &ScalingPolicy{
+				Type: "horizontal",
+				Checks: []*ScalingPolicyCheck{
+					{
+						Name: "missing-strategy",
+					},
+				},
+			},
+			expectedError: "missing strategy",
+		},
+		{
 			name: "valid policy",
 			policy: &ScalingPolicy{
 				Type:         "horizontal",


### PR DESCRIPTION
Return an error if a `check` is missing a `strategy` value to prevent panics.

Closes https://github.com/hashicorp/nomad-autoscaler/issues/611