### PR TITLE
build: update toolchain components to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 
 # devbuild compiles the binary
 # -----------------------------------
-FROM golang:1.23 AS devbuild
+FROM golang:1.24 AS devbuild
 
 # Disable CGO to make sure we build static binaries
 ENV CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad-autoscaler
 
-go 1.23.5
+go 1.24
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/plugins/test/noop-apm/go.mod
+++ b/plugins/test/noop-apm/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad-autoscaler/plugins/test/noop-apm
 
-go 1.23.5
+go 1.24
 
 require (
 	github.com/hashicorp/go-hclog v1.6.3

--- a/plugins/test/noop-strategy/go.mod
+++ b/plugins/test/noop-strategy/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad-autoscaler/plugins/test/noop-strategy
 
-go 1.23.5
+go 1.24
 
 require (
 	github.com/hashicorp/go-hclog v1.6.3

--- a/plugins/test/noop-target/go.mod
+++ b/plugins/test/noop-target/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad-autoscaler/plugins/test/noop-target
 
-go 1.23.5
+go 1.24
 
 require (
 	github.com/hashicorp/go-hclog v1.6.3


### PR DESCRIPTION
We updated to Go 1.24 in #1045 but it looks like this missed a few build components that are now causing issues with dependabot PRs.