### PR TITLE
Healthcheck plugins on dispense, re-instantiating broken ones

### DIFF
--- a/plugins/manager/manager_test.go
+++ b/plugins/manager/manager_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/agent/config"
 	"github.com/hashicorp/nomad-autoscaler/plugins/apm"
+	"github.com/hashicorp/nomad-autoscaler/plugins/base"
 	"github.com/hashicorp/nomad-autoscaler/plugins/strategy"
 	"github.com/hashicorp/nomad-autoscaler/plugins/target"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoad(t *testing.T) {
@@ -153,26 +155,7 @@ func TestDispense(t *testing.T) {
 		{
 			name:      "external plugin",
 			pluginDir: "../test/bin",
-			cfg: map[string][]*config.Plugin{
-				"apm": {
-					&config.Plugin{
-						Name:   "noop",
-						Driver: "noop-apm",
-					},
-				},
-				"strategy": {
-					&config.Plugin{
-						Name:   "noop",
-						Driver: "noop-strategy",
-					},
-				},
-				"target": {
-					&config.Plugin{
-						Name:   "noop",
-						Driver: "noop-target",
-					},
-				},
-			},
+			cfg:       externalPlugins(),
 		},
 	}
 
@@ -203,5 +186,58 @@ func TestDispense(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestExternalPluginDies(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	pm := NewPluginManager(logger, "../test/bin", externalPlugins())
+	defer pm.KillPlugins()
+
+	err := pm.Load()
+	require.NoError(t, err)
+	pi, err := pm.Dispense("noop", "target")
+	require.NoError(t, err)
+
+	// Verify we can talk to the plugin
+	client := pi.Plugin().(base.Base)
+	_, err = client.PluginInfo()
+	require.NoError(t, err)
+
+	// Kill the plugin without the manager noticing
+	pi.Kill()
+	_, err = client.PluginInfo()
+	require.Error(t, err)
+
+	// Now, re-dispense. The manager should recover
+	pi, err = pm.Dispense("noop", "target")
+	require.NoError(t, err)
+
+	// Verify that the returned plugin works
+	client = pi.Plugin().(base.Base)
+	_, err = client.PluginInfo()
+	require.NoError(t, err)
+}
+
+func externalPlugins() map[string][]*config.Plugin {
+	return map[string][]*config.Plugin{
+		"apm": {
+			&config.Plugin{
+				Name:   "noop",
+				Driver: "noop-apm",
+			},
+		},
+		"strategy": {
+			&config.Plugin{
+				Name:   "noop",
+				Driver: "noop-strategy",
+			},
+		},
+		"target": {
+			&config.Plugin{
+				Name:   "noop",
+				Driver: "noop-target",
+			},
+		},
 	}
 }


### PR DESCRIPTION
Disclaimer: I don't really think this is the correct solution. It's just a first pass at it, with the most important bit being the test that reliably reproduces the problem. Very happy to work on the solution in a different way.

At the moment, if an external plugin that nomad-autoscaler relies on dies for any reason (OOM, for instance, or someone coming along and running `kill` on it), the nomad-autoscaler process cannot recover. Instead, we see a steady stream of errors of the form `rpc error: code = Canceled desc = context canceled` for the remaining lifetime of the process.

Attempt to solve this by:

- Running the `PluginInfo` RPC against plugins when they are being dispensed
- Killing the plugin if that fails, removing it from the plugin instances map
- Re-running `dispensePlugins()` if a request is made for a plugin not in the instance map

This seems like the minimal approach in terms of moving code around, but I suspect it has a significant performance impact, and probably spams the logs heavily in a range of scenarios. Still, it's a starting point.

Closes https://github.com/hashicorp/nomad-autoscaler/issues/711