### PR TITLE
threhsold: clarify the behaviour of bounds

### DIFF
--- a/plugins/builtin/strategy/threshold/plugin/plugin.go
+++ b/plugins/builtin/strategy/threshold/plugin/plugin.go
@@ -236,9 +236,9 @@ func parseBound(bound string, input string) (float64, error) {
 
 	switch bound {
 	case runConfigKeyLowerBound:
-		defaultValue = -math.MaxFloat64
+		defaultValue = math.Inf(-1)
 	case runConfigKeyUpperBound:
-		defaultValue = math.MaxFloat64
+		defaultValue = math.Inf(1)
 	}
 
 	if input == "" {

--- a/plugins/builtin/strategy/threshold/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/threshold/plugin/plugin_test.go
@@ -22,6 +22,62 @@ func TestThresholdPlugin(t *testing.T) {
 		expectedErr    string
 	}{
 		{
+			name:    "lower_bound is inclusive",
+			count:   1,
+			metrics: []float64{10, 10, 10, 10, 10},
+			config: map[string]string{
+				"lower_bound": "10",
+				"delta":       "-1",
+			},
+			expectedAction: &sdk.ScalingAction{
+				Count:     0,
+				Direction: sdk.ScaleDirectionDown,
+				Reason:    "scaling down because metric is within bounds",
+			},
+		},
+		{
+			name:    "upper_bound is exclusive",
+			count:   1,
+			metrics: []float64{10, 10, 10, 10, 10},
+			config: map[string]string{
+				"upper_bound": "10",
+				"delta":       "1",
+			},
+			expectedAction: &sdk.ScalingAction{
+				Direction: sdk.ScaleDirectionNone,
+			},
+		},
+		{
+			name:    "lower_bound is inclusive and upper_bound is exclusive/no action",
+			count:   1,
+			metrics: []float64{10, 10, 20, 20, 20},
+			config: map[string]string{
+				"lower_bound":           "10",
+				"upper_bound":           "20",
+				"delta":                 "1",
+				"within_bounds_trigger": "3",
+			},
+			expectedAction: &sdk.ScalingAction{
+				Direction: sdk.ScaleDirectionNone,
+			},
+		},
+		{
+			name:    "lower_bound is inclusive and upper_bound is exclusive/scale",
+			count:   1,
+			metrics: []float64{10, 10, 20, 20, 20},
+			config: map[string]string{
+				"lower_bound":           "10",
+				"upper_bound":           "20",
+				"delta":                 "1",
+				"within_bounds_trigger": "2",
+			},
+			expectedAction: &sdk.ScalingAction{
+				Count:     2,
+				Direction: sdk.ScaleDirectionUp,
+				Reason:    "scaling up because metric is within bounds",
+			},
+		},
+		{
 			name:    "delta scale up",
 			count:   1,
 			metrics: []float64{10, 10, 10, 10, 10, 10},


### PR DESCRIPTION
The `lower_bound` value is always considered inclusive and the `upper_bound` value is always exclusive. This helps prevent overlapping or a dead zone when regions start or end right next to each other.

Also use `math.Inf` instead of `MaxFloat64` to allow a value that matches `MaxFloat64` to be considered within bounds.

No changelog since it doesn't change any user-facing behaviour.

Closes https://github.com/hashicorp/nomad-autoscaler/issues/727