### PR TITLE
Fix race between worker and policy hander

### DIFF
--- a/policy/handler.go
+++ b/policy/handler.go
@@ -82,7 +82,7 @@ func NewHandler(ID PolicyID, log hclog.Logger, pm *manager.PluginManager, ps Sou
 		ch:         make(chan sdk.ScalingPolicy),
 		errCh:      make(chan error),
 		doneCh:     make(chan struct{}),
-		cooldownCh: make(chan time.Duration),
+		cooldownCh: make(chan time.Duration, 1),
 		reloadCh:   make(chan struct{}),
 	}
 }


### PR DESCRIPTION
Because of bug/feature described here https://github.com/hashicorp/nomad-autoscaler/pull/1070 we had a lot of scaling and cooldown actions. With thousands of policies, we've noticed that sometimes all broker workers get stuck. 

After some debugging, I believe this is a result of a race between broker worker goroutine and policy handler goroutine.

Here's what's happening:
After each scaling action, the worker [enforces a cooldown](https://github.com/hashicorp/nomad-autoscaler/blob/main/policyeval/base_worker.go#L337) on the policy handler.
Policy handler gets this information via the `cooldownCh` channel [here](https://github.com/hashicorp/nomad-autoscaler/blob/main/policy/handler.go#L181).
However, if the policy handler is executing [handleTick](https://github.com/hashicorp/nomad-autoscaler/blob/main/policy/handler.go#L167) method, it can notice the scale event and also start cooldown [here](https://github.com/hashicorp/nomad-autoscaler/blob/main/policy/handler.go#L295). This will block the whole `Run` method, and reading from `cooldownCh` will be blocked for a configured cooldown time. 
After `cooldown` time, `handleTick` will finish, and will read from `cooldownCh` and will unlock the worker and block again.

So there are two issues here:
1. Broker worker is blocked. We set `cooldown` to 5min so it's noticeable.
2. The Policy handler is on cooldown twice. Once because of  `handleTick` and once because of  `cooldownCh`

This PR fixes only the first issue. By making  `cooldownCh` channel buffered, we avoid blocking the worker.
