### PR TITLE
Fix policy manager restart due to a monitor failing

### DIFF
--- a/policy/manager.go
+++ b/policy/manager.go
@@ -113,12 +113,11 @@ func (m *Manager) Run(ctx context.Context, evalCh chan<- *sdk.ScalingEvaluation)
 	// Start the metrics reporter.
 	go m.periodicMetricsReporter(ctx, m.metricsInterval)
 
-	// Create a separate context so we can stop the goroutine monitoring the
-	// list of policies independently from the parent context.
-	monitorCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	for {
+		// Create a separate context so we can stop the goroutine monitoring the
+		// list of policies independently from the parent context.
+		monitorCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
 
 		// Start the policy source and listen for changes in the list of policy IDs
 		for _, s := range m.policySources {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad-autoscaler/issues/1206

This reverts part of a change made in https://github.com/hashicorp/nomad-autoscaler/pull/1140. The description on that PR mentions:

> context canceling that could cause memories leaks in the long term.

However, this causes the monitorCtx to remain cancelled for subsequent iterations which as seen in the linked issue can cause the monitor to not start again after failing once.

I am however not sure if the memory leak mentioned in the original change would now be introduced again. If the `defer` is what would cause it, the `defer` could be removed since cancel is called later.