### PR TITLE
policy: handle recommendations independently of scaling no-op

### DIFF
--- a/policy/handler.go
+++ b/policy/handler.go
@@ -334,10 +334,15 @@ func (h *Handler) Run(ctx context.Context) {
 }
 
 // scalingNeeded determines if the action requires a change from the current
-// count.  Although we could potentially include the sdk.ScalingDirection in
-// this calculation, the Enterprise-only Dynamic Application Sizing feature
-// always has sdk.ScalingDirectionNone as its direction.
+// count.
 func scalingNeeded(a sdk.ScalingAction, currentCount int64) bool {
+	if a.Direction == sdk.ScaleDirectionRecommendation {
+		// used only for Enterprise Dynamic Application Sizing (DAS)
+		return a.Count != currentCount
+	}
+	if a.Direction == sdk.ScaleDirectionNone {
+		return false
+	}
 	return a.Count != currentCount
 }
 

--- a/policy/handler_test.go
+++ b/policy/handler_test.go
@@ -715,9 +715,10 @@ func TestHandlerScalingNeeded(t *testing.T) {
 		currentCount int64
 		expect       bool
 	}{
-		{sdk.ScaleDirectionNone, 2, 1, true}, // for DAS
-		{sdk.ScaleDirectionNone, 1, 2, true}, // for DAS
-		{sdk.ScaleDirectionNone, 1, 1, false},
+		{sdk.ScaleDirectionRecommendation, 2, 1, true},  // ex. DAS
+		{sdk.ScaleDirectionRecommendation, 1, 1, false}, // ex. DAS
+		{sdk.ScaleDirectionNone, 2, 1, false},           // ex. target-value/threshold
+		{sdk.ScaleDirectionNone, 1, 1, false},           // ex. target-value/threshold
 		{sdk.ScaleDirectionUp, 2, 1, true},
 		{sdk.ScaleDirectionUp, 1, 2, true},
 		{sdk.ScaleDirectionUp, 1, 1, false},

--- a/sdk/strategy.go
+++ b/sdk/strategy.go
@@ -41,9 +41,8 @@ type ScalingAction struct {
 	Error bool
 
 	// Direction is the scaling direction the strategy has decided should
-	// happen. This is particularly helpful for non-Nomad target
-	// implementations whose APIs dead with increment changes rather than
-	// absolute counts.
+	// happen. This is particularly helpful for non-Nomad target implementations
+	// whose APIs deal with increment changes rather than absolute counts.
 	Direction ScaleDirection
 
 	// Meta
@@ -68,6 +67,10 @@ const (
 	// ScaleDirectionUp indicates the target should increase the number of
 	// running instances of the resource.
 	ScaleDirectionUp
+
+	// ScaleDirectionRecommendation indicates the plugin has made a
+	// recommendation but the autoscaler should not trigger a target plugin
+	ScaleDirectionRecommendation = 127
 )
 
 // String satisfies the Stringer interface and returns as string representation
@@ -78,6 +81,8 @@ func (d ScaleDirection) String() string {
 		return "down"
 	case ScaleDirectionUp:
 		return "up"
+	case ScaleDirectionRecommendation:
+		return "recommendation"
 	default:
 		return "none"
 	}

--- a/sdk/strategy_test.go
+++ b/sdk/strategy_test.go
@@ -402,6 +402,22 @@ func TestPreemptAction(t *testing.T) {
 				Direction: ScaleDirectionUp,
 			},
 		},
+		{
+			// note: we should never actually see these at the same time
+			name: "recommendation vs up",
+			a: &ScalingAction{
+				Count:     3,
+				Direction: ScaleDirectionUp,
+			},
+			b: &ScalingAction{
+				Count:     2,
+				Direction: ScaleDirectionRecommendation,
+			},
+			expected: &ScalingAction{
+				Count:     2,
+				Direction: ScaleDirectionRecommendation,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
In #1221 we changed the check for whether scaling was needed to only rely on the change in count and not the direction, in order to account for non-DAS policies that have hit their limit and have a direction but no change in count. But this failed to account for plugins that return an essentially zero-value `sdk.ScalingAction` where the direction is none. In this case, the logic we added in #1221 will cause the autoscaler to scale down to the minimum value instead of keep it steady.

Because DAS sets `sdk.ScaleDirectionNone` there's no reasonable way to tell the difference between a plugin that's left the count unset (which then gets capped to the minimum) and a plugin like DAS that's setting a specific count. Fix this by adding a new `sdk.ScaleDirectionRecommendation` value to the direction enum, which will be used by DAS built in plugins.

Ref: https://github.com/hashicorp/nomad-autoscaler/pull/1221
Fixes: https://github.com/hashicorp/nomad-autoscaler/issues/1211

---

Additional testing job on top of what we had in #1221 

<details><summary>http-threshold.nomad.hcl</summary>

```hcl
job "httpd" {

  group "web" {

    count = 2

    scaling {
      enabled = true
      min     = 0
      max     = 5

      policy {
        evaluation_interval = "5s"
        cooldown            = "15s"

        check "avg_sessions" {
          source = "prometheus"
          query = "nomad_nomad_job_status_running"

          strategy "threshold" {
            lower_bound = 100
            delta = 1
          }

          target "nomad" {
            Namespace = "default"
            Job       = "httpd"
            Group     = "web"
          }
        }

      }

    }

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    service {
      name     = "httpd"
      provider = "nomad"
      port     = "www"
      tags = [
        "traefik.enable=true",
        "traefik.http.routers.webapp.entrypoints=webapp",
        "traefik.http.routers.webapp.rule=PathPrefix(`/`)"
      ]
    }

    task "http" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      template {
        data = <<EOT
<html>
  <div>hello, Nomad</div>
</html>
        EOT

        destination = "${NOMAD_TASK_DIR}/index.html"
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

</details>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

