### PR TITLE
test: run CI on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build
 
 on:
+  pull_request:
+    paths-ignore:
+      - '*.md'
   push:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,14 @@
 name: CI
 
 on:
+  pull_request:
+    paths-ignore:
+      - '*.md'
   push:
+    branches:
+      - main
+    paths-ignore:
+      - '*.md'
 
 jobs:
   check:

--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -1,7 +1,14 @@
 name: Check Copywrite Headers
 
 on:
-  push: {}
+  pull_request:
+    paths-ignore:
+      - '*.md'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '*.md'
 
 jobs:
   copywrite:


### PR DESCRIPTION
The GitHub Actions configuration doesn't run CI on pull requests, only on pushes which doesn't cover external PRs (Ex https://github.com/hashicorp/nomad-autoscaler/pull/945). Update the behavior to match what we do in Nomad core, where PRs get CI as well as merges to main.