### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Blanket ownership of all PRs.
-* @jrasell @Juanadelacuesta
+* @hashicorp/github-nomad-core @hashicorp/nomad-eng
 
 # release configuration
 /.release/                              @hashicorp/nomad-eng


### PR DESCRIPTION
Add github team as default codeowners for this repo, instead of individual users