### PR TITLE
Fix autoscale when dry-run in set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+BUG FIXES:
+ * agent: Fixed a bug that caused a target in dry-run mode to scale when outside of its min/max range [[GH-845](https://github.com/hashicorp/nomad-autoscaler/pull/845)]
+
 ## 0.4.1 (January 18, 2024)
 
 IMPROVEMENTS:


### PR DESCRIPTION
Autoscaler tries to scale even when dry-run is configured. This happens when the current count is out of the range of the configured min/max. Currently the dry-run check is performed after this checks are executed. https://github.com/hashicorp/nomad-autoscaler/blob/0d0ad24c2381f1c13995504a56354d0e9d269eeb/policyeval/base_worker.go#L146

This PR moves the dry-run check to inside the scaleTarget method so every scaling action goes through the check.