### PR TITLE
Add a different cooldown on scale up option

### DIFF
--- a/policy/handler.go
+++ b/policy/handler.go
@@ -205,7 +205,7 @@ func (h *Handler) updateHandler(updatedPolicy *sdk.ScalingPolicy) {
 // enforceCooldown blocks until the cooldown period has been reached, or the
 // handler has been instructed to exit. The boolean return details whether or
 // not the cooldown period passed without being interrupted.
-func (h *Handler) enforceCooldown(ctx context.Context, t time.Duration) (complete bool) {
+func (h *Handler) enforceCooldown(ctx context.Context, t time.Duration) bool {
 
 	// Log that cooldown is being enforced. This is very useful as cooldown
 	// blocks the ticker making this the only indication of cooldown to
@@ -221,12 +221,12 @@ func (h *Handler) enforceCooldown(ctx context.Context, t time.Duration) (complet
 	// Cooldown should not mean we miss other handler control signals. So wait
 	// on all the channels desired here.
 	select {
-	case <-timer.C:
-		complete = true
-		return
 	case <-ctx.Done():
-		return
+		return false
+	case <-timer.C:
 	}
+
+	return true
 }
 
 // calculateRemainingCooldown calculates the remaining cooldown based on the

--- a/policy/nomad/parser.go
+++ b/policy/nomad/parser.go
@@ -45,10 +45,16 @@ func parsePolicy(p *api.ScalingPolicy) sdk.ScalingPolicy {
 		to.EvaluationInterval, _ = time.ParseDuration(eval)
 	}
 
-	// Parse cooldown as time.Duraction
+	// Parse cooldown as time.Duration
 	// Ignore error since we assume policy has been validated.
 	if cooldown, ok := p.Policy[keyCooldown].(string); ok {
 		to.Cooldown, _ = time.ParseDuration(cooldown)
+	}
+
+	// Parse cooldownOnScaleUp as time.Duration
+	// Ignore error since we assume policy has been validated.
+	if cooldownOnScaleUp, ok := p.Policy[keyCooldownOnScaleUp].(string); ok {
+		to.CooldownOnScaleUp, _ = time.ParseDuration(cooldownOnScaleUp)
 	}
 
 	// Parse on_check_error.

--- a/policy/nomad/parser_test.go
+++ b/policy/nomad/parser_test.go
@@ -29,7 +29,7 @@ func Test_parsePolicy(t *testing.T) {
 				Enabled:            false,
 				EvaluationInterval: 5 * time.Second,
 				Cooldown:           5 * time.Minute,
-				CooldownOnScaleUp:  10 * time.Minute,
+				CooldownOnScaleUp:  2 * time.Minute,
 				Type:               "horizontal",
 				OnCheckError:       "fail",
 				Target: &sdk.ScalingPolicyTarget{

--- a/policy/nomad/parser_test.go
+++ b/policy/nomad/parser_test.go
@@ -29,6 +29,7 @@ func Test_parsePolicy(t *testing.T) {
 				Enabled:            false,
 				EvaluationInterval: 5 * time.Second,
 				Cooldown:           5 * time.Minute,
+				CooldownOnScaleUp:  10 * time.Minute,
 				Type:               "horizontal",
 				OnCheckError:       "fail",
 				Target: &sdk.ScalingPolicyTarget{

--- a/policy/nomad/source.go
+++ b/policy/nomad/source.go
@@ -36,6 +36,7 @@ const (
 	keyGroup              = "group"
 	keyStrategy           = "strategy"
 	keyCooldown           = "cooldown"
+	keyCooldownOnScaleUp  = "cooldown_on_scale_up"
 )
 
 // Ensure NomadSource satisfies the Source interface.

--- a/policy/nomad/source_test.go
+++ b/policy/nomad/source_test.go
@@ -326,12 +326,13 @@ func TestSource_canonicalizePolicy(t *testing.T) {
 			},
 		},
 		{
-			name:  "sets cooldown from agent",
+			name:  "sets cooldown and cooldownonscalingup from agent",
 			input: &sdk.ScalingPolicy{},
 			expected: &sdk.ScalingPolicy{
 				Type:               sdk.ScalingPolicyTypeHorizontal,
 				EvaluationInterval: 10 * time.Second,
 				Cooldown:           1 * time.Hour,
+				CooldownOnScaleUp:  1 * time.Hour,
 				Target: &sdk.ScalingPolicyTarget{
 					Name:   plugins.InternalTargetNomad,
 					Config: map[string]string{},

--- a/policy/nomad/test-fixtures/GNUmakefile
+++ b/policy/nomad/test-fixtures/GNUmakefile
@@ -23,3 +23,11 @@ clean-golden:
 	@nomad stop -purge $* > /dev/null
 	@# hardcode scaling policy ID so tests don't break every time the files are regenerated
 	@jq -rM 'if .Job.TaskGroups[0].Scaling then.Job.TaskGroups[0].Scaling.ID = "id" else . end' $@  > $@.tmp && mv $@{.tmp,}
+
+.PHONY: hclfmt
+hclfmt: ## Format HCL files with hclfmt
+	@echo "==> Formatting HCL"
+	@find . -name '.terraform' -prune \
+	        -o -name '.git' -prune \
+	        -o \( -name '*.nomad' -o -name '*.hcl' -o -name '*.tf' \) \
+	      -print0 | xargs -0 hclfmt -w

--- a/policy/nomad/test-fixtures/empty-check.json.golden
+++ b/policy/nomad/test-fixtures/empty-check.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 230,
+    "CreateIndex": 11,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "empty-check",
-    "JobModifyIndex": 230,
+    "JobModifyIndex": 11,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 231,
+    "ModifyIndex": 12,
     "Multiregion": null,
     "Name": "empty-check",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936896836272000,
+    "SubmitTime": 1750941680088842000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 230,
+          "CreateIndex": 11,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 230,
+          "ModifyIndex": 11,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -100,10 +100,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/empty-check.json.golden
+++ b/policy/nomad/test-fixtures/empty-check.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 252,
+    "ConsulNamespace": "",
+    "CreateIndex": 230,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "empty-check",
-    "JobModifyIndex": 252,
+    "JobModifyIndex": 230,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 253,
+    "ModifyIndex": 231,
     "Multiregion": null,
     "Name": "empty-check",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724429635116000,
+    "SubmitTime": 1750936896836272000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 252,
+          "CreateIndex": 230,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 252,
+          "ModifyIndex": 230,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -76,9 +84,9 @@
             ]
           },
           "Target": {
+            "Namespace": "default",
             "Job": "empty-check",
-            "Group": "test",
-            "Namespace": "default"
+            "Group": "test"
           },
           "Type": "horizontal"
         },
@@ -88,6 +96,7 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
@@ -97,15 +106,32 @@
               "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -113,19 +139,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -139,6 +171,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -151,7 +184,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/empty-check.json.golden
+++ b/policy/nomad/test-fixtures/empty-check.json.golden
@@ -6,7 +6,7 @@
     "ConsulNamespace": "",
     "CreateIndex": 11,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941680088842000,
+    "SubmitTime": 1751038603803727000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -84,9 +84,9 @@
             ]
           },
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "empty-check",
-            "Group": "test"
+            "Job": "empty-check"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/empty-policy.json.golden
+++ b/policy/nomad/test-fixtures/empty-policy.json.golden
@@ -6,7 +6,7 @@
     "ConsulNamespace": "",
     "CreateIndex": 15,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941680411324000,
+    "SubmitTime": 1751038604221151000,
     "TaskGroups": [
       {
         "Affinities": null,

--- a/policy/nomad/test-fixtures/empty-policy.json.golden
+++ b/policy/nomad/test-fixtures/empty-policy.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 234,
+    "CreateIndex": 15,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "empty-policy",
-    "JobModifyIndex": 234,
+    "JobModifyIndex": 15,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 235,
+    "ModifyIndex": 16,
     "Multiregion": null,
     "Name": "empty-policy",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936897146868000,
+    "SubmitTime": 1750941680411324000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -72,18 +72,18 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 234,
+          "CreateIndex": 15,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 234,
+          "ModifyIndex": 15,
           "Namespace": "",
           "Policy": {},
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "empty-policy"
+            "Job": "empty-policy",
+            "Group": "test"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/empty-policy.json.golden
+++ b/policy/nomad/test-fixtures/empty-policy.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 218,
+    "ConsulNamespace": "",
+    "CreateIndex": 234,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "empty-policy",
-    "JobModifyIndex": 218,
+    "JobModifyIndex": 234,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 219,
+    "ModifyIndex": 235,
     "Multiregion": null,
     "Name": "empty-policy",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,17 +32,20 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724424188174000,
+    "SubmitTime": 1750936897146868000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": {
           "HealthCheck": "checks",
@@ -49,6 +55,7 @@
         },
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 0,
           "Delay": 30000000000,
@@ -61,21 +68,22 @@
           "Attempts": 2,
           "Delay": 15000000000,
           "Interval": 1800000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 218,
+          "CreateIndex": 234,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 218,
+          "ModifyIndex": 234,
           "Namespace": "",
           "Policy": {},
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "empty-policy",
-            "Group": "test"
+            "Job": "empty-policy"
           },
           "Type": "horizontal"
         },
@@ -85,6 +93,7 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
@@ -94,15 +103,32 @@
               "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -110,19 +136,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 2,
               "Delay": 15000000000,
               "Interval": 1800000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -146,6 +178,7 @@
       }
     ],
     "Type": "service",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -158,7 +191,7 @@
       "Stagger": 30000000000
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/empty-strategy.json.golden
+++ b/policy/nomad/test-fixtures/empty-strategy.json.golden
@@ -6,7 +6,7 @@
     "ConsulNamespace": "",
     "CreateIndex": 19,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941680717601000,
+    "SubmitTime": 1751038604541342000,
     "TaskGroups": [
       {
         "Affinities": null,

--- a/policy/nomad/test-fixtures/empty-strategy.json.golden
+++ b/policy/nomad/test-fixtures/empty-strategy.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 238,
+    "CreateIndex": 19,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "empty-strategy",
-    "JobModifyIndex": 238,
+    "JobModifyIndex": 19,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 239,
+    "ModifyIndex": 20,
     "Multiregion": null,
     "Name": "empty-strategy",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936897454876000,
+    "SubmitTime": 1750941680717601000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 238,
+          "CreateIndex": 19,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 238,
+          "ModifyIndex": 19,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -92,9 +92,9 @@
             ]
           },
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "empty-strategy"
+            "Job": "empty-strategy",
+            "Group": "test"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/empty-strategy.json.golden
+++ b/policy/nomad/test-fixtures/empty-strategy.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 315,
+    "ConsulNamespace": "",
+    "CreateIndex": 238,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "empty-strategy",
-    "JobModifyIndex": 315,
+    "JobModifyIndex": 238,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 316,
+    "ModifyIndex": 239,
     "Multiregion": null,
     "Name": "empty-strategy",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724439894161000,
+    "SubmitTime": 1750936897454876000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 315,
+          "CreateIndex": 238,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 315,
+          "ModifyIndex": 238,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -84,9 +92,9 @@
             ]
           },
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "empty-strategy",
-            "Group": "test"
+            "Job": "empty-strategy"
           },
           "Type": "horizontal"
         },
@@ -96,24 +104,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -121,19 +147,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -147,6 +179,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -159,7 +192,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/empty-target.json.golden
+++ b/policy/nomad/test-fixtures/empty-target.json.golden
@@ -6,7 +6,7 @@
     "ConsulNamespace": "",
     "CreateIndex": 23,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941681029420000,
+    "SubmitTime": 1751038604855350000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -84,9 +84,9 @@
             ]
           },
           "Target": {
-            "Job": "empty-target",
             "Group": "test",
-            "Namespace": "default"
+            "Namespace": "default",
+            "Job": "empty-target"
           },
           "Type": "horizontal"
         },
@@ -100,10 +100,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/empty-target.json.golden
+++ b/policy/nomad/test-fixtures/empty-target.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 208,
+    "ConsulNamespace": "",
+    "CreateIndex": 242,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "empty-target",
-    "JobModifyIndex": 208,
+    "JobModifyIndex": 242,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 209,
+    "ModifyIndex": 243,
     "Multiregion": null,
     "Name": "empty-target",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724422487972000,
+    "SubmitTime": 1750936897767198000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 208,
+          "CreateIndex": 242,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 208,
+          "ModifyIndex": 242,
           "Namespace": "",
           "Policy": {
             "target": [
@@ -76,9 +84,9 @@
             ]
           },
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "empty-target",
-            "Group": "test"
+            "Job": "empty-target"
           },
           "Type": "horizontal"
         },
@@ -88,24 +96,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -113,19 +139,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -139,6 +171,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -151,7 +184,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/empty-target.json.golden
+++ b/policy/nomad/test-fixtures/empty-target.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 242,
+    "CreateIndex": 23,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "empty-target",
-    "JobModifyIndex": 242,
+    "JobModifyIndex": 23,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 243,
+    "ModifyIndex": 24,
     "Multiregion": null,
     "Name": "empty-target",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936897767198000,
+    "SubmitTime": 1750941681029420000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 242,
+          "CreateIndex": 23,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 242,
+          "ModifyIndex": 23,
           "Namespace": "",
           "Policy": {
             "target": [
@@ -84,9 +84,9 @@
             ]
           },
           "Target": {
+            "Job": "empty-target",
             "Group": "test",
-            "Namespace": "default",
-            "Job": "empty-target"
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/full-scaling.json.golden
+++ b/policy/nomad/test-fixtures/full-scaling.json.golden
@@ -6,7 +6,7 @@
     "ConsulNamespace": "",
     "CreateIndex": 27,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941681334535000,
+    "SubmitTime": 1751038605162034000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -79,42 +79,42 @@
               {
                 "check-1": [
                   {
-                    "on_error": "ignore",
-                    "query": "query-1",
-                    "query_window": "1m",
-                    "query_window_offset": "2m",
-                    "source": "source-1",
                     "strategy": [
                       {
                         "strategy-1": [
                           {
-                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0
+                            "int_config": 2.0,
+                            "str_config": "str"
                           }
                         ]
                       }
-                    ]
+                    ],
+                    "on_error": "ignore",
+                    "query": "query-1",
+                    "query_window": "1m",
+                    "query_window_offset": "2m",
+                    "source": "source-1"
                   }
                 ]
               },
               {
                 "check-2": [
                   {
-                    "query": "query-2",
-                    "source": "source-2",
                     "strategy": [
                       {
                         "strategy-2": [
                           {
-                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0
+                            "int_config": 2.0,
+                            "str_config": "str"
                           }
                         ]
                       }
                     ],
-                    "group": "group-2"
+                    "group": "group-2",
+                    "query": "query-2",
+                    "source": "source-2"
                   }
                 ]
               }
@@ -127,18 +127,18 @@
               {
                 "target": [
                   {
+                    "str_config": "str",
                     "bool_config": true,
-                    "int_config": 2.0,
-                    "str_config": "str"
+                    "int_config": 2.0
                   }
                 ]
               }
             ]
           },
           "Target": {
+            "Job": "full-scaling",
             "Group": "test",
-            "Namespace": "default",
-            "Job": "full-scaling"
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/full-scaling.json.golden
+++ b/policy/nomad/test-fixtures/full-scaling.json.golden
@@ -4,18 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "ConsulToken": "",
-    "CreateIndex": 9,
+    "CreateIndex": 246,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "full-scaling",
-    "JobModifyIndex": 9,
+    "JobModifyIndex": 246,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 14,
+    "ModifyIndex": 247,
     "Multiregion": null,
     "Name": "full-scaling",
     "Namespace": "default",
@@ -30,20 +29,17 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1707527436368244000,
+    "SubmitTime": 1750936898077945000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
-        "Consul": {
-          "Cluster": "default",
-          "Namespace": "",
-          "Partition": ""
-        },
+        "Consul": null,
         "Count": 2,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
@@ -71,21 +67,21 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 9,
+          "CreateIndex": 246,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 2,
-          "ModifyIndex": 9,
+          "ModifyIndex": 246,
           "Namespace": "",
           "Policy": {
             "target": [
               {
                 "target": [
                   {
+                    "bool_config": true,
                     "int_config": 2.0,
-                    "str_config": "str",
-                    "bool_config": true
+                    "str_config": "str"
                   }
                 ]
               }
@@ -94,8 +90,6 @@
               {
                 "check-1": [
                   {
-                    "on_error": "ignore",
-                    "query": "query-1",
                     "query_window": "1m",
                     "query_window_offset": "2m",
                     "source": "source-1",
@@ -109,7 +103,9 @@
                           }
                         ]
                       }
-                    ]
+                    ],
+                    "on_error": "ignore",
+                    "query": "query-1"
                   }
                 ]
               },
@@ -135,6 +131,7 @@
               }
             ],
             "cooldown": "5m",
+            "cooldown_on_scale_up": "2m",
             "evaluation_interval": "5s",
             "on_check_error": "fail"
           },
@@ -174,6 +171,7 @@
               "ChangeSignal": "",
               "Env": false,
               "File": false,
+              "Filepath": "",
               "Name": "default",
               "ServiceName": "",
               "TTL": 0
@@ -200,7 +198,8 @@
               "MemoryMB": 300,
               "MemoryMaxMB": 0,
               "NUMA": null,
-              "Networks": null
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
@@ -210,6 +209,7 @@
               "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -223,6 +223,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -235,7 +236,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/full-scaling.json.golden
+++ b/policy/nomad/test-fixtures/full-scaling.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 246,
+    "CreateIndex": 27,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "full-scaling",
-    "JobModifyIndex": 246,
+    "JobModifyIndex": 27,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 247,
+    "ModifyIndex": 28,
     "Multiregion": null,
     "Name": "full-scaling",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936898077945000,
+    "SubmitTime": 1750941681334535000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,29 +67,20 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 246,
+          "CreateIndex": 27,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 2,
-          "ModifyIndex": 246,
+          "ModifyIndex": 27,
           "Namespace": "",
           "Policy": {
-            "target": [
-              {
-                "target": [
-                  {
-                    "bool_config": true,
-                    "int_config": 2.0,
-                    "str_config": "str"
-                  }
-                ]
-              }
-            ],
             "check": [
               {
                 "check-1": [
                   {
+                    "on_error": "ignore",
+                    "query": "query-1",
                     "query_window": "1m",
                     "query_window_offset": "2m",
                     "source": "source-1",
@@ -103,29 +94,27 @@
                           }
                         ]
                       }
-                    ],
-                    "on_error": "ignore",
-                    "query": "query-1"
+                    ]
                   }
                 ]
               },
               {
                 "check-2": [
                   {
-                    "group": "group-2",
                     "query": "query-2",
                     "source": "source-2",
                     "strategy": [
                       {
                         "strategy-2": [
                           {
+                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0,
-                            "str_config": "str"
+                            "int_config": 2.0
                           }
                         ]
                       }
-                    ]
+                    ],
+                    "group": "group-2"
                   }
                 ]
               }
@@ -133,12 +122,23 @@
             "cooldown": "5m",
             "cooldown_on_scale_up": "2m",
             "evaluation_interval": "5s",
-            "on_check_error": "fail"
+            "on_check_error": "fail",
+            "target": [
+              {
+                "target": [
+                  {
+                    "bool_config": true,
+                    "int_config": 2.0,
+                    "str_config": "str"
+                  }
+                ]
+              }
+            ]
           },
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "full-scaling",
-            "Group": "test"
+            "Job": "full-scaling"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-check.json.golden
+++ b/policy/nomad/test-fixtures/invalid-check.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 269,
+    "ConsulNamespace": "",
+    "CreateIndex": 252,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-check",
-    "JobModifyIndex": 269,
+    "JobModifyIndex": 252,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 270,
+    "ModifyIndex": 253,
     "Multiregion": null,
     "Name": "invalid-check",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724432695692000,
+    "SubmitTime": 1750936898403487000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 269,
+          "CreateIndex": 252,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 269,
+          "ModifyIndex": 252,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -84,6 +92,7 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
@@ -93,15 +102,32 @@
               ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -109,19 +135,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -135,6 +167,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -147,7 +180,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-check.json.golden
+++ b/policy/nomad/test-fixtures/invalid-check.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 33,
+    "CreateIndex": 32,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-check",
-    "JobModifyIndex": 33,
+    "JobModifyIndex": 32,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 34,
+    "ModifyIndex": 33,
     "Multiregion": null,
     "Name": "invalid-check",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941681664426000,
+    "SubmitTime": 1751038605483872000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 33,
+          "CreateIndex": 32,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 33,
+          "ModifyIndex": 32,
           "Namespace": "",
           "Policy": {
             "check": [

--- a/policy/nomad/test-fixtures/invalid-check.json.golden
+++ b/policy/nomad/test-fixtures/invalid-check.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 252,
+    "CreateIndex": 33,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-check",
-    "JobModifyIndex": 252,
+    "JobModifyIndex": 33,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 253,
+    "ModifyIndex": 34,
     "Multiregion": null,
     "Name": "invalid-check",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936898403487000,
+    "SubmitTime": 1750941681664426000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 252,
+          "CreateIndex": 33,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 252,
+          "ModifyIndex": 33,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -80,9 +80,9 @@
             ]
           },
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-check",
-            "Group": "test"
+            "Job": "invalid-check"
           },
           "Type": "horizontal"
         },
@@ -96,10 +96,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up-type.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up-type.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 37,
+    "CreateIndex": 36,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-cooldown-on-scale-up-type",
-    "JobModifyIndex": 37,
+    "JobModifyIndex": 36,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 38,
+    "ModifyIndex": 37,
     "Multiregion": null,
     "Name": "invalid-cooldown-on-scale-up-type",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941681975975000,
+    "SubmitTime": 1751038605791812000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 37,
+          "CreateIndex": 36,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 37,
+          "ModifyIndex": 36,
           "Namespace": "",
           "Policy": {
             "cooldown": 5.0

--- a/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up-type.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up-type.json.golden
@@ -4,19 +4,19 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 264,
+    "CreateIndex": 256,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
-    "ID": "invalid-cooldown-type",
-    "JobModifyIndex": 264,
+    "ID": "invalid-cooldown-on-scale-up-type",
+    "JobModifyIndex": 256,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 265,
+    "ModifyIndex": 257,
     "Multiregion": null,
-    "Name": "invalid-cooldown-type",
+    "Name": "invalid-cooldown-on-scale-up-type",
     "Namespace": "default",
     "NodePool": "default",
     "NomadTokenID": "",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936899321315000,
+    "SubmitTime": 1750936898709661000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,19 +67,19 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 264,
+          "CreateIndex": 256,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 264,
+          "ModifyIndex": 256,
           "Namespace": "",
           "Policy": {
             "cooldown": 5.0
           },
           "Target": {
             "Namespace": "default",
-            "Job": "invalid-cooldown-type",
+            "Job": "invalid-cooldown-on-scale-up-type",
             "Group": "test"
           },
           "Type": "horizontal"

--- a/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up-type.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up-type.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 256,
+    "CreateIndex": 37,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-cooldown-on-scale-up-type",
-    "JobModifyIndex": 256,
+    "JobModifyIndex": 37,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 257,
+    "ModifyIndex": 38,
     "Multiregion": null,
     "Name": "invalid-cooldown-on-scale-up-type",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936898709661000,
+    "SubmitTime": 1750941681975975000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 256,
+          "CreateIndex": 37,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 256,
+          "ModifyIndex": 37,
           "Namespace": "",
           "Policy": {
             "cooldown": 5.0

--- a/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 260,
+    "CreateIndex": 41,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-cooldown-on-scale-up",
-    "JobModifyIndex": 260,
+    "JobModifyIndex": 41,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 261,
+    "ModifyIndex": 42,
     "Multiregion": null,
     "Name": "invalid-cooldown-on-scale-up",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936899014276000,
+    "SubmitTime": 1750941682300316000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,20 +67,20 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 260,
+          "CreateIndex": 41,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 260,
+          "ModifyIndex": 41,
           "Namespace": "",
           "Policy": {
             "cooldown_on_scale_up": "invalid"
           },
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-cooldown-on-scale-up",
-            "Group": "test"
+            "Job": "invalid-cooldown-on-scale-up"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 41,
+    "CreateIndex": 40,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-cooldown-on-scale-up",
-    "JobModifyIndex": 41,
+    "JobModifyIndex": 40,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 42,
+    "ModifyIndex": 41,
     "Multiregion": null,
     "Name": "invalid-cooldown-on-scale-up",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941682300316000,
+    "SubmitTime": 1751038606096883000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,20 +67,20 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 41,
+          "CreateIndex": 40,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 41,
+          "ModifyIndex": 40,
           "Namespace": "",
           "Policy": {
             "cooldown_on_scale_up": "invalid"
           },
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-cooldown-on-scale-up"
+            "Job": "invalid-cooldown-on-scale-up",
+            "Group": "test"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown-on-scale-up.json.golden
@@ -4,19 +4,19 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 264,
+    "CreateIndex": 260,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
-    "ID": "invalid-cooldown-type",
-    "JobModifyIndex": 264,
+    "ID": "invalid-cooldown-on-scale-up",
+    "JobModifyIndex": 260,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 265,
+    "ModifyIndex": 261,
     "Multiregion": null,
-    "Name": "invalid-cooldown-type",
+    "Name": "invalid-cooldown-on-scale-up",
     "Namespace": "default",
     "NodePool": "default",
     "NomadTokenID": "",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936899321315000,
+    "SubmitTime": 1750936899014276000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,19 +67,19 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 264,
+          "CreateIndex": 260,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 264,
+          "ModifyIndex": 260,
           "Namespace": "",
           "Policy": {
-            "cooldown": 5.0
+            "cooldown_on_scale_up": "invalid"
           },
           "Target": {
             "Namespace": "default",
-            "Job": "invalid-cooldown-type",
+            "Job": "invalid-cooldown-on-scale-up",
             "Group": "test"
           },
           "Type": "horizontal"

--- a/policy/nomad/test-fixtures/invalid-cooldown-type.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown-type.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 46,
+    "CreateIndex": 45,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-cooldown-type",
-    "JobModifyIndex": 46,
+    "JobModifyIndex": 45,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 47,
+    "ModifyIndex": 46,
     "Multiregion": null,
     "Name": "invalid-cooldown-type",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941682617391000,
+    "SubmitTime": 1751038606403147000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 46,
+          "CreateIndex": 45,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 46,
+          "ModifyIndex": 45,
           "Namespace": "",
           "Policy": {
             "cooldown": 5.0

--- a/policy/nomad/test-fixtures/invalid-cooldown-type.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown-type.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 264,
+    "CreateIndex": 46,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-cooldown-type",
-    "JobModifyIndex": 264,
+    "JobModifyIndex": 46,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 265,
+    "ModifyIndex": 47,
     "Multiregion": null,
     "Name": "invalid-cooldown-type",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936899321315000,
+    "SubmitTime": 1750941682617391000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 264,
+          "CreateIndex": 46,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 264,
+          "ModifyIndex": 46,
           "Namespace": "",
           "Policy": {
             "cooldown": 5.0

--- a/policy/nomad/test-fixtures/invalid-cooldown.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 269,
+    "CreateIndex": 50,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-cooldown",
-    "JobModifyIndex": 269,
+    "JobModifyIndex": 50,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 270,
+    "ModifyIndex": 51,
     "Multiregion": null,
     "Name": "invalid-cooldown",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936899627350000,
+    "SubmitTime": 1750941682972987000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 269,
+          "CreateIndex": 50,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 269,
+          "ModifyIndex": 50,
           "Namespace": "",
           "Policy": {
             "cooldown": "invalid"
@@ -94,10 +94,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-cooldown.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 287,
+    "ConsulNamespace": "",
+    "CreateIndex": 269,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-cooldown",
-    "JobModifyIndex": 287,
+    "JobModifyIndex": 269,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 288,
+    "ModifyIndex": 270,
     "Multiregion": null,
     "Name": "invalid-cooldown",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724435085697000,
+    "SubmitTime": 1750936899627350000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,23 +63,24 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 287,
+          "CreateIndex": 269,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 287,
+          "ModifyIndex": 269,
           "Namespace": "",
           "Policy": {
             "cooldown": "invalid"
           },
           "Target": {
-            "Namespace": "default",
             "Job": "invalid-cooldown",
-            "Group": "test"
+            "Group": "test",
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },
@@ -82,24 +90,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -107,19 +133,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -133,6 +165,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -145,7 +178,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-cooldown.json.golden
+++ b/policy/nomad/test-fixtures/invalid-cooldown.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 50,
+    "CreateIndex": 49,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-cooldown",
-    "JobModifyIndex": 50,
+    "JobModifyIndex": 49,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 51,
+    "ModifyIndex": 50,
     "Multiregion": null,
     "Name": "invalid-cooldown",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941682972987000,
+    "SubmitTime": 1751038606714006000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,20 +67,20 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 50,
+          "CreateIndex": 49,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 50,
+          "ModifyIndex": 49,
           "Namespace": "",
           "Policy": {
             "cooldown": "invalid"
           },
           "Target": {
+            "Namespace": "default",
             "Job": "invalid-cooldown",
-            "Group": "test",
-            "Namespace": "default"
+            "Group": "test"
           },
           "Type": "horizontal"
         },
@@ -94,10 +94,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-empty-query.json.golden
+++ b/policy/nomad/test-fixtures/invalid-empty-query.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 54,
+    "CreateIndex": 53,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-empty-query",
-    "JobModifyIndex": 54,
+    "JobModifyIndex": 53,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 55,
+    "ModifyIndex": 54,
     "Multiregion": null,
     "Name": "invalid-empty-query",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941683299608000,
+    "SubmitTime": 1751038607018129000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,39 +67,39 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 54,
+          "CreateIndex": 53,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 54,
+          "ModifyIndex": 53,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
-                    "query": "",
                     "strategy": [
                       {
                         "strategy": [
                           {
-                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0
+                            "int_config": 2.0,
+                            "str_config": "str"
                           }
                         ]
                       }
-                    ]
+                    ],
+                    "query": ""
                   }
                 ]
               }
             ]
           },
           "Target": {
+            "Job": "invalid-empty-query",
             "Group": "test",
-            "Namespace": "default",
-            "Job": "invalid-empty-query"
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-empty-query.json.golden
+++ b/policy/nomad/test-fixtures/invalid-empty-query.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 304,
+    "ConsulNamespace": "",
+    "CreateIndex": 273,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-empty-query",
-    "JobModifyIndex": 304,
+    "JobModifyIndex": 273,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 307,
+    "ModifyIndex": 274,
     "Multiregion": null,
     "Name": "invalid-empty-query",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724438153574000,
+    "SubmitTime": 1750936899955946000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,42 +63,43 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 304,
+          "CreateIndex": 273,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 304,
+          "ModifyIndex": 273,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
+                    "query": "",
                     "strategy": [
                       {
                         "strategy": [
                           {
                             "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2
+                            "int_config": 2.0
                           }
                         ]
                       }
-                    ],
-                    "query": ""
+                    ]
                   }
                 ]
               }
             ]
           },
           "Target": {
+            "Namespace": "default",
             "Job": "invalid-empty-query",
-            "Group": "test",
-            "Namespace": "default"
+            "Group": "test"
           },
           "Type": "horizontal"
         },
@@ -101,24 +109,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -126,19 +152,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -152,6 +184,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -164,7 +197,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-empty-query.json.golden
+++ b/policy/nomad/test-fixtures/invalid-empty-query.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 273,
+    "CreateIndex": 54,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-empty-query",
-    "JobModifyIndex": 273,
+    "JobModifyIndex": 54,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 274,
+    "ModifyIndex": 55,
     "Multiregion": null,
     "Name": "invalid-empty-query",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936899955946000,
+    "SubmitTime": 1750941683299608000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 273,
+          "CreateIndex": 54,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 273,
+          "ModifyIndex": 54,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -97,9 +97,9 @@
             ]
           },
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-empty-query",
-            "Group": "test"
+            "Job": "invalid-empty-query"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-evaluation-interval-type.json.golden
+++ b/policy/nomad/test-fixtures/invalid-evaluation-interval-type.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 278,
+    "CreateIndex": 61,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-evaluation-interval-type",
-    "JobModifyIndex": 278,
+    "JobModifyIndex": 61,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 279,
+    "ModifyIndex": 62,
     "Multiregion": null,
     "Name": "invalid-evaluation-interval-type",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936900282733000,
+    "SubmitTime": 1750941684648238000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 278,
+          "CreateIndex": 61,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 278,
+          "ModifyIndex": 61,
           "Namespace": "",
           "Policy": {
             "evaluation_interval": 5.0

--- a/policy/nomad/test-fixtures/invalid-evaluation-interval-type.json.golden
+++ b/policy/nomad/test-fixtures/invalid-evaluation-interval-type.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 61,
+    "CreateIndex": 59,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-evaluation-interval-type",
-    "JobModifyIndex": 61,
+    "JobModifyIndex": 59,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 62,
+    "ModifyIndex": 60,
     "Multiregion": null,
     "Name": "invalid-evaluation-interval-type",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941684648238000,
+    "SubmitTime": 1751038607333363000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,20 +67,20 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 61,
+          "CreateIndex": 59,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 61,
+          "ModifyIndex": 59,
           "Namespace": "",
           "Policy": {
             "evaluation_interval": 5.0
           },
           "Target": {
-            "Job": "invalid-evaluation-interval-type",
             "Group": "test",
-            "Namespace": "default"
+            "Namespace": "default",
+            "Job": "invalid-evaluation-interval-type"
           },
           "Type": "horizontal"
         },
@@ -94,10 +94,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-evaluation-interval-type.json.golden
+++ b/policy/nomad/test-fixtures/invalid-evaluation-interval-type.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 238,
+    "ConsulNamespace": "",
+    "CreateIndex": 278,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-evaluation-interval-type",
-    "JobModifyIndex": 238,
+    "JobModifyIndex": 278,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 239,
+    "ModifyIndex": 279,
     "Multiregion": null,
     "Name": "invalid-evaluation-interval-type",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724427590599000,
+    "SubmitTime": 1750936900282733000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,18 +63,19 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 238,
+          "CreateIndex": 278,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 238,
+          "ModifyIndex": 278,
           "Namespace": "",
           "Policy": {
-            "evaluation_interval": 5
+            "evaluation_interval": 5.0
           },
           "Target": {
             "Job": "invalid-evaluation-interval-type",
@@ -82,6 +90,7 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
@@ -91,15 +100,32 @@
               ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -107,19 +133,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -133,6 +165,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -145,7 +178,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-evaluation-interval.json.golden
+++ b/policy/nomad/test-fixtures/invalid-evaluation-interval.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 65,
+    "CreateIndex": 63,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-evaluation-interval",
-    "JobModifyIndex": 65,
+    "JobModifyIndex": 63,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 66,
+    "ModifyIndex": 64,
     "Multiregion": null,
     "Name": "invalid-evaluation-interval",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941684989424000,
+    "SubmitTime": 1751038607634147000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,20 +67,20 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 65,
+          "CreateIndex": 63,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 65,
+          "ModifyIndex": 63,
           "Namespace": "",
           "Policy": {
             "evaluation_interval": "invalid"
           },
           "Target": {
-            "Job": "invalid-evaluation-interval",
             "Group": "test",
-            "Namespace": "default"
+            "Namespace": "default",
+            "Job": "invalid-evaluation-interval"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-evaluation-interval.json.golden
+++ b/policy/nomad/test-fixtures/invalid-evaluation-interval.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 283,
+    "CreateIndex": 65,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-evaluation-interval",
-    "JobModifyIndex": 283,
+    "JobModifyIndex": 65,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 284,
+    "ModifyIndex": 66,
     "Multiregion": null,
     "Name": "invalid-evaluation-interval",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936900595243000,
+    "SubmitTime": 1750941684989424000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,20 +67,20 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 283,
+          "CreateIndex": 65,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 283,
+          "ModifyIndex": 65,
           "Namespace": "",
           "Policy": {
             "evaluation_interval": "invalid"
           },
           "Target": {
+            "Job": "invalid-evaluation-interval",
             "Group": "test",
-            "Namespace": "default",
-            "Job": "invalid-evaluation-interval"
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },
@@ -94,10 +94,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-evaluation-interval.json.golden
+++ b/policy/nomad/test-fixtures/invalid-evaluation-interval.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 277,
+    "ConsulNamespace": "",
+    "CreateIndex": 283,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-evaluation-interval",
-    "JobModifyIndex": 277,
+    "JobModifyIndex": 283,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 278,
+    "ModifyIndex": 284,
     "Multiregion": null,
     "Name": "invalid-evaluation-interval",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724433380668000,
+    "SubmitTime": 1750936900595243000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,23 +63,24 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 277,
+          "CreateIndex": 283,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 277,
+          "ModifyIndex": 283,
           "Namespace": "",
           "Policy": {
             "evaluation_interval": "invalid"
           },
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-evaluation-interval",
-            "Group": "test"
+            "Job": "invalid-evaluation-interval"
           },
           "Type": "horizontal"
         },
@@ -82,24 +90,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -107,19 +133,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -133,6 +165,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -145,7 +178,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-missing-query.json.golden
+++ b/policy/nomad/test-fixtures/invalid-missing-query.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 69,
+    "CreateIndex": 67,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-missing-query",
-    "JobModifyIndex": 69,
+    "JobModifyIndex": 67,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 70,
+    "ModifyIndex": 68,
     "Multiregion": null,
     "Name": "invalid-missing-query",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941685290077000,
+    "SubmitTime": 1751038607938819000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 69,
+          "CreateIndex": 67,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 69,
+          "ModifyIndex": 67,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -83,9 +83,9 @@
                       {
                         "strategy": [
                           {
+                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0,
-                            "str_config": "str"
+                            "int_config": 2.0
                           }
                         ]
                       }

--- a/policy/nomad/test-fixtures/invalid-missing-query.json.golden
+++ b/policy/nomad/test-fixtures/invalid-missing-query.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 263,
+    "ConsulNamespace": "",
+    "CreateIndex": 287,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-missing-query",
-    "JobModifyIndex": 263,
+    "JobModifyIndex": 287,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 266,
+    "ModifyIndex": 288,
     "Multiregion": null,
     "Name": "invalid-missing-query",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724431336385000,
+    "SubmitTime": 1750936900907014000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 263,
+          "CreateIndex": 287,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 263,
+          "ModifyIndex": 287,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -75,9 +83,9 @@
                       {
                         "strategy": [
                           {
+                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2,
-                            "str_config": "str"
+                            "int_config": 2.0
                           }
                         ]
                       }
@@ -100,24 +108,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -125,19 +151,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -151,6 +183,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -163,7 +196,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-missing-query.json.golden
+++ b/policy/nomad/test-fixtures/invalid-missing-query.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 287,
+    "CreateIndex": 69,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-missing-query",
-    "JobModifyIndex": 287,
+    "JobModifyIndex": 69,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 288,
+    "ModifyIndex": 70,
     "Multiregion": null,
     "Name": "invalid-missing-query",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936900907014000,
+    "SubmitTime": 1750941685290077000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 287,
+          "CreateIndex": 69,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 287,
+          "ModifyIndex": 69,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -83,9 +83,9 @@
                       {
                         "strategy": [
                           {
-                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0
+                            "int_config": 2.0,
+                            "str_config": "str"
                           }
                         ]
                       }
@@ -96,9 +96,9 @@
             ]
           },
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-missing-query"
+            "Job": "invalid-missing-query",
+            "Group": "test"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-multiple-strategies.json.golden
+++ b/policy/nomad/test-fixtures/invalid-multiple-strategies.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 74,
+    "CreateIndex": 72,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-multiple-strategies",
-    "JobModifyIndex": 74,
+    "JobModifyIndex": 72,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 75,
+    "ModifyIndex": 73,
     "Multiregion": null,
     "Name": "invalid-multiple-strategies",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941685614999000,
+    "SubmitTime": 1751038608268613000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,18 +67,19 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 74,
+          "CreateIndex": 72,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 74,
+          "ModifyIndex": 72,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
+                    "query": "query",
                     "strategy": [
                       {
                         "strategy-1": [
@@ -90,8 +91,7 @@
                           {}
                         ]
                       }
-                    ],
-                    "query": "query"
+                    ]
                   }
                 ]
               }
@@ -114,10 +114,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-multiple-strategies.json.golden
+++ b/policy/nomad/test-fixtures/invalid-multiple-strategies.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 232,
+    "ConsulNamespace": "",
+    "CreateIndex": 292,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-multiple-strategies",
-    "JobModifyIndex": 232,
+    "JobModifyIndex": 292,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 235,
+    "ModifyIndex": 293,
     "Multiregion": null,
     "Name": "invalid-multiple-strategies",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724426232809000,
+    "SubmitTime": 1750936901224351000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 232,
+          "CreateIndex": 292,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 232,
+          "ModifyIndex": 292,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -102,24 +110,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -127,19 +153,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -153,6 +185,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -165,7 +198,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-multiple-strategies.json.golden
+++ b/policy/nomad/test-fixtures/invalid-multiple-strategies.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 292,
+    "CreateIndex": 74,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-multiple-strategies",
-    "JobModifyIndex": 292,
+    "JobModifyIndex": 74,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 293,
+    "ModifyIndex": 75,
     "Multiregion": null,
     "Name": "invalid-multiple-strategies",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936901224351000,
+    "SubmitTime": 1750941685614999000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,19 +67,18 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 292,
+          "CreateIndex": 74,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 292,
+          "ModifyIndex": 74,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
-                    "query": "query",
                     "strategy": [
                       {
                         "strategy-1": [
@@ -91,16 +90,17 @@
                           {}
                         ]
                       }
-                    ]
+                    ],
+                    "query": "query"
                   }
                 ]
               }
             ]
           },
           "Target": {
+            "Job": "invalid-multiple-strategies",
             "Group": "test",
-            "Namespace": "default",
-            "Job": "invalid-multiple-strategies"
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-multiple-targets.json.golden
+++ b/policy/nomad/test-fixtures/invalid-multiple-targets.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 298,
+    "CreateIndex": 80,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-multiple-targets",
-    "JobModifyIndex": 298,
+    "JobModifyIndex": 80,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 299,
+    "ModifyIndex": 81,
     "Multiregion": null,
     "Name": "invalid-multiple-targets",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936901635799000,
+    "SubmitTime": 1750941685930702000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 298,
+          "CreateIndex": 80,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 298,
+          "ModifyIndex": 80,
           "Namespace": "",
           "Policy": {
             "target": [
@@ -91,18 +91,18 @@
               {
                 "check": [
                   {
+                    "query": "query",
                     "strategy": [
                       {
                         "strategy": [
                           {
+                            "bool_config": true,
                             "int_config": 2.0,
-                            "str_config": "str",
-                            "bool_config": true
+                            "str_config": "str"
                           }
                         ]
                       }
-                    ],
-                    "query": "query"
+                    ]
                   }
                 ]
               }

--- a/policy/nomad/test-fixtures/invalid-multiple-targets.json.golden
+++ b/policy/nomad/test-fixtures/invalid-multiple-targets.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 319,
+    "ConsulNamespace": "",
+    "CreateIndex": 298,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-multiple-targets",
-    "JobModifyIndex": 319,
+    "JobModifyIndex": 298,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 322,
+    "ModifyIndex": 299,
     "Multiregion": null,
     "Name": "invalid-multiple-targets",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724440240885000,
+    "SubmitTime": 1750936901635799000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,37 +63,18 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 319,
+          "CreateIndex": 298,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 319,
+          "ModifyIndex": 298,
           "Namespace": "",
           "Policy": {
-            "check": [
-              {
-                "check": [
-                  {
-                    "query": "query",
-                    "strategy": [
-                      {
-                        "strategy": [
-                          {
-                            "bool_config": true,
-                            "int_config": 2,
-                            "str_config": "str"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
             "target": [
               {
                 "target-1": [
@@ -98,12 +86,32 @@
                   {}
                 ]
               }
+            ],
+            "check": [
+              {
+                "check": [
+                  {
+                    "strategy": [
+                      {
+                        "strategy": [
+                          {
+                            "int_config": 2.0,
+                            "str_config": "str",
+                            "bool_config": true
+                          }
+                        ]
+                      }
+                    ],
+                    "query": "query"
+                  }
+                ]
+              }
             ]
           },
           "Target": {
+            "Namespace": "default",
             "Job": "invalid-multiple-targets",
-            "Group": "test",
-            "Namespace": "default"
+            "Group": "test"
           },
           "Type": "horizontal"
         },
@@ -113,6 +121,7 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
@@ -122,15 +131,32 @@
               "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -138,19 +164,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -164,6 +196,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -176,7 +209,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-multiple-targets.json.golden
+++ b/policy/nomad/test-fixtures/invalid-multiple-targets.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 80,
+    "CreateIndex": 78,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-multiple-targets",
-    "JobModifyIndex": 80,
+    "JobModifyIndex": 78,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 81,
+    "ModifyIndex": 79,
     "Multiregion": null,
     "Name": "invalid-multiple-targets",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941685930702000,
+    "SubmitTime": 1751038608594188000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,14 +67,34 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 80,
+          "CreateIndex": 78,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 80,
+          "ModifyIndex": 78,
           "Namespace": "",
           "Policy": {
+            "check": [
+              {
+                "check": [
+                  {
+                    "strategy": [
+                      {
+                        "strategy": [
+                          {
+                            "str_config": "str",
+                            "bool_config": true,
+                            "int_config": 2.0
+                          }
+                        ]
+                      }
+                    ],
+                    "query": "query"
+                  }
+                ]
+              }
+            ],
             "target": [
               {
                 "target-1": [
@@ -86,32 +106,12 @@
                   {}
                 ]
               }
-            ],
-            "check": [
-              {
-                "check": [
-                  {
-                    "query": "query",
-                    "strategy": [
-                      {
-                        "strategy": [
-                          {
-                            "bool_config": true,
-                            "int_config": 2.0,
-                            "str_config": "str"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
             ]
           },
           "Target": {
+            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-multiple-targets",
-            "Group": "test"
+            "Job": "invalid-multiple-targets"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-query-window1.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query-window1.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 85,
+    "CreateIndex": 83,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-query-window1",
-    "JobModifyIndex": 85,
+    "JobModifyIndex": 83,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 86,
+    "ModifyIndex": 84,
     "Multiregion": null,
     "Name": "invalid-query-window1",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941686244059000,
+    "SubmitTime": 1751038608926884000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 85,
+          "CreateIndex": 83,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 85,
+          "ModifyIndex": 83,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -85,9 +85,9 @@
                       {
                         "strategy": [
                           {
+                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0,
-                            "str_config": "str"
+                            "int_config": 2.0
                           }
                         ]
                       }
@@ -114,10 +114,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-query-window1.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query-window1.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 246,
+    "ConsulNamespace": "",
+    "CreateIndex": 303,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-query-window1",
-    "JobModifyIndex": 246,
+    "JobModifyIndex": 303,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 249,
+    "ModifyIndex": 304,
     "Multiregion": null,
     "Name": "invalid-query-window1",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724428276409000,
+    "SubmitTime": 1750936901955826000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,43 +63,44 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 246,
+          "CreateIndex": 303,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 246,
+          "ModifyIndex": 303,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
-                    "query": "query",
-                    "query_window": 5,
+                    "query_window": 5.0,
                     "strategy": [
                       {
                         "strategy": [
                           {
-                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2
+                            "int_config": 2.0,
+                            "str_config": "str"
                           }
                         ]
                       }
-                    ]
+                    ],
+                    "query": "query"
                   }
                 ]
               }
             ]
           },
           "Target": {
+            "Job": "invalid-query-window1",
             "Group": "test",
-            "Namespace": "default",
-            "Job": "invalid-query-window1"
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },
@@ -102,6 +110,7 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
@@ -111,15 +120,32 @@
               "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -127,19 +153,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -153,6 +185,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -165,7 +198,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-query-window1.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query-window1.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 303,
+    "CreateIndex": 85,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-query-window1",
-    "JobModifyIndex": 303,
+    "JobModifyIndex": 85,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 304,
+    "ModifyIndex": 86,
     "Multiregion": null,
     "Name": "invalid-query-window1",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936901955826000,
+    "SubmitTime": 1750941686244059000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,18 +67,19 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 303,
+          "CreateIndex": 85,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 303,
+          "ModifyIndex": 85,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
+                    "query": "query",
                     "query_window": 5.0,
                     "strategy": [
                       {
@@ -90,17 +91,16 @@
                           }
                         ]
                       }
-                    ],
-                    "query": "query"
+                    ]
                   }
                 ]
               }
             ]
           },
           "Target": {
+            "Namespace": "default",
             "Job": "invalid-query-window1",
-            "Group": "test",
-            "Namespace": "default"
+            "Group": "test"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-query-window2.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query-window2.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 308,
+    "CreateIndex": 90,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-query-window2",
-    "JobModifyIndex": 308,
+    "JobModifyIndex": 90,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 309,
+    "ModifyIndex": 91,
     "Multiregion": null,
     "Name": "invalid-query-window2",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936902270555000,
+    "SubmitTime": 1750941686554233000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,40 +67,40 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 308,
+          "CreateIndex": 90,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 308,
+          "ModifyIndex": 90,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
-                    "query": "query",
                     "query_window": "not quite right",
                     "strategy": [
                       {
                         "strategy": [
                           {
-                            "int_config": 2.0,
                             "str_config": "str",
-                            "bool_config": true
+                            "bool_config": true,
+                            "int_config": 2.0
                           }
                         ]
                       }
-                    ]
+                    ],
+                    "query": "query"
                   }
                 ]
               }
             ]
           },
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-query-window2"
+            "Job": "invalid-query-window2",
+            "Group": "test"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-query-window2.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query-window2.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 222,
+    "ConsulNamespace": "",
+    "CreateIndex": 308,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-query-window2",
-    "JobModifyIndex": 222,
+    "JobModifyIndex": 308,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 225,
+    "ModifyIndex": 309,
     "Multiregion": null,
     "Name": "invalid-query-window2",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724424533032000,
+    "SubmitTime": 1750936902270555000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 222,
+          "CreateIndex": 308,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 222,
+          "ModifyIndex": 308,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -77,7 +85,7 @@
                       {
                         "strategy": [
                           {
-                            "int_config": 2,
+                            "int_config": 2.0,
                             "str_config": "str",
                             "bool_config": true
                           }
@@ -102,6 +110,7 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
@@ -111,15 +120,32 @@
               "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -127,19 +153,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -153,6 +185,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -165,7 +198,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-query-window2.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query-window2.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 90,
+    "CreateIndex": 88,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-query-window2",
-    "JobModifyIndex": 90,
+    "JobModifyIndex": 88,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 91,
+    "ModifyIndex": 89,
     "Multiregion": null,
     "Name": "invalid-query-window2",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941686554233000,
+    "SubmitTime": 1751038609250387000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,31 +67,31 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 90,
+          "CreateIndex": 88,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 90,
+          "ModifyIndex": 88,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
+                    "query": "query",
                     "query_window": "not quite right",
                     "strategy": [
                       {
                         "strategy": [
                           {
+                            "int_config": 2.0,
                             "str_config": "str",
-                            "bool_config": true,
-                            "int_config": 2.0
+                            "bool_config": true
                           }
                         ]
                       }
-                    ],
-                    "query": "query"
+                    ]
                   }
                 ]
               }

--- a/policy/nomad/test-fixtures/invalid-query.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 297,
+    "ConsulNamespace": "",
+    "CreateIndex": 315,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-query",
-    "JobModifyIndex": 297,
+    "JobModifyIndex": 315,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 301,
+    "ModifyIndex": 316,
     "Multiregion": null,
     "Name": "invalid-query",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724436789253000,
+    "SubmitTime": 1750936903618550000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,33 +63,34 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 297,
+          "CreateIndex": 315,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 297,
+          "ModifyIndex": 315,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
-                    "query": 5,
                     "strategy": [
                       {
                         "strategy": [
                           {
-                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2
+                            "int_config": 2.0,
+                            "str_config": "str"
                           }
                         ]
                       }
-                    ]
+                    ],
+                    "query": 5.0
                   }
                 ]
               }
@@ -101,24 +109,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -126,19 +152,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -152,6 +184,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -164,7 +197,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-query.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 315,
+    "CreateIndex": 96,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-query",
-    "JobModifyIndex": 315,
+    "JobModifyIndex": 96,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 316,
+    "ModifyIndex": 97,
     "Multiregion": null,
     "Name": "invalid-query",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936903618550000,
+    "SubmitTime": 1750941686869875000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 315,
+          "CreateIndex": 96,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 315,
+          "ModifyIndex": 96,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -97,9 +97,9 @@
             ]
           },
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-query"
+            "Job": "invalid-query",
+            "Group": "test"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/invalid-query.json.golden
+++ b/policy/nomad/test-fixtures/invalid-query.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 96,
+    "CreateIndex": 94,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-query",
-    "JobModifyIndex": 96,
+    "JobModifyIndex": 94,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 97,
+    "ModifyIndex": 95,
     "Multiregion": null,
     "Name": "invalid-query",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941686869875000,
+    "SubmitTime": 1751038609568530000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,30 +67,30 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 96,
+          "CreateIndex": 94,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 96,
+          "ModifyIndex": 94,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
+                    "query": 5.0,
                     "strategy": [
                       {
                         "strategy": [
                           {
-                            "bool_config": true,
                             "int_config": 2.0,
-                            "str_config": "str"
+                            "str_config": "str",
+                            "bool_config": true
                           }
                         ]
                       }
-                    ],
-                    "query": 5.0
+                    ]
                   }
                 ]
               }
@@ -113,10 +113,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-source-not-string.json.golden
+++ b/policy/nomad/test-fixtures/invalid-source-not-string.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 212,
+    "ConsulNamespace": "",
+    "CreateIndex": 320,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-source-not-string",
-    "JobModifyIndex": 212,
+    "JobModifyIndex": 320,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 215,
+    "ModifyIndex": 321,
     "Multiregion": null,
     "Name": "invalid-source-not-string",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724422826471000,
+    "SubmitTime": 1750936903936195000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,29 +63,30 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 212,
+          "CreateIndex": 320,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 212,
+          "ModifyIndex": 320,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
-                    "source": 2,
+                    "source": 2.0,
                     "strategy": [
                       {
                         "strategy": [
                           {
-                            "bool_config": true,
-                            "int_config": 2,
-                            "str_config": "str"
+                            "int_config": 2.0,
+                            "str_config": "str",
+                            "bool_config": true
                           }
                         ]
                       }
@@ -102,24 +110,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -127,19 +153,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -153,6 +185,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -165,7 +198,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-source-not-string.json.golden
+++ b/policy/nomad/test-fixtures/invalid-source-not-string.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 101,
+    "CreateIndex": 99,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-source-not-string",
-    "JobModifyIndex": 101,
+    "JobModifyIndex": 99,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 102,
+    "ModifyIndex": 100,
     "Multiregion": null,
     "Name": "invalid-source-not-string",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941687184827000,
+    "SubmitTime": 1751038609899811000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,31 +67,31 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 101,
+          "CreateIndex": 99,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 101,
+          "ModifyIndex": 99,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
+                    "source": 2.0,
                     "strategy": [
                       {
                         "strategy": [
                           {
-                            "int_config": 2.0,
                             "str_config": "str",
-                            "bool_config": true
+                            "bool_config": true,
+                            "int_config": 2.0
                           }
                         ]
                       }
                     ],
-                    "query": "query",
-                    "source": 2.0
+                    "query": "query"
                   }
                 ]
               }
@@ -114,10 +114,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-source-not-string.json.golden
+++ b/policy/nomad/test-fixtures/invalid-source-not-string.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 320,
+    "CreateIndex": 101,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-source-not-string",
-    "JobModifyIndex": 320,
+    "JobModifyIndex": 101,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 321,
+    "ModifyIndex": 102,
     "Multiregion": null,
     "Name": "invalid-source-not-string",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936903936195000,
+    "SubmitTime": 1750941687184827000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,19 +67,18 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 320,
+          "CreateIndex": 101,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 320,
+          "ModifyIndex": 101,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
-                    "source": 2.0,
                     "strategy": [
                       {
                         "strategy": [
@@ -91,16 +90,17 @@
                         ]
                       }
                     ],
-                    "query": "query"
+                    "query": "query",
+                    "source": 2.0
                   }
                 ]
               }
             ]
           },
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-source-not-string"
+            "Job": "invalid-source-not-string",
+            "Group": "test"
           },
           "Type": "horizontal"
         },
@@ -114,10 +114,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-strategy.json.golden
+++ b/policy/nomad/test-fixtures/invalid-strategy.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 204,
+    "ConsulNamespace": "",
+    "CreateIndex": 325,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-strategy",
-    "JobModifyIndex": 204,
+    "JobModifyIndex": 325,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 205,
+    "ModifyIndex": 326,
     "Multiregion": null,
     "Name": "invalid-strategy",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724422143286000,
+    "SubmitTime": 1750936904253133000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 204,
+          "CreateIndex": 325,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 204,
+          "ModifyIndex": 325,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -92,24 +100,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -117,19 +143,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -143,6 +175,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -155,7 +188,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-strategy.json.golden
+++ b/policy/nomad/test-fixtures/invalid-strategy.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 325,
+    "CreateIndex": 106,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-strategy",
-    "JobModifyIndex": 325,
+    "JobModifyIndex": 106,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 326,
+    "ModifyIndex": 107,
     "Multiregion": null,
     "Name": "invalid-strategy",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936904253133000,
+    "SubmitTime": 1750941687495619000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 325,
+          "CreateIndex": 106,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 325,
+          "ModifyIndex": 106,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -88,9 +88,9 @@
             ]
           },
           "Target": {
-            "Namespace": "default",
             "Job": "invalid-strategy",
-            "Group": "test"
+            "Group": "test",
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },
@@ -104,10 +104,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-strategy.json.golden
+++ b/policy/nomad/test-fixtures/invalid-strategy.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 106,
+    "CreateIndex": 104,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-strategy",
-    "JobModifyIndex": 106,
+    "JobModifyIndex": 104,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 107,
+    "ModifyIndex": 105,
     "Multiregion": null,
     "Name": "invalid-strategy",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941687495619000,
+    "SubmitTime": 1751038610213498000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 106,
+          "CreateIndex": 104,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 106,
+          "ModifyIndex": 104,
           "Namespace": "",
           "Policy": {
             "check": [

--- a/policy/nomad/test-fixtures/invalid-target.json.golden
+++ b/policy/nomad/test-fixtures/invalid-target.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 111,
+    "CreateIndex": 109,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-target",
-    "JobModifyIndex": 111,
+    "JobModifyIndex": 109,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 112,
+    "ModifyIndex": 110,
     "Multiregion": null,
     "Name": "invalid-target",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941687802311000,
+    "SubmitTime": 1751038610522422000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 111,
+          "CreateIndex": 109,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 111,
+          "ModifyIndex": 109,
           "Namespace": "",
           "Policy": {
             "target": [
@@ -80,9 +80,9 @@
             ]
           },
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "invalid-target"
+            "Job": "invalid-target",
+            "Group": "test"
           },
           "Type": "horizontal"
         },
@@ -96,10 +96,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/invalid-target.json.golden
+++ b/policy/nomad/test-fixtures/invalid-target.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 228,
+    "ConsulNamespace": "",
+    "CreateIndex": 329,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-target",
-    "JobModifyIndex": 228,
+    "JobModifyIndex": 329,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 229,
+    "ModifyIndex": 330,
     "Multiregion": null,
     "Name": "invalid-target",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724425892850000,
+    "SubmitTime": 1750936904557431000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 228,
+          "CreateIndex": 329,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 228,
+          "ModifyIndex": 329,
           "Namespace": "",
           "Policy": {
             "target": [
@@ -84,24 +92,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -109,19 +135,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -135,6 +167,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -147,7 +180,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/invalid-target.json.golden
+++ b/policy/nomad/test-fixtures/invalid-target.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 329,
+    "CreateIndex": 111,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "invalid-target",
-    "JobModifyIndex": 329,
+    "JobModifyIndex": 111,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 330,
+    "ModifyIndex": 112,
     "Multiregion": null,
     "Name": "invalid-target",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936904557431000,
+    "SubmitTime": 1750941687802311000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 329,
+          "CreateIndex": 111,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 329,
+          "ModifyIndex": 111,
           "Namespace": "",
           "Policy": {
             "target": [
@@ -96,10 +96,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/minimum-valid-scaling.json.golden
+++ b/policy/nomad/test-fixtures/minimum-valid-scaling.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 115,
+    "CreateIndex": 113,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "minimum-valid-scaling",
-    "JobModifyIndex": 115,
+    "JobModifyIndex": 113,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 116,
+    "ModifyIndex": 114,
     "Multiregion": null,
     "Name": "minimum-valid-scaling",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941688105061000,
+    "SubmitTime": 1751038610817995000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 115,
+          "CreateIndex": 113,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 115,
+          "ModifyIndex": 113,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -84,9 +84,9 @@
                       {
                         "strategy": [
                           {
+                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0,
-                            "str_config": "str"
+                            "int_config": 2.0
                           }
                         ]
                       }

--- a/policy/nomad/test-fixtures/minimum-valid-scaling.json.golden
+++ b/policy/nomad/test-fixtures/minimum-valid-scaling.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 281,
+    "ConsulNamespace": "",
+    "CreateIndex": 334,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "minimum-valid-scaling",
-    "JobModifyIndex": 281,
+    "JobModifyIndex": 334,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 284,
+    "ModifyIndex": 335,
     "Multiregion": null,
     "Name": "minimum-valid-scaling",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724433723277000,
+    "SubmitTime": 1750936904869501000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 281,
+          "CreateIndex": 334,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 281,
+          "ModifyIndex": 334,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -76,9 +84,9 @@
                       {
                         "strategy": [
                           {
+                            "int_config": 2.0,
                             "str_config": "str",
-                            "bool_config": true,
-                            "int_config": 2
+                            "bool_config": true
                           }
                         ]
                       }
@@ -89,9 +97,9 @@
             ]
           },
           "Target": {
-            "Namespace": "default",
             "Job": "minimum-valid-scaling",
-            "Group": "test"
+            "Group": "test",
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },
@@ -101,6 +109,7 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
@@ -110,15 +119,32 @@
               "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -126,19 +152,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -152,6 +184,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -164,7 +197,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/minimum-valid-scaling.json.golden
+++ b/policy/nomad/test-fixtures/minimum-valid-scaling.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 334,
+    "CreateIndex": 115,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "minimum-valid-scaling",
-    "JobModifyIndex": 334,
+    "JobModifyIndex": 115,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 335,
+    "ModifyIndex": 116,
     "Multiregion": null,
     "Name": "minimum-valid-scaling",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936904869501000,
+    "SubmitTime": 1750941688105061000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 334,
+          "CreateIndex": 115,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 334,
+          "ModifyIndex": 115,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -84,9 +84,9 @@
                       {
                         "strategy": [
                           {
+                            "bool_config": true,
                             "int_config": 2.0,
-                            "str_config": "str",
-                            "bool_config": true
+                            "str_config": "str"
                           }
                         ]
                       }
@@ -97,9 +97,9 @@
             ]
           },
           "Target": {
+            "Namespace": "default",
             "Job": "minimum-valid-scaling",
-            "Group": "test",
-            "Namespace": "default"
+            "Group": "test"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/missing-policy.json.golden
+++ b/policy/nomad/test-fixtures/missing-policy.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 120,
+    "CreateIndex": 118,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "missing-policy",
-    "JobModifyIndex": 120,
+    "JobModifyIndex": 118,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 121,
+    "ModifyIndex": 119,
     "Multiregion": null,
     "Name": "missing-policy",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941688422713000,
+    "SubmitTime": 1751038611130393000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 120,
+          "CreateIndex": 118,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 2,
-          "ModifyIndex": 120,
+          "ModifyIndex": 118,
           "Namespace": "",
           "Policy": null,
           "Target": {
@@ -92,10 +92,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/missing-policy.json.golden
+++ b/policy/nomad/test-fixtures/missing-policy.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 339,
+    "CreateIndex": 120,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "missing-policy",
-    "JobModifyIndex": 339,
+    "JobModifyIndex": 120,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 340,
+    "ModifyIndex": 121,
     "Multiregion": null,
     "Name": "missing-policy",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936905191397000,
+    "SubmitTime": 1750941688422713000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 339,
+          "CreateIndex": 120,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 2,
-          "ModifyIndex": 339,
+          "ModifyIndex": 120,
           "Namespace": "",
           "Policy": null,
           "Target": {
@@ -92,10 +92,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/missing-policy.json.golden
+++ b/policy/nomad/test-fixtures/missing-policy.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 197,
+    "ConsulNamespace": "",
+    "CreateIndex": 339,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "missing-policy",
-    "JobModifyIndex": 197,
+    "JobModifyIndex": 339,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 201,
+    "ModifyIndex": 340,
     "Multiregion": null,
     "Name": "missing-policy",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724420772624000,
+    "SubmitTime": 1750936905191397000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 2,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,21 +63,22 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 197,
+          "CreateIndex": 339,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 2,
-          "ModifyIndex": 197,
+          "ModifyIndex": 339,
           "Namespace": "",
           "Policy": null,
           "Target": {
+            "Namespace": "default",
             "Job": "missing-policy",
-            "Group": "test",
-            "Namespace": "default"
+            "Group": "test"
           },
           "Type": "horizontal"
         },
@@ -80,24 +88,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -105,19 +131,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -131,6 +163,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -143,7 +176,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/missing-scaling.json.golden
+++ b/policy/nomad/test-fixtures/missing-scaling.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 344,
+    "CreateIndex": 125,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "missing-scaling",
-    "JobModifyIndex": 344,
+    "JobModifyIndex": 125,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 345,
+    "ModifyIndex": 126,
     "Multiregion": null,
     "Name": "missing-scaling",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936905514887000,
+    "SubmitTime": 1750941688744187000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -77,10 +77,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/missing-scaling.json.golden
+++ b/policy/nomad/test-fixtures/missing-scaling.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 291,
+    "ConsulNamespace": "",
+    "CreateIndex": 344,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "missing-scaling",
-    "JobModifyIndex": 291,
+    "JobModifyIndex": 344,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 294,
+    "ModifyIndex": 345,
     "Multiregion": null,
     "Name": "missing-scaling",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724435429383000,
+    "SubmitTime": 1750936905514887000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,7 +63,8 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": null,
         "Services": null,
@@ -65,24 +73,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -90,19 +116,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -116,6 +148,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -128,7 +161,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/missing-scaling.json.golden
+++ b/policy/nomad/test-fixtures/missing-scaling.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 125,
+    "CreateIndex": 123,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "missing-scaling",
-    "JobModifyIndex": 125,
+    "JobModifyIndex": 123,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 126,
+    "ModifyIndex": 124,
     "Multiregion": null,
     "Name": "missing-scaling",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941688744187000,
+    "SubmitTime": 1751038611437477000,
     "TaskGroups": [
       {
         "Affinities": null,

--- a/policy/nomad/test-fixtures/missing-strategy.json.golden
+++ b/policy/nomad/test-fixtures/missing-strategy.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 350,
+    "CreateIndex": 131,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "missing-strategy",
-    "JobModifyIndex": 350,
+    "JobModifyIndex": 131,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 351,
+    "ModifyIndex": 132,
     "Multiregion": null,
     "Name": "missing-strategy",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936905830196000,
+    "SubmitTime": 1750941689064389000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,20 +67,20 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 350,
+          "CreateIndex": 131,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 350,
+          "ModifyIndex": 131,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
-                    "source": "source",
-                    "query": "query"
+                    "query": "query",
+                    "source": "source"
                   }
                 ]
               }
@@ -103,10 +103,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/missing-strategy.json.golden
+++ b/policy/nomad/test-fixtures/missing-strategy.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 131,
+    "CreateIndex": 129,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "missing-strategy",
-    "JobModifyIndex": 131,
+    "JobModifyIndex": 129,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 132,
+    "ModifyIndex": 130,
     "Multiregion": null,
     "Name": "missing-strategy",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941689064389000,
+    "SubmitTime": 1751038611746837000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 131,
+          "CreateIndex": 129,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 131,
+          "ModifyIndex": 129,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -87,9 +87,9 @@
             ]
           },
           "Target": {
-            "Group": "test",
             "Namespace": "default",
-            "Job": "missing-strategy"
+            "Job": "missing-strategy",
+            "Group": "test"
           },
           "Type": "horizontal"
         },
@@ -103,10 +103,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/missing-strategy.json.golden
+++ b/policy/nomad/test-fixtures/missing-strategy.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 311,
+    "ConsulNamespace": "",
+    "CreateIndex": 350,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "missing-strategy",
-    "JobModifyIndex": 311,
+    "JobModifyIndex": 350,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 312,
+    "ModifyIndex": 351,
     "Multiregion": null,
     "Name": "missing-strategy",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724439544604000,
+    "SubmitTime": 1750936905830196000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 311,
+          "CreateIndex": 350,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 311,
+          "ModifyIndex": 350,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -79,9 +87,9 @@
             ]
           },
           "Target": {
-            "Job": "missing-strategy",
             "Group": "test",
-            "Namespace": "default"
+            "Namespace": "default",
+            "Job": "missing-strategy"
           },
           "Type": "horizontal"
         },
@@ -91,24 +99,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -116,19 +142,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -142,6 +174,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -154,7 +187,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/single-check.json.golden
+++ b/policy/nomad/test-fixtures/single-check.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 135,
+    "CreateIndex": 133,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "single-check",
-    "JobModifyIndex": 135,
+    "JobModifyIndex": 133,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 136,
+    "ModifyIndex": 134,
     "Multiregion": null,
     "Name": "single-check",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941689372789000,
+    "SubmitTime": 1751038612043300000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,40 +67,40 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 135,
+          "CreateIndex": 133,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 135,
+          "ModifyIndex": 133,
           "Namespace": "",
           "Policy": {
             "check": [
               {
                 "check": [
                   {
-                    "query": "query",
                     "source": "source",
                     "strategy": [
                       {
                         "strategy": [
                           {
-                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0
+                            "int_config": 2.0,
+                            "str_config": "str"
                           }
                         ]
                       }
-                    ]
+                    ],
+                    "query": "query"
                   }
                 ]
               }
             ]
           },
           "Target": {
-            "Job": "single-check",
             "Group": "test",
-            "Namespace": "default"
+            "Namespace": "default",
+            "Job": "single-check"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/single-check.json.golden
+++ b/policy/nomad/test-fixtures/single-check.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 273,
+    "ConsulNamespace": "",
+    "CreateIndex": 354,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "single-check",
-    "JobModifyIndex": 273,
+    "JobModifyIndex": 354,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 274,
+    "ModifyIndex": 355,
     "Multiregion": null,
     "Name": "single-check",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -29,21 +32,25 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1602724433038736000,
+    "SubmitTime": 1750936906137100000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 0,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 273,
+          "CreateIndex": 354,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 273,
+          "ModifyIndex": 354,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -79,7 +87,7 @@
                           {
                             "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2
+                            "int_config": 2.0
                           }
                         ]
                       }
@@ -90,9 +98,9 @@
             ]
           },
           "Target": {
-            "Job": "single-check",
             "Group": "test",
-            "Namespace": "default"
+            "Namespace": "default",
+            "Job": "single-check"
           },
           "Type": "horizontal"
         },
@@ -102,24 +110,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -127,19 +153,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -153,6 +185,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -165,7 +198,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/single-check.json.golden
+++ b/policy/nomad/test-fixtures/single-check.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 354,
+    "CreateIndex": 135,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "single-check",
-    "JobModifyIndex": 354,
+    "JobModifyIndex": 135,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 355,
+    "ModifyIndex": 136,
     "Multiregion": null,
     "Name": "single-check",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "dead",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936906137100000,
+    "SubmitTime": 1750941689372789000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 354,
+          "CreateIndex": 135,
           "Enabled": false,
           "ID": "id",
           "Max": 10,
           "Min": 0,
-          "ModifyIndex": 354,
+          "ModifyIndex": 135,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -98,9 +98,9 @@
             ]
           },
           "Target": {
+            "Job": "single-check",
             "Group": "test",
-            "Namespace": "default",
-            "Job": "single-check"
+            "Namespace": "default"
           },
           "Type": "horizontal"
         },

--- a/policy/nomad/test-fixtures/src/empty-check.hcl
+++ b/policy/nomad/test-fixtures/src/empty-check.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "empty-check" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/empty-check.hcl
+++ b/policy/nomad/test-fixtures/src/empty-check.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "empty-check" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/empty-policy.hcl
+++ b/policy/nomad/test-fixtures/src/empty-policy.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "empty-policy" {
-  datacenters = ["dc1"]
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/empty-strategy.hcl
+++ b/policy/nomad/test-fixtures/src/empty-strategy.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "empty-strategy" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/empty-strategy.hcl
+++ b/policy/nomad/test-fixtures/src/empty-strategy.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "empty-strategy" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/empty-target.hcl
+++ b/policy/nomad/test-fixtures/src/empty-target.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "empty-target" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/empty-target.hcl
+++ b/policy/nomad/test-fixtures/src/empty-target.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "empty-target" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/full-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/full-scaling.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "full-scaling" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/full-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/full-scaling.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "full-scaling" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/full-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/full-scaling.hcl
@@ -12,9 +12,10 @@ job "full-scaling" {
       enabled = false
 
       policy {
-        evaluation_interval = "5s"
-        cooldown            = "5m"
-        on_check_error      = "fail"
+        evaluation_interval  = "5s"
+        cooldown             = "5m"
+        cooldown_on_scale_up = "2m"
+        on_check_error       = "fail"
 
         target "target" {
           int_config  = 2

--- a/policy/nomad/test-fixtures/src/invalid-check.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-check.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-check" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-check.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-check.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-check" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up-type.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up-type.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-cooldown-on-scale-up-type" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up-type.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up-type.hcl
@@ -1,0 +1,27 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+job "invalid-cooldown-on-scale-up-type" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  group "test" {
+    scaling {
+      min     = 0
+      max     = 10
+      enabled = false
+
+      policy {
+        cooldown = 5
+      }
+    }
+
+    task "echo" {
+      driver = "raw_exec"
+      config {
+        command = "echo"
+        args    = ["hi"]
+      }
+    }
+  }
+}

--- a/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up-type.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up-type.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-cooldown-on-scale-up-type" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-cooldown-on-scale-up" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-cooldown-on-scale-up" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown-on-scale-up.hcl
@@ -1,0 +1,27 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+job "invalid-cooldown-on-scale-up" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  group "test" {
+    scaling {
+      min     = 0
+      max     = 10
+      enabled = false
+
+      policy {
+        cooldown_on_scale_up = "invalid"
+      }
+    }
+
+    task "echo" {
+      driver = "raw_exec"
+      config {
+        command = "echo"
+        args    = ["hi"]
+      }
+    }
+  }
+}

--- a/policy/nomad/test-fixtures/src/invalid-cooldown-type.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown-type.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-cooldown-type" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-cooldown-type.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown-type.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-cooldown-type" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-cooldown.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-cooldown" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-cooldown.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-cooldown.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-cooldown" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-empty-query.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-empty-query.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-empty-query" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-empty-query.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-empty-query.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-empty-query" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-evaluation-interval-type.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-evaluation-interval-type.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-evaluation-interval-type" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-evaluation-interval-type.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-evaluation-interval-type.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-evaluation-interval-type" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-evaluation-interval.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-evaluation-interval.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-evaluation-interval" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-evaluation-interval.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-evaluation-interval.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-evaluation-interval" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-missing-query.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-missing-query.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-missing-query" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-missing-query.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-missing-query.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-missing-query" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-multiple-strategies.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-multiple-strategies.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-multiple-strategies" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-multiple-strategies.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-multiple-strategies.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-multiple-strategies" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-multiple-targets.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-multiple-targets.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-multiple-targets" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-multiple-targets.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-multiple-targets.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-multiple-targets" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-query-window1.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-query-window1.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-query-window1" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-query-window1.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-query-window1.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-query-window1" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-query-window2.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-query-window2.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-query-window2" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-query-window2.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-query-window2.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-query-window2" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-query.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-query.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-query" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-query.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-query.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-query" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-source-not-string.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-source-not-string.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-source-not-string" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-source-not-string.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-source-not-string.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-source-not-string" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-strategy.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-strategy.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-strategy" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/invalid-strategy.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-strategy.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-strategy" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-target.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-target.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-target" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/invalid-target.hcl
+++ b/policy/nomad/test-fixtures/src/invalid-target.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "invalid-target" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/minimum-valid-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/minimum-valid-scaling.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "minimum-valid-scaling" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/minimum-valid-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/minimum-valid-scaling.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "minimum-valid-scaling" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/missing-policy.hcl
+++ b/policy/nomad/test-fixtures/src/missing-policy.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "missing-policy" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/missing-policy.hcl
+++ b/policy/nomad/test-fixtures/src/missing-policy.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "missing-policy" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/missing-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/missing-scaling.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "missing-scaling" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/missing-scaling.hcl
+++ b/policy/nomad/test-fixtures/src/missing-scaling.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "missing-scaling" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     task "echo" {

--- a/policy/nomad/test-fixtures/src/missing-strategy.hcl
+++ b/policy/nomad/test-fixtures/src/missing-strategy.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "missing-strategy" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/missing-strategy.hcl
+++ b/policy/nomad/test-fixtures/src/missing-strategy.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "missing-strategy" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/single-check.hcl
+++ b/policy/nomad/test-fixtures/src/single-check.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "single-check" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/single-check.hcl
+++ b/policy/nomad/test-fixtures/src/single-check.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "single-check" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/src/strategy-without-metric.hcl
+++ b/policy/nomad/test-fixtures/src/strategy-without-metric.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "strategy-without-metric" {
-  type        = "batch"
+  type = "batch"
 
   group "test" {
     scaling {

--- a/policy/nomad/test-fixtures/src/strategy-without-metric.hcl
+++ b/policy/nomad/test-fixtures/src/strategy-without-metric.hcl
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 job "strategy-without-metric" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   group "test" {

--- a/policy/nomad/test-fixtures/strategy-without-metric.json.golden
+++ b/policy/nomad/test-fixtures/strategy-without-metric.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 358,
+    "CreateIndex": 139,
     "Datacenters": [
       "dc1"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "strategy-without-metric",
-    "JobModifyIndex": 358,
+    "JobModifyIndex": 139,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 359,
+    "ModifyIndex": 140,
     "Multiregion": null,
     "Name": "strategy-without-metric",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750936906452484000,
+    "SubmitTime": 1750941689672028000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 358,
+          "CreateIndex": 139,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 358,
+          "ModifyIndex": 139,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -112,10 +112,10 @@
             "Affinities": null,
             "Artifacts": null,
             "Config": {
+              "command": "echo",
               "args": [
                 "hi"
-              ],
-              "command": "echo"
+              ]
             },
             "Constraints": null,
             "Consul": null,

--- a/policy/nomad/test-fixtures/strategy-without-metric.json.golden
+++ b/policy/nomad/test-fixtures/strategy-without-metric.json.golden
@@ -3,19 +3,22 @@
     "Affinities": null,
     "AllAtOnce": false,
     "Constraints": null,
-    "CreateIndex": 10,
+    "ConsulNamespace": "",
+    "CreateIndex": 358,
     "Datacenters": [
       "dc1"
     ],
+    "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "strategy-without-metric",
-    "JobModifyIndex": 10,
+    "JobModifyIndex": 358,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 14,
+    "ModifyIndex": 359,
     "Multiregion": null,
     "Name": "strategy-without-metric",
     "Namespace": "default",
+    "NodePool": "default",
     "NomadTokenID": "",
     "ParameterizedJob": null,
     "ParentID": "",
@@ -26,24 +29,28 @@
     "Reschedule": null,
     "Spreads": null,
     "Stable": false,
-    "Status": "dead",
+    "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1617295837558199000,
+    "SubmitTime": 1750936906452484000,
     "TaskGroups": [
       {
         "Affinities": null,
         "Constraints": null,
+        "Consul": null,
         "Count": 1,
+        "Disconnect": null,
         "EphemeralDisk": {
           "Migrate": false,
           "SizeMB": 300,
           "Sticky": false
         },
+        "MaxClientDisconnect": null,
         "Meta": null,
         "Migrate": null,
         "Name": "test",
         "Networks": null,
+        "PreventRescheduleOnLost": false,
         "ReschedulePolicy": {
           "Attempts": 1,
           "Delay": 5000000000,
@@ -56,15 +63,16 @@
           "Attempts": 3,
           "Delay": 15000000000,
           "Interval": 86400000000000,
-          "Mode": "fail"
+          "Mode": "fail",
+          "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 10,
+          "CreateIndex": 358,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 10,
+          "ModifyIndex": 358,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -76,7 +84,7 @@
                         "fixed-value": [
                           {
                             "bool_config": true,
-                            "int_config": 2,
+                            "int_config": 2.0,
                             "str_config": "str"
                           }
                         ]
@@ -100,24 +108,42 @@
         "StopAfterClientDisconnect": null,
         "Tasks": [
           {
+            "Actions": null,
             "Affinities": null,
             "Artifacts": null,
             "Config": {
-              "command": "echo",
               "args": [
                 "hi"
-              ]
+              ],
+              "command": "echo"
             },
             "Constraints": null,
+            "Consul": null,
             "DispatchPayload": null,
             "Driver": "raw_exec",
             "Env": null,
+            "Identities": null,
+            "Identity": {
+              "Audience": [
+                "nomadproject.io"
+              ],
+              "ChangeMode": "",
+              "ChangeSignal": "",
+              "Env": false,
+              "File": false,
+              "Filepath": "",
+              "Name": "default",
+              "ServiceName": "",
+              "TTL": 0
+            },
             "KillSignal": "",
             "KillTimeout": 5000000000,
             "Kind": "",
             "Leader": false,
             "Lifecycle": null,
             "LogConfig": {
+              "Disabled": false,
+              "Enabled": null,
               "MaxFileSizeMB": 10,
               "MaxFiles": 10
             },
@@ -125,19 +151,25 @@
             "Name": "echo",
             "Resources": {
               "CPU": 100,
+              "Cores": 0,
               "Devices": null,
               "DiskMB": 0,
               "IOPS": 0,
               "MemoryMB": 300,
-              "Networks": null
+              "MemoryMaxMB": 0,
+              "NUMA": null,
+              "Networks": null,
+              "SecretsMB": 0
             },
             "RestartPolicy": {
               "Attempts": 3,
               "Delay": 15000000000,
               "Interval": 86400000000000,
-              "Mode": "fail"
+              "Mode": "fail",
+              "RenderTemplates": false
             },
             "ScalingPolicies": null,
+            "Schedule": null,
             "Services": null,
             "ShutdownDelay": 0,
             "Templates": null,
@@ -151,6 +183,7 @@
       }
     ],
     "Type": "batch",
+    "UI": null,
     "Update": {
       "AutoPromote": false,
       "AutoRevert": false,
@@ -163,7 +196,7 @@
       "Stagger": 0
     },
     "VaultNamespace": "",
-    "VaultToken": "",
-    "Version": 0
+    "Version": 0,
+    "VersionTag": null
   }
 }

--- a/policy/nomad/test-fixtures/strategy-without-metric.json.golden
+++ b/policy/nomad/test-fixtures/strategy-without-metric.json.golden
@@ -4,17 +4,17 @@
     "AllAtOnce": false,
     "Constraints": null,
     "ConsulNamespace": "",
-    "CreateIndex": 139,
+    "CreateIndex": 137,
     "Datacenters": [
-      "dc1"
+      "*"
     ],
     "DispatchIdempotencyToken": "",
     "Dispatched": false,
     "ID": "strategy-without-metric",
-    "JobModifyIndex": 139,
+    "JobModifyIndex": 137,
     "Meta": null,
     "Migrate": null,
-    "ModifyIndex": 140,
+    "ModifyIndex": 138,
     "Multiregion": null,
     "Name": "strategy-without-metric",
     "Namespace": "default",
@@ -32,7 +32,7 @@
     "Status": "running",
     "StatusDescription": "",
     "Stop": false,
-    "SubmitTime": 1750941689672028000,
+    "SubmitTime": 1751038612341561000,
     "TaskGroups": [
       {
         "Affinities": null,
@@ -67,12 +67,12 @@
           "RenderTemplates": false
         },
         "Scaling": {
-          "CreateIndex": 139,
+          "CreateIndex": 137,
           "Enabled": true,
           "ID": "id",
           "Max": 10,
           "Min": 1,
-          "ModifyIndex": 139,
+          "ModifyIndex": 137,
           "Namespace": "",
           "Policy": {
             "check": [
@@ -83,9 +83,9 @@
                       {
                         "fixed-value": [
                           {
+                            "str_config": "str",
                             "bool_config": true,
-                            "int_config": 2.0,
-                            "str_config": "str"
+                            "int_config": 2.0
                           }
                         ]
                       }

--- a/policy/nomad/validate.go
+++ b/policy/nomad/validate.go
@@ -90,9 +90,15 @@ func validatePolicy(p map[string]interface{}) error {
 	}
 
 	// Validate Cooldown, if present.
-	//   1. Cooldown should be a valid duration.
+	//   1. Cooldown and cooldownOnScaleUp should be a valid duration.
 	if cooldown, ok := p[keyCooldown]; ok {
 		if err := validateDuration(cooldown, path+"."+keyCooldown); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	if cooldownOnScaleUp, ok := p[keyCooldownOnScaleUp]; ok {
+		if err := validateDuration(cooldownOnScaleUp, path+"."+keyCooldownOnScaleUp); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}

--- a/policy/nomad/validate_test.go
+++ b/policy/nomad/validate_test.go
@@ -463,6 +463,16 @@ func Test_validateScalingPolicy(t *testing.T) {
 			inputFile:   "invalid-cooldown",
 			expectError: true,
 		},
+		{
+			name:        "policy.cooldown_on_scale_up has wrong type",
+			inputFile:   "invalid-cooldown-on-scale-up-type",
+			expectError: true,
+		},
+		{
+			name:        "policy.cooldown_on_scale_up has wrong format",
+			inputFile:   "invalid-cooldown-on-scale-up",
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -37,6 +37,11 @@ func (pr *Processor) ApplyPolicyDefaults(p *sdk.ScalingPolicy) {
 	if p.Cooldown == 0 {
 		p.Cooldown = pr.defaults.DefaultCooldown
 	}
+
+	if p.CooldownOnScaleUp == 0 {
+		p.CooldownOnScaleUp = p.Cooldown
+	}
+
 	if p.EvaluationInterval == 0 {
 		p.EvaluationInterval = pr.defaults.DefaultEvaluationInterval
 	}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -350,7 +350,7 @@ func TestProcessor_ApplyPolicyDefaults(t *testing.T) {
 				CooldownOnScaleUp:  10 * time.Minute,
 				EvaluationInterval: 5 * time.Minute,
 			},
-			name: "cooldown and cooldowonscale up set",
+			name: "cooldown and cool_down_scale_up set",
 		},
 	}
 

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -270,6 +270,7 @@ func TestProcessor_ApplyPolicyDefaults(t *testing.T) {
 			},
 			expectedOutputPolicy: &sdk.ScalingPolicy{
 				Cooldown:           20 * time.Second,
+				CooldownOnScaleUp:  20 * time.Second,
 				EvaluationInterval: 5 * time.Second,
 			},
 			name: "evaluation interval set to default",
@@ -284,6 +285,7 @@ func TestProcessor_ApplyPolicyDefaults(t *testing.T) {
 			},
 			expectedOutputPolicy: &sdk.ScalingPolicy{
 				Cooldown:           11 * time.Second,
+				CooldownOnScaleUp:  11 * time.Second,
 				EvaluationInterval: 15 * time.Second,
 			},
 			name: "cooldown set to default",
@@ -296,6 +298,7 @@ func TestProcessor_ApplyPolicyDefaults(t *testing.T) {
 			},
 			expectedOutputPolicy: &sdk.ScalingPolicy{
 				Cooldown:           10 * time.Second,
+				CooldownOnScaleUp:  10 * time.Second,
 				EvaluationInterval: 5 * time.Second,
 			},
 			name: "evaluation interval and cooldown set to default",
@@ -311,9 +314,43 @@ func TestProcessor_ApplyPolicyDefaults(t *testing.T) {
 			},
 			expectedOutputPolicy: &sdk.ScalingPolicy{
 				Cooldown:           10 * time.Minute,
+				CooldownOnScaleUp:  10 * time.Minute,
 				EvaluationInterval: 5 * time.Minute,
 			},
 			name: "neither set to default",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				CooldownOnScaleUp:  10 * time.Minute,
+				EvaluationInterval: 5 * time.Minute,
+			},
+			inputDefaults: &ConfigDefaults{
+				DefaultEvaluationInterval: 5 * time.Second,
+				DefaultCooldown:           5 * time.Second,
+			},
+			expectedOutputPolicy: &sdk.ScalingPolicy{
+				Cooldown:           5 * time.Second,
+				CooldownOnScaleUp:  10 * time.Minute,
+				EvaluationInterval: 5 * time.Minute,
+			},
+			name: "cooldown not set",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				Cooldown:           5 * time.Second,
+				CooldownOnScaleUp:  10 * time.Minute,
+				EvaluationInterval: 5 * time.Minute,
+			},
+			inputDefaults: &ConfigDefaults{
+				DefaultEvaluationInterval: 5 * time.Second,
+				DefaultCooldown:           15 * time.Second,
+			},
+			expectedOutputPolicy: &sdk.ScalingPolicy{
+				Cooldown:           5 * time.Second,
+				CooldownOnScaleUp:  10 * time.Minute,
+				EvaluationInterval: 5 * time.Minute,
+			},
+			name: "cooldown and cooldowonscale up set",
 		},
 	}
 

--- a/policyeval/base_worker.go
+++ b/policyeval/base_worker.go
@@ -334,8 +334,16 @@ func (w *BaseWorker) scaleTarget(
 	metrics.IncrCounterWithLabels([]string{"scale", "invoke", "success_count"}, 1, metricLabels)
 
 	// Enforce the cooldown after a successful scaling event.
-	w.policyManager.EnforceCooldown(policy.ID, policy.Cooldown)
+	w.policyManager.EnforceCooldown(policy.ID, calculateCooldown(policy, action))
 	return nil
+}
+
+func calculateCooldown(p *sdk.ScalingPolicy, a sdk.ScalingAction) time.Duration {
+	if a.Direction == sdk.ScaleDirectionUp {
+		return p.CooldownOnScaleUp
+	}
+
+	return p.Cooldown
 }
 
 // runTargetStatus wraps the target.Status call to provide operational

--- a/policyeval/base_worker.go
+++ b/policyeval/base_worker.go
@@ -21,18 +21,22 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/sdk/helper/uuid"
 )
 
+type cooldownEnforcer interface {
+	EnforceCooldown(policyID string, coolDownDuration time.Duration)
+}
+
 // errTargetNotReady is used by a check handler to indicate the policy target
 // is not ready.
 var errTargetNotReady = errors.New("target not ready")
 
 // Worker is responsible for executing a policy evaluation request.
 type BaseWorker struct {
-	id            string
-	logger        hclog.Logger
-	pluginManager *manager.PluginManager
-	policyManager *policy.Manager
-	broker        *Broker
-	queue         string
+	id               string
+	logger           hclog.Logger
+	pluginManager    *manager.PluginManager
+	cooldownEnforcer cooldownEnforcer
+	broker           *Broker
+	queue            string
 }
 
 // NewBaseWorker returns a new BaseWorker instance.
@@ -40,12 +44,12 @@ func NewBaseWorker(l hclog.Logger, pm *manager.PluginManager, m *policy.Manager,
 	id := uuid.Generate()
 
 	return &BaseWorker{
-		id:            id,
-		logger:        l.Named("worker").With("id", id, "queue", queue),
-		pluginManager: pm,
-		policyManager: m,
-		broker:        b,
-		queue:         queue,
+		id:               id,
+		logger:           l.Named("worker").With("id", id, "queue", queue),
+		pluginManager:    pm,
+		cooldownEnforcer: m,
+		broker:           b,
+		queue:            queue,
 	}
 }
 
@@ -132,7 +136,7 @@ func (w *BaseWorker) handlePolicy(ctx context.Context, eval *sdk.ScalingEvaluati
 			Reason:    reason,
 			Direction: sdk.ScaleDirectionUp,
 		}
-		return w.scaleTarget(logger, target, eval.Policy, action, currentStatus)
+		return w.scaleTarget(target, eval.Policy, action, currentStatus)
 	}
 	if currentStatus.Count > eval.Policy.Max {
 		reason := fmt.Sprintf("scaling down because current count %d is greater than policy max value of %d",
@@ -143,7 +147,7 @@ func (w *BaseWorker) handlePolicy(ctx context.Context, eval *sdk.ScalingEvaluati
 			Reason:    reason,
 			Direction: sdk.ScaleDirectionDown,
 		}
-		return w.scaleTarget(logger, target, eval.Policy, action, currentStatus)
+		return w.scaleTarget(target, eval.Policy, action, currentStatus)
 	}
 
 	// Prepare handlers.
@@ -277,7 +281,7 @@ func (w *BaseWorker) handlePolicy(ctx context.Context, eval *sdk.ScalingEvaluati
 	default:
 	}
 
-	err = w.scaleTarget(logger, target, eval.Policy, *winner.action, currentStatus)
+	err = w.scaleTarget(target, eval.Policy, *winner.action, currentStatus)
 	if err != nil {
 		return err
 	}
@@ -289,8 +293,7 @@ func (w *BaseWorker) handlePolicy(ctx context.Context, eval *sdk.ScalingEvaluati
 // scaleTarget performs all the necessary checks and actions necessary to scale
 // a target.
 func (w *BaseWorker) scaleTarget(
-	logger hclog.Logger,
-	targetImpl target.Target,
+	targetScaler target.TargetScaler,
 	policy *sdk.ScalingPolicy,
 	action sdk.ScalingAction,
 	currentStatus *sdk.TargetStatus,
@@ -300,15 +303,15 @@ func (w *BaseWorker) scaleTarget(
 	// action count to nil so its no-nop. This allows us to still
 	// submit the job, but not alter its state.
 	if val, ok := policy.Target.Config["dry-run"]; ok && val == "true" {
-		logger.Info("scaling dry-run is enabled, using no-op task group count")
+		w.logger.Info("scaling dry-run is enabled, using no-op task group count")
 		action.SetDryRun()
 	}
 
 	if action.Count == sdk.StrategyActionMetaValueDryRunCount {
-		logger.Debug("registering scaling event",
+		w.logger.Debug("registering scaling event",
 			"count", currentStatus.Count, "reason", action.Reason, "meta", action.Meta)
 	} else {
-		logger.Info("scaling target",
+		w.logger.Info("scaling target",
 			"from", currentStatus.Count, "to", action.Count,
 			"reason", action.Reason, "meta", action.Meta)
 	}
@@ -318,10 +321,10 @@ func (w *BaseWorker) scaleTarget(
 		{Name: "target_name", Value: policy.Target.Name},
 	}
 
-	err := runTargetScale(targetImpl, policy, action)
+	err := runTargetScale(targetScaler, policy, action)
 	if err != nil {
 		if _, ok := err.(*sdk.TargetScalingNoOpError); ok {
-			logger.Info("scaling action skipped", "reason", err)
+			w.logger.Info("scaling action skipped", "reason", err)
 			return nil
 		}
 
@@ -329,12 +332,12 @@ func (w *BaseWorker) scaleTarget(
 		return fmt.Errorf("failed to scale target: %v", err)
 	}
 
-	logger.Debug("successfully submitted scaling action to target",
+	w.logger.Debug("successfully submitted scaling action to target",
 		"desired_count", action.Count)
 	metrics.IncrCounterWithLabels([]string{"scale", "invoke", "success_count"}, 1, metricLabels)
 
 	// Enforce the cooldown after a successful scaling event.
-	w.policyManager.EnforceCooldown(policy.ID, calculateCooldown(policy, action))
+	w.cooldownEnforcer.EnforceCooldown(policy.ID, calculateCooldown(policy, action))
 	return nil
 }
 
@@ -359,7 +362,7 @@ func runTargetStatus(t target.Target, policy *sdk.ScalingPolicy) (*sdk.TargetSta
 
 // runTargetScale wraps the target.Scale call to provide operational
 // functionality.
-func runTargetScale(targetImpl target.Target, policy *sdk.ScalingPolicy, action sdk.ScalingAction) error {
+func runTargetScale(targetImpl target.TargetScaler, policy *sdk.ScalingPolicy, action sdk.ScalingAction) error {
 	// Trigger a metric measure to track latency of the call.
 	labels := []metrics.Label{{Name: "plugin_name", Value: policy.Target.Name}, {Name: "policy_id", Value: policy.ID}}
 	defer metrics.MeasureSinceWithLabels([]string{"plugin", "target", "scale", "invoke_ms"}, time.Now(), labels)

--- a/policyeval/base_worker.go
+++ b/policyeval/base_worker.go
@@ -329,7 +329,7 @@ func (w *BaseWorker) scaleTarget(
 		}
 
 		metrics.IncrCounterWithLabels([]string{"scale", "invoke", "error_count"}, 1, metricLabels)
-		return fmt.Errorf("failed to scale target: %v", err)
+		return fmt.Errorf("failed to scale target: %w", err)
 	}
 
 	w.logger.Debug("successfully submitted scaling action to target",

--- a/policyeval/base_worker_test.go
+++ b/policyeval/base_worker_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package policyeval
 
 import (
@@ -101,6 +104,7 @@ func TestScaleTarget_Cooldown(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			testPolicy.Target = tc.target
+
 			mcde := &mockCoolDownEnforcer{}
 			mts := &mockTargetScaler{}
 

--- a/policyeval/base_worker_test.go
+++ b/policyeval/base_worker_test.go
@@ -62,64 +62,64 @@ func TestScaleTarget_Cooldown(t *testing.T) {
 		expectedCount    int64
 		expectedErr      error
 	}{
-		/* 		{
-		   			name: "scaling_up",
+		{
+			name: "scaling_up",
 
-		   			scalingAction: sdk.ScalingAction{
-		   				Count:     4,
-		   				Direction: sdk.ScaleDirectionUp,
-		   			},
-		   			target: &sdk.ScalingPolicyTarget{
-		   				Name: "testTarget",
-		   			},
-		   			expectedCooldown: testPolicy.CooldownOnScaleUp,
-		   			expectedCount:    4,
-		   		},
-		   		{
-		   			name: "scaling_down",
+			scalingAction: sdk.ScalingAction{
+				Count:     4,
+				Direction: sdk.ScaleDirectionUp,
+			},
+			target: &sdk.ScalingPolicyTarget{
+				Name: "testTarget",
+			},
+			expectedCooldown: testPolicy.CooldownOnScaleUp,
+			expectedCount:    4,
+		},
+		{
+			name: "scaling_down",
 
-		   			scalingAction: sdk.ScalingAction{
-		   				Count:     1,
-		   				Direction: sdk.ScaleDirectionDown,
-		   			},
-		   			target: &sdk.ScalingPolicyTarget{
-		   				Name: "testTarget",
-		   			},
-		   			expectedCooldown: testPolicy.Cooldown,
-		   			expectedCount:    1,
-		   		},
-		   		{
-		   			name: "scaling_dry_run",
-		   			scalingAction: sdk.ScalingAction{
-		   				Count:     4,
-		   				Direction: sdk.ScaleDirectionUp,
-		   				Meta:      map[string]interface{}{},
-		   			},
-		   			target: &sdk.ScalingPolicyTarget{
-		   				Name: "testTarget",
-		   				Config: map[string]string{
-		   					"dry-run": "true",
-		   				},
-		   			},
-		   			expectedCooldown: testPolicy.Cooldown,
-		   			expectedCount:    -1,
-		   		},
-		   		{
-		   			name:         "error_propagation",
-		   			scalingError: testError,
-		   			scalingAction: sdk.ScalingAction{
-		   				Count:     4,
-		   				Direction: sdk.ScaleDirectionUp,
-		   				Meta:      map[string]interface{}{},
-		   			},
-		   			target: &sdk.ScalingPolicyTarget{
-		   				Name:   "testTarget",
-		   				Config: map[string]string{},
-		   			},
-		   			expectedCooldown: 0,
-		   			expectedErr:      testError,
-		   			expectedCount:    4,
-		   		},*/
+			scalingAction: sdk.ScalingAction{
+				Count:     1,
+				Direction: sdk.ScaleDirectionDown,
+			},
+			target: &sdk.ScalingPolicyTarget{
+				Name: "testTarget",
+			},
+			expectedCooldown: testPolicy.Cooldown,
+			expectedCount:    1,
+		},
+		{
+			name: "scaling_dry_run",
+			scalingAction: sdk.ScalingAction{
+				Count:     4,
+				Direction: sdk.ScaleDirectionUp,
+				Meta:      map[string]interface{}{},
+			},
+			target: &sdk.ScalingPolicyTarget{
+				Name: "testTarget",
+				Config: map[string]string{
+					"dry-run": "true",
+				},
+			},
+			expectedCooldown: testPolicy.Cooldown,
+			expectedCount:    -1,
+		},
+		{
+			name:         "error_propagation",
+			scalingError: testError,
+			scalingAction: sdk.ScalingAction{
+				Count:     4,
+				Direction: sdk.ScaleDirectionUp,
+				Meta:      map[string]interface{}{},
+			},
+			target: &sdk.ScalingPolicyTarget{
+				Name:   "testTarget",
+				Config: map[string]string{},
+			},
+			expectedCooldown: 0,
+			expectedErr:      testError,
+			expectedCount:    4,
+		},
 		{
 			name:         "error_no_op",
 			scalingError: sdk.NewTargetScalingNoOpError("test"),

--- a/policyeval/base_worker_test.go
+++ b/policyeval/base_worker_test.go
@@ -1,0 +1,119 @@
+package policyeval
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/shoenig/test/must"
+)
+
+type mockTargetScaler struct {
+	count     int64
+	direction sdk.ScaleDirection
+}
+
+func (mts *mockTargetScaler) Scale(action sdk.ScalingAction, config map[string]string) error {
+	mts.setCount(action.Count)
+	return nil
+}
+
+func (mts *mockTargetScaler) setCount(newCount int64) {
+	mts.count = newCount
+}
+
+func (mts *mockTargetScaler) getCount() int64 {
+	return mts.count
+}
+
+type mockCoolDownEnforcer struct {
+	policyID string
+	duration time.Duration
+}
+
+func (mce *mockCoolDownEnforcer) EnforceCooldown(_ string, coolDownDuration time.Duration) {
+	mce.duration = coolDownDuration
+}
+
+func TestScaleTarget_Cooldown(t *testing.T) {
+
+	testPolicy := &sdk.ScalingPolicy{
+		ID:                "test_policy",
+		Cooldown:          10 * time.Minute,
+		CooldownOnScaleUp: 20 * time.Second,
+	}
+
+	testStatus := &sdk.TargetStatus{
+		Count: 2,
+	}
+
+	testCases := []struct {
+		name             string
+		scalingAction    sdk.ScalingAction
+		target           *sdk.ScalingPolicyTarget
+		expectedCooldown time.Duration
+		expectedCount    int64
+	}{
+		{
+			name: "scaling_up",
+
+			scalingAction: sdk.ScalingAction{
+				Count:     4,
+				Direction: sdk.ScaleDirectionUp,
+			},
+			target: &sdk.ScalingPolicyTarget{
+				Name: "testTarget",
+			},
+			expectedCooldown: testPolicy.CooldownOnScaleUp,
+			expectedCount:    4,
+		},
+		{
+			name: "scaling_down",
+
+			scalingAction: sdk.ScalingAction{
+				Count:     1,
+				Direction: sdk.ScaleDirectionDown,
+			},
+			target: &sdk.ScalingPolicyTarget{
+				Name: "testTarget",
+			},
+			expectedCooldown: testPolicy.Cooldown,
+			expectedCount:    1,
+		},
+		{
+			name: "scaling_dry_run",
+			scalingAction: sdk.ScalingAction{
+				Count:     4,
+				Direction: sdk.ScaleDirectionUp,
+				Meta:      map[string]interface{}{},
+			},
+			target: &sdk.ScalingPolicyTarget{
+				Name: "testTarget",
+				Config: map[string]string{
+					"dry-run": "true",
+				},
+			},
+			expectedCooldown: testPolicy.Cooldown,
+			expectedCount:    -1,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testPolicy.Target = tc.target
+			mcde := &mockCoolDownEnforcer{}
+			mts := &mockTargetScaler{}
+
+			testBaseWorker := BaseWorker{
+				logger:           hclog.NewNullLogger(),
+				cooldownEnforcer: mcde,
+			}
+
+			testBaseWorker.scaleTarget(mts, testPolicy, tc.scalingAction, testStatus)
+
+			must.Eq(t, tc.expectedCooldown, mcde.duration)
+			must.Eq(t, tc.expectedCount, mts.getCount())
+		})
+	}
+
+}

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -57,9 +57,15 @@ type ScalingPolicy struct {
 	// be taken.
 	OnCheckError string
 
-	// Cooldown is the time period after a scaling action if performed, during
+	// Cooldown is the time period after a scaling action is performed, during
 	// which no policy evaluations will be started.
 	Cooldown time.Duration
+
+	// CooldownOnScaleUp is the time period after a scaling up action
+	// is performed, during which no policy evaluations will be started. It is
+	// as a separate option to allow for more aggressive scale up in case of
+	// surges.
+	CooldownOnScaleUp time.Duration
 
 	// EvaluationInterval indicates the frequency at which the policy is
 	// evaluated. A lower value means more frequent evaluation and can result
@@ -223,6 +229,7 @@ type FileDecodeScalingPolicy struct {
 type FileDecodePolicyDoc struct {
 	Cooldown              time.Duration
 	CooldownHCL           string `hcl:"cooldown,optional"`
+	CooldownOnScaleUpHCL  string `hcl:"cooldown_on_scale_up,optional"`
 	EvaluationInterval    time.Duration
 	EvaluationIntervalHCL string                      `hcl:"evaluation_interval,optional"`
 	OnCheckError          string                      `hcl:"on_check_error,optional"`

--- a/sdk/strategy.go
+++ b/sdk/strategy.go
@@ -97,6 +97,7 @@ func (a *ScalingAction) SetDryRun() {
 	a.Meta[strategyActionMetaKeyDryRun] = true
 	a.Meta[strategyActionMetaKeyDryRunCount] = a.Count
 	a.Count = StrategyActionMetaValueDryRunCount
+	a.Direction = ScaleDirectionNone
 }
 
 // CapCount caps the value of Count so it remains within the specified limits.


### PR DESCRIPTION
Having a different cooldown period for scaling up allows for a faster and more aggressive response in times of spikes. This PR introduces the option to add this new configuration, that defaults to the normal cooldown period if not provided.

The cool down period is set and enforced in 2 different places in the code:

1. After a regular [scale event](https://github.com/hashicorp/nomad-autoscaler/blob/5e0cf9f9a8ea08ede6f1b070239578d5a32f1f48/policyeval/base_worker.go#L337)
2. At a policy handler evaluation time [after a disaster recovery or failover](https://github.com/hashicorp/nomad-autoscaler/blob/5e0cf9f9a8ea08ede6f1b070239578d5a32f1f48/policy/handler.go#L148), what is referred to as "out of band events".

This PR only handles the first place, the second will be handled later because given the fact that the autoscaler is stateless, it relies on the providers to look up for ongoing scaling events, and the current APIs don't have a straight forward way to extract the direction of the current or past scaling events, making it impossible to respect the coldown on scale up configuration.