### PR TITLE
policy: add `query_window_offset` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
  * plugin/strategy/target-value: Add new configuration `max_scale_up` and `max_scale_down` to allow restricting how much change is applied on each scaling event [[GH-848](https://github.com/hashicorp/nomad-autoscaler/pull/848)]
+ * policy: Add new configuration `query_window_offset` to apply a time offset to the query window [[GH-850](https://github.com/hashicorp/nomad-autoscaler/pull/850)]
 
 BUG FIXES:
  * agent: Fixed a bug that caused a target in dry-run mode to scale when outside of its min/max range [[GH-845](https://github.com/hashicorp/nomad-autoscaler/pull/845)]

--- a/policy/file/parse.go
+++ b/policy/file/parse.go
@@ -61,16 +61,21 @@ func decodePolicyDoc(decodePolicy *sdk.FileDecodeScalingPolicy) error {
 	for i := 0; i < len(decodePolicy.Doc.Checks); i++ {
 		check := decodePolicy.Doc.Checks[i]
 
-		// Skip parsing if query_window not set.
-		if check.QueryWindowHCL == "" {
-			continue
+		if check.QueryWindowHCL != "" {
+			w, err := time.ParseDuration(check.QueryWindowHCL)
+			if err != nil {
+				return err
+			}
+			decodePolicy.Doc.Checks[i].QueryWindow = w
 		}
 
-		w, err := time.ParseDuration(check.QueryWindowHCL)
-		if err != nil {
-			return err
+		if check.QueryWindowOffsetHCL != "" {
+			o, err := time.ParseDuration(check.QueryWindowOffsetHCL)
+			if err != nil {
+				return err
+			}
+			decodePolicy.Doc.Checks[i].QueryWindowOffset = o
 		}
-		decodePolicy.Doc.Checks[i].QueryWindow = w
 	}
 
 	return nil

--- a/policy/file/parse_test.go
+++ b/policy/file/parse_test.go
@@ -32,11 +32,12 @@ func Test_decodeFile(t *testing.T) {
 					OnCheckError:       "error",
 					Checks: []*sdk.ScalingPolicyCheck{
 						{
-							Name:        "cpu_nomad",
-							Group:       "cpu",
-							Source:      "nomad_apm",
-							Query:       "cpu_high-memory",
-							QueryWindow: time.Minute,
+							Name:              "cpu_nomad",
+							Group:             "cpu",
+							Source:            "nomad_apm",
+							Query:             "cpu_high-memory",
+							QueryWindow:       time.Minute,
+							QueryWindowOffset: 2 * time.Minute,
 							Strategy: &sdk.ScalingPolicyStrategy{
 								Name: "target-value",
 								Config: map[string]string{

--- a/policy/file/test-fixtures/full-cluster-policy.hcl
+++ b/policy/file/test-fixtures/full-cluster-policy.hcl
@@ -14,10 +14,11 @@ scaling "full-cluster-policy" {
     on_check_error      = "error"
 
     check "cpu_nomad" {
-      source       = "nomad_apm"
-      query        = "cpu_high-memory"
-      query_window = "1m"
-      group        = "cpu"
+      source              = "nomad_apm"
+      query               = "cpu_high-memory"
+      query_window        = "1m"
+      query_window_offset = "2m"
+      group               = "cpu"
 
       strategy "target-value" {
         target = "80"

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -111,14 +111,15 @@ func parseChecks(cs interface{}) []*sdk.ScalingPolicyCheck {
 //
 //	scaling {
 //	  policy {
-//	  +--------------------------------+
-//	  | check "name" {                 |
-//	  |   source = "source"            |
-//	  |   query = "query"              |
-//	  |   query_window = "5m"          |
-//	  |   strategy "strategy" { ... }  |
-//	  | }                              |
-//	  +--------------------------------+
+//	  +---------------------------------+
+//	  | check "name" {                  |
+//	  |   source = "source"             |
+//	  |   query               = "query" |
+//	  |   query_window        = "5m"    |
+//	  |   query_window_offset = "1m"    |
+//	  |   strategy "strategy" { ... }   |
+//	  | }                               |
+//	  +---------------------------------+
 //	  }
 //	}
 func parseCheck(c interface{}) *sdk.ScalingPolicyCheck {
@@ -148,19 +149,24 @@ func parseCheck(c interface{}) *sdk.ScalingPolicyCheck {
 	on_error, _ := checkMap[keyOnError].(string)
 	group, _ := checkMap[keyGroup].(string)
 
-	// Parse query_window ignoring errors since we assume policy has been validated.
-	var queryWindow time.Duration
+	// Parse query_window and query_window_offset ignoring errors since we
+	// assume policy has been validated.
+	var queryWindow, queryWindowOffset time.Duration
 	if queryWindowStr, ok := checkMap[keyQueryWindow].(string); ok {
 		queryWindow, _ = time.ParseDuration(queryWindowStr)
 	}
+	if queryWindowOffsetStr, ok := checkMap[keyQueryWindowOffset].(string); ok {
+		queryWindowOffset, _ = time.ParseDuration(queryWindowOffsetStr)
+	}
 
 	return &sdk.ScalingPolicyCheck{
-		Group:       group,
-		Query:       query,
-		QueryWindow: queryWindow,
-		Source:      source,
-		Strategy:    strategy,
-		OnError:     on_error,
+		Group:             group,
+		Query:             query,
+		QueryWindow:       queryWindow,
+		QueryWindowOffset: queryWindowOffset,
+		Source:            source,
+		Strategy:          strategy,
+		OnError:           on_error,
 	}
 }
 

--- a/policy/nomad/parser_test.go
+++ b/policy/nomad/parser_test.go
@@ -44,11 +44,12 @@ func Test_parsePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Name:        "check-1",
-						Source:      "source-1",
-						Query:       "query-1",
-						QueryWindow: time.Minute,
-						OnError:     "ignore",
+						Name:              "check-1",
+						Source:            "source-1",
+						Query:             "query-1",
+						QueryWindow:       time.Minute,
+						QueryWindowOffset: 2 * time.Minute,
+						OnError:           "ignore",
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Name: "strategy-1",
 							Config: map[string]string{

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -25,6 +25,7 @@ const (
 	keySource             = "source"
 	keyQuery              = "query"
 	keyQueryWindow        = "query_window"
+	keyQueryWindowOffset  = "query_window_offset"
 	keyEvaluationInterval = "evaluation_interval"
 	keyOnCheckError       = "on_check_error"
 	keyOnError            = "on_error"

--- a/policy/nomad/source_test.go
+++ b/policy/nomad/source_test.go
@@ -42,10 +42,11 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Name:        "check",
-						Source:      "source",
-						Query:       "query",
-						QueryWindow: 5 * time.Minute,
+						Name:              "check",
+						Source:            "source",
+						Query:             "query",
+						QueryWindow:       5 * time.Minute,
+						QueryWindowOffset: 2 * time.Minute,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Name: "strategy",
 							Config: map[string]string{
@@ -75,10 +76,11 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 				},
 				Checks: []*sdk.ScalingPolicyCheck{
 					{
-						Name:        "check",
-						Source:      "source",
-						Query:       "query",
-						QueryWindow: 5 * time.Minute,
+						Name:              "check",
+						Source:            "source",
+						Query:             "query",
+						QueryWindow:       5 * time.Minute,
+						QueryWindowOffset: 2 * time.Minute,
 						Strategy: &sdk.ScalingPolicyStrategy{
 							Name: "strategy",
 							Config: map[string]string{

--- a/policy/nomad/test-fixtures/full-scaling.json.golden
+++ b/policy/nomad/test-fixtures/full-scaling.json.golden
@@ -3,20 +3,23 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 195,
+    "ConsulNamespace": "",
+    "ConsulToken": "",
+    "CreateIndex": 9,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "full-scaling",
-    "JobModifyIndex": 195,
+    "JobModifyIndex": 9,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 199,
+    "ModifyIndex": 14,
     "Multiregion": null,
     "Name": "full-scaling",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -30,21 +33,28 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1645143603621529000,
+    "SubmitTime": 1707527436368244000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": {
+          "Cluster": "default",
+          "Namespace": "",
+          "Partition": ""
+        },
         "Count": 2,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -57,24 +67,25 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 195,
+          "CreateIndex": 9,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 2,
-          "ModifyIndex": 195,
+          "ModifyIndex": 9,
           "Namespace": "",
           "Policy": {
             "target": [
               {
                 "target": [
                   {
-                    "bool_config": true,
-                    "int_config": 2,
-                    "str_config": "str"
+                    "int_config": 2.0,
+                    "str_config": "str",
+                    "bool_config": true
                   }
                 ]
               }
@@ -83,21 +94,22 @@
               {
                 "check-1": [
                   {
+                    "on_error": "ignore",
+                    "query": "query-1",
                     "query_window": "1m",
+                    "query_window_offset": "2m",
                     "source": "source-1",
                     "strategy": [
                       {
                         "strategy-1": [
                           {
-                            "int_config": 2,
                             "str_config": "str",
-                            "bool_config": true
+                            "bool_config": true,
+                            "int_config": 2.0
                           }
                         ]
                       }
-                    ],
-                    "on_error": "ignore",
-                    "query": "query-1"
+                    ]
                   }
                 ]
               },
@@ -111,9 +123,9 @@
                       {
                         "strategy-2": [
                           {
-                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2
+                            "int_config": 2.0,
+                            "str_config": "str"
                           }
                         ]
                       }
@@ -139,24 +151,41 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -170,13 +199,15 @@
               "IOPS": 0,
               "MemoryMB": 300,
               "MemoryMaxMB": 0,
+              "NUMA": null,
               "Networks": null
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
             "Services": null,

--- a/policy/nomad/test-fixtures/src/full-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/full-scaling.hcl
@@ -23,10 +23,11 @@ job "full-scaling" {
         }
 
         check "check-1" {
-          source       = "source-1"
-          query        = "query-1"
-          query_window = "1m"
-          on_error     = "ignore"
+          source              = "source-1"
+          query               = "query-1"
+          query_window        = "1m"
+          query_window_offset = "2m"
+          on_error            = "ignore"
 
           strategy "strategy-1" {
             int_config  = 2

--- a/policyeval/base_worker.go
+++ b/policyeval/base_worker.go
@@ -501,7 +501,7 @@ func (h *checkHandler) runAPMQuery(apmImpl apm.APM) (sdk.TimestampedMetrics, err
 	defer metrics.MeasureSinceWithLabels([]string{"plugin", "apm", "query", "invoke_ms"}, time.Now(), labels)
 
 	// Calculate query range from the query window defined in the check.
-	to := time.Now()
+	to := time.Now().Add(-h.checkEval.Check.QueryWindowOffset)
 	from := to.Add(-h.checkEval.Check.QueryWindow)
 	r := sdk.TimeRange{From: from, To: to}
 

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -139,6 +139,10 @@ type ScalingPolicyCheck struct {
 	// metrics.
 	QueryWindow time.Duration
 
+	// QueryWindowOffset defines an offset from the current time to apply to
+	// the query window.
+	QueryWindowOffset time.Duration
+
 	// Strategy is the ScalingPolicyStrategy to use when performing the
 	// ScalingPolicyCheck evaluation.
 	Strategy *ScalingPolicyStrategy
@@ -227,14 +231,16 @@ type FileDecodePolicyDoc struct {
 }
 
 type FileDecodePolicyCheckDoc struct {
-	Name           string `hcl:"name,label"`
-	Group          string `hcl:"group,optional"`
-	Source         string `hcl:"source,optional"`
-	Query          string `hcl:"query,optional"`
-	QueryWindow    time.Duration
-	QueryWindowHCL string                 `hcl:"query_window,optional"`
-	OnError        string                 `hcl:"on_error,optional"`
-	Strategy       *ScalingPolicyStrategy `hcl:"strategy,block"`
+	Name                 string `hcl:"name,label"`
+	Group                string `hcl:"group,optional"`
+	Source               string `hcl:"source,optional"`
+	Query                string `hcl:"query,optional"`
+	QueryWindow          time.Duration
+	QueryWindowHCL       string `hcl:"query_window,optional"`
+	QueryWindowOffset    time.Duration
+	QueryWindowOffsetHCL string                 `hcl:"query_window_offset,optional"`
+	OnError              string                 `hcl:"on_error,optional"`
+	Strategy             *ScalingPolicyStrategy `hcl:"strategy,block"`
 }
 
 // Translate all values from the decoded policy file into our internal policy
@@ -275,6 +281,7 @@ func (fdc *FileDecodePolicyCheckDoc) Translate(c *ScalingPolicyCheck) {
 	c.Source = fdc.Source
 	c.Query = fdc.Query
 	c.QueryWindow = fdc.QueryWindow
+	c.QueryWindowOffset = fdc.QueryWindowOffset
 	c.OnError = fdc.OnError
 	c.Strategy = fdc.Strategy
 }

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -171,11 +171,13 @@ func TestFileDecodePolicy_Translate(t *testing.T) {
 					EvaluationIntervalHCL: "10ns",
 					Checks: []*FileDecodePolicyCheckDoc{
 						{
-							Name:           "approach-speed",
-							Source:         "front-sensor",
-							Query:          "how-fast-am-i-going",
-							QueryWindow:    time.Minute,
-							QueryWindowHCL: "1m",
+							Name:                 "approach-speed",
+							Source:               "front-sensor",
+							Query:                "how-fast-am-i-going",
+							QueryWindow:          time.Minute,
+							QueryWindowHCL:       "1m",
+							QueryWindowOffset:    2 * time.Minute,
+							QueryWindowOffsetHCL: "2m",
 							Strategy: &ScalingPolicyStrategy{
 								Name: "approach-velocity",
 								Config: map[string]string{
@@ -201,10 +203,11 @@ func TestFileDecodePolicy_Translate(t *testing.T) {
 				EvaluationInterval: 10 * time.Nanosecond,
 				Checks: []*ScalingPolicyCheck{
 					{
-						Name:        "approach-speed",
-						Source:      "front-sensor",
-						Query:       "how-fast-am-i-going",
-						QueryWindow: time.Minute,
+						Name:              "approach-speed",
+						Source:            "front-sensor",
+						Query:             "how-fast-am-i-going",
+						QueryWindow:       time.Minute,
+						QueryWindowOffset: 2 * time.Minute,
 						Strategy: &ScalingPolicyStrategy{
 							Name: "approach-velocity",
 							Config: map[string]string{


### PR DESCRIPTION
The Nomad Autoscaler uses the current time as the end of the query window. This can cause instability, specially for strategies that only take the most recent data point into account, because the latest data may still be processing.

`query_window_offset` defines a time offset applied to the query window to push it back in time. A short `query_window_offset` value can help with the unstable readings, and a long value can be used for predictive scaling based on historical data (for example, from `7d` ago).

Closes https://github.com/hashicorp/nomad-autoscaler/issues/843.