### PR TITLE
Do not return negative newCount

### DIFF
--- a/plugins/builtin/strategy/threshold/plugin/plugin.go
+++ b/plugins/builtin/strategy/threshold/plugin/plugin.go
@@ -122,6 +122,10 @@ func (s *StrategyPlugin) Run(eval *sdk.ScalingCheckEvaluation, count int64) (*sd
 		newCount = runValue(config.actionValue)
 	}
 
+	if newCount < 0 {
+		newCount = 0
+	}
+
 	// Identify the direction of scaling, and exit early if none.
 	eval.Action.Direction = calculateDirection(count, newCount)
 	if eval.Action.Direction == sdk.ScaleDirectionNone {

--- a/plugins/builtin/strategy/threshold/plugin/plugin_test.go
+++ b/plugins/builtin/strategy/threshold/plugin/plugin_test.go
@@ -108,6 +108,20 @@ func TestThresholdPlugin(t *testing.T) {
 			},
 		},
 		{
+			name:    "delta scale down, no negative",
+			count:   0,
+			metrics: []float64{10, 10, 10, 10, 10, 10},
+			config: map[string]string{
+				"lower_bound": "5",
+				"upper_bound": "20",
+				"delta":       "-1",
+			},
+			expectedAction: &sdk.ScalingAction{
+				Count:     0,
+				Direction: sdk.ScaleDirectionNone,
+			},
+		},
+		{
 			name:    "percentage scale up",
 			count:   10,
 			metrics: []float64{10, 10, 10, 10, 10, 10},


### PR DESCRIPTION
When the number of instances is 0 and the threshold plugin is used with `delta=  -1` it could return a `newCount = -1`.
This would cause creating a new scaling event. 

To avoid such behavior, I'm adding a check and set `newCount` to 0.