### PR TITLE
Fix scaling loops caused by change in `scalingNeeded` logic

### DIFF
--- a/policy/handler.go
+++ b/policy/handler.go
@@ -334,10 +334,7 @@ func (h *Handler) Run(ctx context.Context) {
 }
 
 func scalingNeeded(a sdk.ScalingAction, countCount int64) bool {
-	// The DAS returns count but the direction is none, for vertical and horizontal
-	// policies checking the direction is enough.
-	return (a.Direction == sdk.ScaleDirectionNone && countCount != a.Count) ||
-		a.Direction != sdk.ScaleDirectionNone
+	return a.Direction != sdk.ScaleDirectionNone && countCount != a.Count
 }
 
 func (h *Handler) waitAndScale(ctx context.Context) error {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad-autoscaler/issues/1194.

Reverts the following commit https://github.com/hashicorp/nomad-autoscaler/commit/d2df3081464bcd5eee10d9991ca3a0cd456e2899 which is causing the behavior explained in the above issue.

Not 100% if this is the correct fix, especially seeing the comment in the function. It might fix the loop, but might brake something else that is relying on the current behavior.