### PR TITLE
config: use `URL` method to get Nomad address for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+BUG FIXES:
+* config: Fixed a bug where the Nomad strategy and target plugins would fail to connect to Nomad's Task API socket [[GH-966](https://github.com/hashicorp/nomad-autoscaler/pull/966)]
+
 ## 0.4.5 (August 13, 2024)
 
 IMPROVEMENTS:

--- a/sdk/helper/nomad/config.go
+++ b/sdk/helper/nomad/config.go
@@ -112,7 +112,11 @@ func MergeMapWithAgentConfig(m map[string]string, cfg *api.Config) {
 	}
 
 	if cfg.Address != "" && m[configKeyNomadAddress] == "" {
-		m[configKeyNomadAddress] = cfg.Address
+		if cfg.URL() != nil {
+			m[configKeyNomadAddress] = cfg.URL().String()
+		} else {
+			m[configKeyNomadAddress] = cfg.Address
+		}
 	}
 	if cfg.Region != "" && m[configKeyNomadRegion] == "" {
 		m[configKeyNomadRegion] = cfg.Region


### PR DESCRIPTION
For #944 we fixed the Nomad API package so that it no longer mutated the private `url` field if previously set, which allowed reusing an `api.Config` object between clients when a unix domain socket was in use.

However, the autoscaler plugins for Nomad strategy and target don't use the `api.Config` object we parse directly and instead get a map of string->string derived from that config so it can be passed over the go-plugin interface. This mapping did not account for the `Address` field being mutated when unix domain sockets are in use, so the bug was not actually fixed.

Update the mapping to use the safe `URL()` method on the config, rather than reading the `Address` field.

Fixes: https://github.com/hashicorp/nomad-autoscaler/issues/955
Ref: https://github.com/hashicorp/nomad/pull/23785