### PR TITLE
ci: triage false positives

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -2,9 +2,21 @@
 # SPDX-License-Identifier: MPL-2.0
 
 container {
-  dependencies = true
-  alpine_secdb = true
-  secrets      = true
+  dependencies    = true
+  alpine_security = true
+  secrets         = true
+
+  # Triage items that are _safe_ to ignore here. Note that this list should be
+  # periodically cleaned up to remove items that are no longer found by the
+  # scanner.
+  triage {
+    suppress {
+      vulnerabilities = [
+        "CVE-2024-58251", // busybox@1.37.0-r18 remove when dep updated.
+        "CVE-2025-46394", // busybox@1.37.0-r18 remove when dep updated.
+      ]
+    }
+  }
 }
 
 binary {


### PR DESCRIPTION
Triaging false positive alert from the security scanner. Updated to use `alpine_security`.
