### PR TITLE
build: bump alpine base image to 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN go build -o nomad-autoscaler .
 
 # dev runs the binary from devbuild
 # -----------------------------------
-FROM alpine:3.21 AS dev
+FROM alpine:3.22 AS dev
 
 COPY --from=devbuild /build/nomad-autoscaler /bin/
 COPY ./scripts/docker-entrypoint.sh /
@@ -35,7 +35,7 @@ CMD ["help"]
 #   Release images.
 # ===================================
 
-FROM alpine:3.21 AS release
+FROM alpine:3.22 AS release
 
 ARG PRODUCT_NAME=nomad-autoscaler
 ARG PRODUCT_VERSION


### PR DESCRIPTION
The build pipeline's security scanner is picking up a (not meaningful) vuln in the Alpine base image we're using, which is preventing nightlies from being published. Rev the alpine base image.

Ref: https://github.com/hashicorp/crt-workflows-common/actions/runs/15543056919/job/43758419778
Fixes: https://github.com/hashicorp/nomad-autoscaler/issues/1097