### PR TITLE
tool: tidy plugin dependencies

### DIFF
--- a/tools/tidy-plugin-deps.sh
+++ b/tools/tidy-plugin-deps.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# tidy-plugin-deps.sh runs 'go mod tidy' on every test plugin directory and adds
+# the appropriate files to the git index. Use this when dependabot updates a
+# dependency used in the root that then needs to get updated in the test
+# plugins.
+
+tidy() {
+    plugin=$1
+    pushd "plugins/test/$plugin"
+    go mod tidy
+    git add go.mod
+    git add go.sum
+    popd
+}
+
+tidy noop-apm
+tidy noop-strategy
+tidy noop-target


### PR DESCRIPTION
When we get a dependabot update, we frequently have to update the go.mod/go.sum for test plugins as well. Add a helper script for reducing some toil here.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

