### PR TITLE
stage changes for Nomad 1.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+* build: Updated Nomad API dependency to 1.10.0 [[GH-1061](https://github.com/hashicorp/nomad-autoscaler/pull/1061)]
 * build: Updated to Go 1.24.0 [[GH-1045](https://github.com/hashicorp/nomad-autoscaler/pull/1045)]
 
 ## 0.4.6 (December 12, 2024)
@@ -14,7 +15,7 @@ IMPROVEMENTS:
 * build: Updated Nomad API dependency to 1.9.3 [[GH-1010](https://github.com/hashicorp/nomad-autoscaler/pull/1010)]
 * build: Updated to Go 1.23.4 [[GH-1009](https://github.com/hashicorp/nomad-autoscaler/pull/1009)]
 
-* scaleutils: Add new node selector option `oldest_create_index` to select nodes with the oldest creation date  [[GH-961](https://github.com/hashicorp/nomad-autoscaler/pull/961)] 
+* scaleutils: Add new node selector option `oldest_create_index` to select nodes with the oldest creation date  [[GH-961](https://github.com/hashicorp/nomad-autoscaler/pull/961)]
 
 ## 0.4.5 (August 13, 2024)
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.6.3
 	github.com/hashicorp/hcl/v2 v2.23.0
-	github.com/hashicorp/nomad/api v0.0.0-20241111163541-d92bf1014886
+	github.com/hashicorp/nomad/api v0.0.0-20250327125806-3ab167355223
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/nomad/api v0.0.0-20241111163541-d92bf1014886 h1:dJzU4tRIy/Y0DB1UyRcl8fHLox7I/bz8gsVTu0aDOkc=
-github.com/hashicorp/nomad/api v0.0.0-20241111163541-d92bf1014886/go.mod h1:svtxn6QnrQ69P23VvIWMR34tg3vmwLz4UdUzm1dSCgE=
+github.com/hashicorp/nomad/api v0.0.0-20250327125806-3ab167355223 h1:MoCZEoNKNrjCKTmR/6+fRqMbphvEh8o8v5GKju9RZPg=
+github.com/hashicorp/nomad/api v0.0.0-20250327125806-3ab167355223/go.mod h1:ke9JNxf926l1gzdv+hldAgk72SgvmrjSos1rRqDJLq8=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=


### PR DESCRIPTION
Update the Nomad API package to the current tip of main so we can verify builds are green ahead of the Nomad 1.10.0 GA.