### PR TITLE
build: Update the Docker image to Alpine 3.23 and patch zlib.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 
 IMPROVEMENTS:
 * agent: The `nomad.namespace` config field and `-nomad-namespace` CLI flag now accept multiple values, allowing the autoscaler to monitor scaling policies across several Nomad namespaces. Use `*` to monitor all namespaces. When a single namespace is provided the existing behaviour is preserved. [[GH-1251](https://github.com/hashicorp/nomad-autoscaler/pull/1251)]
+* build: Updated the Alpine container image used to `alpine:3.23` [[GH-1272](https://github.com/hashicorp/nomad-autoscaler/pull/1272)]
 * policy: Reuse identical APM query results within a single policy evaluation to avoid duplicate source requests for checks that share the same source, query, query window, and query window offset. [[GH-1252](https://github.com/hashicorp/nomad-autoscaler/pull/1252)] 
 * plugins: Fixed AWS-ASG plugin error handling so the underlying error is preserved when retry limit is reached. [[GH-1266](https://github.com/hashicorp/nomad-autoscaler/pull/1266)]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2025
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # This Dockerfile contains multiple targets.
@@ -22,7 +22,10 @@ RUN go build -o nomad-autoscaler .
 
 # dev runs the binary from devbuild
 # -----------------------------------
-FROM alpine:3.22 AS dev
+FROM alpine:3.23 AS dev
+
+# Pull patched zlib (fixes CVE-2026-27171: zlib < 1.3.2).
+RUN apk add --no-cache --upgrade zlib
 
 COPY --from=devbuild /build/nomad-autoscaler /bin/
 COPY ./scripts/docker-entrypoint.sh /
@@ -35,7 +38,10 @@ CMD ["help"]
 #   Release images.
 # ===================================
 
-FROM alpine:3.22 AS release
+FROM alpine:3.23 AS release
+
+# Pull patched zlib (fixes CVE-2026-27171: zlib < 1.3.2).
+RUN apk add --no-cache --upgrade zlib
 
 ARG PRODUCT_NAME=nomad-autoscaler
 ARG PRODUCT_VERSION


### PR DESCRIPTION
This change updates the Alpine image used to build the Autoscaler container to 3.23. As part of this work, zlib is upgraded to 1.3.2-r0 which contains a patch for CVE-2026-27171.

Resolve container scanning failures due to the identified CVE in Alpine zlib.


