### PR TITLE
build: don't lint when building dev target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -70,7 +70,7 @@ pkg/%.zip: pkg/%/nomad-autoscaler ## Build and zip Nomad Autoscaler for GOOS_GOA
 	zip -j $@ $(dir $<)*
 
 .PHONY: dev
-dev: lint ## Build for the current development version
+dev: hclfmt ## Build for the current development version
 	@echo "==> Building autoscaler..."
 	@CGO_ENABLED=0 GOPROXY=direct go build \
 		-ldflags $(GO_LDFLAGS) \
@@ -86,7 +86,7 @@ proto: ## Generate the protocol buffers
 	@echo "==> Done"
 
 .PHONY: lint
-lint: lint-tools generate-tools hclfmt ## Lint the source code
+lint: hclfmt ## Lint the source code
 	@echo "==> Linting source code..."
 	@GOPROXY=direct \
 	golangci-lint run -j 1 --build-tags "$(GO_TAGS)" --timeout=15m


### PR DESCRIPTION
Using `golangci-lint` is quite slow and memory hungry, so using it for every dev build slows down bug fixes. We run it in CI and developers should have linting wired up in their editors already. Doing the `hclfmt` is quick and cheap, and we do it on the core product already.

Also, there's no need to reinstall all the tools every time we run the linter. They'll already be installed.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

