### PR TITLE
policy: only count should be used to determine if scaling is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## UNRELEASED
 
 BUG FIXES:
-* plugin/target/aws-asg: Ignore warm pool activities when determining ASG readiness [[GH-1151]](https://github.com/hashicorp/nomad-autoscaler/pull/1151)
+* plugin/target/aws-asg: Ignore warm pool activities when determining ASG readiness [[GH-1151](https://github.com/hashicorp/nomad-autoscaler/pull/1151)]
+* policy: Fixed a bug where policy evaluations made scaling requests even when no change was required. [[GH-1221](https://github.com/hashicorp/nomad-autoscaler/pull/1221)]
 
 ## 0.4.8 (November 13, 2025)
 

--- a/policy/handler.go
+++ b/policy/handler.go
@@ -333,11 +333,12 @@ func (h *Handler) Run(ctx context.Context) {
 	}
 }
 
-func scalingNeeded(a sdk.ScalingAction, countCount int64) bool {
-	// The DAS returns count but the direction is none, for vertical and horizontal
-	// policies checking the direction is enough.
-	return (a.Direction == sdk.ScaleDirectionNone && countCount != a.Count) ||
-		a.Direction != sdk.ScaleDirectionNone
+// scalingNeeded determines if the action requires a change from the current
+// count.  Although we could potentially include the sdk.ScalingDirection in
+// this calculation, the Enterprise-only Dynamic Application Sizing feature
+// always has sdk.ScalingDirectionNone as its direction.
+func scalingNeeded(a sdk.ScalingAction, currentCount int64) bool {
+	return a.Count != currentCount
 }
 
 func (h *Handler) waitAndScale(ctx context.Context) error {


### PR DESCRIPTION
In d2df3081464b we changed the calculation for determining if scaling is needed to only include the count if direction was `sdk.ScaleDirectionNone` in order to support Dynamic Application Sizing (DAS). But in practice we can get a up/down direction with a count that's unchanged from non-DAS policies in cases where we've reached the limit. This causes deployment loops as we keep re-submitting the scaling request.

Ref: https://github.com/hashicorp/nomad-autoscaler/commit/d2df3081464bcd5eee10d9991ca3a0cd456e2899
Fixes: https://github.com/hashicorp/nomad-autoscaler/issues/1194
Fixes: https://github.com/hashicorp/nomad-autoscaler/issues/1213
Fixes: https://github.com/hashicorp/nomad-autoscaler/issues/1211

---

In addition to the test changes I've made here, I tested this with the following jobspecs. Prior to this patch, we end up with a loop of recommendations submitted or job scaling requests. Afterwards, we do not.

<details><summary>traefik</summary>

```hcl
job "traefik" {

  group "traefik" {

    network {
      port "admin" {
        static = 8081
      }
      port "webapp" {
        static = 8000
      }
      port "prometheus" {
        static = 9090
      }
    }

    service {
      name     = "traefik-admin"
      provider = "nomad"
      port     = "admin"
      tags = [
        "metrics"
      ]

      check {
        type     = "http"
        path     = "/ping"
        interval = "10s"
        timeout  = "2s"
      }
    }

    task "server" {
      driver = "docker"
      config {
        image        = "traefik:v2.9.1"
        ports        = ["admin", "webapp", "prometheus"]
        network_mode = "host"
        args = [
          "--api.dashboard=true",
          "--api.insecure=true",
          "--entrypoints.traefik.address=:${NOMAD_PORT_admin}",
          "--entrypoints.webapp.address=:${NOMAD_PORT_webapp}",
          "--entrypoints.prometheus.address=:${NOMAD_PORT_prometheus}",
          "--metrics.prometheus=true",
          "--metrics.prometheus.addServicesLabels=true",
          "--ping=true",
          "--providers.nomad=true",
          "--providers.nomad.exposedByDefault=false",
          "--providers.nomad.endpoint.address=http://${attr.unique.network.ip-address}:4646"
        ]
      }
    }
  }
}
```

</details>

<details><summary>prometheus</summary>

```hcl
job "prometheus" {

  group "monitoring" {

    network {
      mode = "host"
      port "ui" {      }
    }

    service {
      provider = "nomad"
      name     = "prometheus"
      port     = "ui"
      check {
        type     = "http"
        path     = "/-/healthy"
        interval = "5s"
        timeout  = "2s"
      }
       tags = [
          "traefik.enable=true",
          "traefik.http.routers.prometheus.entrypoints=prometheus",
          "traefik.http.routers.prometheus.rule=PathPrefix(`/`)"
        ]
    }

    task "prometheus" {
      driver = "docker"

      config {
        image = "docker.io/prom/prometheus:v2.45.0"
        args  = [
          "--config.file=${NOMAD_TASK_DIR}/config.yaml",
          "--web.listen-address=0.0.0.0:${NOMAD_PORT_ui}",
          "--web.console.libraries=/usr/share/prometheus/console_libraries",
          "--web.console.templates=/usr/share/prometheus/consoles",
        ]
        ports = ["ui"]
        network_mode = "host"
      }

      # suitable for scraping allocation metrics
      template {
        change_mode = "noop"
        destination = "local/config.yaml"
        data        = <<EOH
global:
  scrape_interval: 5s
  evaluation_interval: 5s

scrape_configs:

  - job_name: 'nomad_sd'
    nomad_sd_configs:
      - server: 'http://{{ env "attr.unique.network.ip-address" }}:4646'
    relabel_configs:
      - source_labels: ['__meta_nomad_tags']
        regex: '(.*),metrics,(.*)'
        action: keep
      - source_labels: [__meta_nomad_service]
        target_label: job

  - job_name: nomad
    metrics_path: /v1/metrics
    params:
      format: ['prometheus']
    static_configs:
    - targets: ['{{ env "attr.unique.network.ip-address" }}:4646']

EOH
      }

      resources {
        cpu    = 256
        memory = 512
      }

    }
  }
}
```

</details>



<details><summary>autoscaler</summary>

```hcl
job "autoscaler" {

  group "autoscaler" {

    network {
      mode = "host"
      port "http" {}
    }

    service {
      name     = "autoscaler"
      provider = "nomad"
      port     = "http"

      check {
        type     = "http"
        path     = "/v1/health"
        interval = "3s"
        timeout  = "1s"
      }
    }

    task "autoscaler" {
      driver = "docker"

      config {
        image   = "busybox:1"
        command = "/opt/nomad-autoscaler"
        args = [
          "agent",
          "-config",
          "${NOMAD_TASK_DIR}/config.hcl",
          "-http-bind-address",
          "0.0.0.0",
          "-http-bind-port",
          "${NOMAD_PORT_http}",
        ]
        ports = ["http"]

        volumes = [
          "/home/tim/go/bin/nomad-autoscaler:/opt/nomad-autoscaler",
        ]
      }

      template {
        data = <<EOT
nomad {
  address = "http://{{ env "attr.unique.network.ip-address" }}:4646"
}

apm "prometheus" {
  driver = "prometheus"
  config = {
    address = "http://{{ env "attr.unique.network.ip-address" }}:9090"
  }
}

EOT

        destination = "${NOMAD_TASK_DIR}/config.hcl"
      }


      resources {
        cpu    = 50
        memory = 128
      }

    }
  }
}

```

</details>


<details><summary>webapp (horizontal)</summary>

```hcl
job "httpd" {

  group "web" {

    count = 1

    scaling {
      enabled = true
      min     = 1
      max     = 5

      policy {
        evaluation_interval = "5s"
        cooldown            = "15s"

        check "avg_sessions" {
          source = "prometheus"
          # i.e. "run one per job we're running"
          query  = "nomad_nomad_job_summary_running{exported_job=\"httpd\",task_group=\"web\"}"

          strategy "pass-through" {}

          target "nomad" {
            Namespace = "default"
            Job       = "httpd"
            Group     = "web"
          }
        }

      }

    }

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    service {
      name     = "httpd"
      provider = "nomad"
      port     = "www"
      tags = [
        "traefik.enable=true",
        "traefik.http.routers.webapp.entrypoints=webapp",
        "traefik.http.routers.webapp.rule=PathPrefix(`/`)"
      ]
    }

    task "http" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      template {
        data = <<EOT
<html>
  <div>hello, Nomad</div>
</html>
        EOT

        destination = "${NOMAD_TASK_DIR}/index.html"
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

</details>


<details><summary>webapp (DAS)</summary>

```hcl
job "httpd" {

  group "web" {

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    service {
      name     = "httpd"
      provider = "nomad"
      port     = "www"
      tags = [
        "traefik.enable=true",
        "traefik.http.routers.webapp.entrypoints=webapp",
        "traefik.http.routers.webapp.rule=PathPrefix(`/`)"
      ]
    }

    task "http" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      template {
        data = <<EOT
<html>
  <div>hello, Nomad</div>
</html>
        EOT

        destination = "${NOMAD_TASK_DIR}/index.html"
      }

      scaling "mem" {
        enabled = true
        min     = 50
        max     = 200

        policy {
          evaluation_interval = "5s"
          cooldown            = "10s"

          check "num_running" {
            source = "prometheus"
            # i.e. "100x number of jobs running"
            query = "nomad_nomad_job_summary_running{exported_job=\"httpd\",task_group=\"web\"} * 100"
            strategy "app-sizing-avg" {}

            target "app-sizing-nomad" {
              Namespace = "default"
              Job       = "httpd"
              Group     = "web"
              Task      = "http"
              Resource  = "MemoryMB"
            }
          }

        }
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}

```

</details>

```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

