### PR TITLE
Tracking policies from different sources

### DIFF
--- a/policy/manager.go
+++ b/policy/manager.go
@@ -79,6 +79,13 @@ func NewManager(log hclog.Logger, ps map[SourceName]Source, pm *manager.PluginMa
 	}
 }
 
+func (m *Manager) getHandlersNumPerSource(s SourceName) int {
+	m.handlersLock.RLock()
+	defer m.handlersLock.RUnlock()
+
+	return len(m.handlers[s])
+}
+
 func (m *Manager) getHandlersNum() int {
 	m.handlersLock.RLock()
 	defer m.handlersLock.RUnlock()

--- a/policy/manager_test.go
+++ b/policy/manager_test.go
@@ -406,7 +406,7 @@ func TestMonitoring(t *testing.T) {
 
 			must.Eq(t, tc.expCallsToLatestVersionMS1, ms1.getCallsCounter())
 			must.Eq(t, tc.expCallsToLatestVersionMS2, ms2.getCallsCounter())
-			must.Eq(t, len(tc.inputIDMessage.IDs), len(testedManager.handlers[tc.inputIDMessage.Source]))
+			must.Eq(t, len(tc.inputIDMessage.IDs), testedManager.getHandlersNumPerSource(tc.inputIDMessage.Source))
 
 			for id := range tc.inputIDMessage.IDs {
 				ph, ok := testedManager.handlers[tc.inputIDMessage.Source][id]


### PR DESCRIPTION
This PR addresses 2 big bugs present on the policy tracking:

- When updating the file policy source, the internal map that holds the policies was only being populated with the policy name and file, but the content was missing, resulting on every file policy resolving to nil.
- The policy update messages where compared to all running handlers disregarding the source, which led to updates on one source deleting handlers for the others.