### PR TITLE
accept max_scale_up and max_scale_down for target-value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+ * plugin/strategy/target-value: Add new configuration `max_scale_up` and `max_scale_down` to allow restricting how much change is applied on each scaling event [[GH-848](https://github.com/hashicorp/nomad-autoscaler/pull/848)]
+
 BUG FIXES:
  * agent: Fixed a bug that caused a target in dry-run mode to scale when outside of its min/max range [[GH-845](https://github.com/hashicorp/nomad-autoscaler/pull/845)]
 


### PR DESCRIPTION
Hey,

The two optional parameters max_scale_up and max_scale_down determine the maximum and minimum number of scaling differences between two evaluations.

It is useful to avoid scaling down or scaling up a job too quickly.



The code is not tested yet. For now, this is a draft pull request to see if you might be interested to include the feature in the target-value plugin.