### PR TITLE
Prevent misconfigured strategy errors from panicking policy evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ IMPROVEMENTS:
 * policy: Reuse identical APM query results within a single policy evaluation to avoid duplicate source requests for checks that share the same source, query, query window, and query window offset. [[GH-1252](https://github.com/hashicorp/nomad-autoscaler/pull/1252)] 
 * plugins: Fixed AWS-ASG plugin error handling so the underlying error is preserved when retry limit is reached. [[GH-1266](https://github.com/hashicorp/nomad-autoscaler/pull/1266)]
 
+BUG FIXES:
+* policy: Fixed a bug where misconfigured strategy checks could crash the autoscaler instead of following normal `on_error` and `on_check_error` behavior. [[GH-1275](https://github.com/hashicorp/nomad-autoscaler/pull/1275)]
+
 ## 0.4.9 (January 6, 2026)
 
 BUG FIXES:

--- a/plugins/builtin/apm/nomad/plugin/node.go
+++ b/plugins/builtin/apm/nomad/plugin/node.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package plugin

--- a/plugins/builtin/apm/nomad/plugin/node_test.go
+++ b/plugins/builtin/apm/nomad/plugin/node_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package plugin

--- a/policy/check.go
+++ b/policy/check.go
@@ -118,6 +118,8 @@ func (ch *checkRunner) getNewCountFromStrategy(ctx context.Context, currentCount
 			if ch.policy.OnCheckError == sdk.ScalingPolicyOnErrorFail {
 				return sdk.ScalingAction{}, err
 			}
+
+			return sdk.ScalingAction{}, nil
 		}
 	}
 

--- a/policy/check.go
+++ b/policy/check.go
@@ -92,9 +92,8 @@ func (ch *checkRunner) ensureCompiledSchedule() error {
 	return ch.scheduleErr
 }
 
-// getNewCountFromStrategy begins the execution of the checks and returns
-// and action containing the instance count after applying the strategy to the
-// metrics.
+// getNewCountFromStrategy runs the check strategy and applies the effective
+// check or policy error-handling behavior to the result.
 func (ch *checkRunner) getNewCountFromStrategy(ctx context.Context, currentCount int64,
 	metrics sdk.TimestampedMetrics) (sdk.ScalingAction, error) {
 	ch.log.Debug("calculating new count", "current count", currentCount)
@@ -105,8 +104,8 @@ func (ch *checkRunner) getNewCountFromStrategy(ctx context.Context, currentCount
 			"on_error", ch.check.OnError, "on_check_error",
 			ch.policy.OnCheckError, "error", err)
 
-		// Define how to handle error.
-		// Use check behaviour if set or fail iff the policy is set to fail.
+		// check.on_error has priority. If it is unset or unrecognized, fall
+		// back to policy.on_check_error.
 		switch ch.check.OnError {
 		case sdk.ScalingPolicyOnErrorIgnore:
 			return sdk.ScalingAction{}, nil

--- a/policy/check.go
+++ b/policy/check.go
@@ -92,8 +92,8 @@ func (ch *checkRunner) ensureCompiledSchedule() error {
 	return ch.scheduleErr
 }
 
-// getNewCountFromStrategy runs the check strategy and applies the effective
-// check or policy error-handling behavior to the result.
+// getNewCountFromStrategy runs the strategy for one check and returns a
+// scaling action, applying check-level and policy-level error handling.
 func (ch *checkRunner) getNewCountFromStrategy(ctx context.Context, currentCount int64,
 	metrics sdk.TimestampedMetrics) (sdk.ScalingAction, error) {
 	ch.log.Debug("calculating new count", "current count", currentCount)
@@ -104,8 +104,8 @@ func (ch *checkRunner) getNewCountFromStrategy(ctx context.Context, currentCount
 			"on_error", ch.check.OnError, "on_check_error",
 			ch.policy.OnCheckError, "error", err)
 
-		// check.on_error has priority. If it is unset or unrecognized, fall
-		// back to policy.on_check_error.
+		// Use recognized check-level on_error values first.
+		// For unset or unrecognized values, fall back to policy on_check_error.
 		switch ch.check.OnError {
 		case sdk.ScalingPolicyOnErrorIgnore:
 			return sdk.ScalingAction{}, nil
@@ -118,6 +118,8 @@ func (ch *checkRunner) getNewCountFromStrategy(ctx context.Context, currentCount
 				return sdk.ScalingAction{}, err
 			}
 
+			// Non-fatal fallback path: skip this check result and continue evaluating
+			// the remaining checks in the policy.
 			return sdk.ScalingAction{}, nil
 		}
 	}

--- a/policy/check_test.go
+++ b/policy/check_test.go
@@ -115,6 +115,24 @@ func TestCheckHandler_getNewCountFromMetrics(t *testing.T) {
 			expectedAction: sdk.ScalingAction{},
 		},
 		{
+			name:           "unexpected_check_on_error_falls_back_to_policy_fail",
+			checkOnError:   "unexpected",
+			runErr:         testErr,
+			policy:         testPolicyOnErrorFail,
+			metrics:        sdk.TimestampedMetrics{},
+			expError:       testErr,
+			expectedAction: sdk.ScalingAction{},
+		},
+		{
+			name:           "unexpected_check_on_error_falls_back_to_policy_ignore",
+			checkOnError:   "unexpected",
+			runErr:         testErr,
+			policy:         testPolicy,
+			metrics:        sdk.TimestampedMetrics{},
+			expError:       nil,
+			expectedAction: sdk.ScalingAction{},
+		},
+		{
 			name:           "fail_on_check_error_from_policy",
 			checkOnError:   "",
 			runErr:         testErr,
@@ -362,7 +380,7 @@ func TestCheckHandler_runCheckAndCapCount_OutsideSchedule(t *testing.T) {
 	must.Eq(t, 0, sr.runCalls, errMsg)
 }
 
-func TestCheckHandler_runCheckAndCapCount_IgnoresStrategyErrorsWithoutPanicking(t *testing.T) {
+func TestCheckHandler_runCheckAndCapCount_IgnoredStrategyErrorsContinueEvaluation(t *testing.T) {
 	nowFunc = func() time.Time {
 		return time.Date(2026, 1, 1, 10, 30, 0, 0, time.UTC)
 	}
@@ -393,15 +411,17 @@ func TestCheckHandler_runCheckAndCapCount_IgnoresStrategyErrorsWithoutPanicking(
 
 	action, err := runner.runCheckAndCapCount(context.Background(), 5, newQueryMetricsCache())
 	must.NoError(t, err)
-	must.Eq(t, sdk.ScalingAction{
-		Count:  1,
-		Reason: "capped count from 0 to 1 to stay within limits",
-		Meta: map[string]interface{}{
-			"nomad_autoscaler.count.capped":   true,
-			"nomad_autoscaler.count.original": int64(0),
-			"nomad_autoscaler.reason_history": []string{},
-		},
-	}, action)
+	must.Eq(t, sdk.ScaleDirectionNone, action.Direction)
+
+	// Side-effect sanity check: count is capped into policy bounds when the
+	// ignored strategy error returns an empty action.
+	must.Eq(t, testPolicy.Min, action.Count)
+	capped, ok := action.Meta["nomad_autoscaler.count.capped"].(bool)
+	must.True(t, ok)
+	must.True(t, capped)
+	original, ok := action.Meta["nomad_autoscaler.count.original"].(int64)
+	must.True(t, ok)
+	must.Eq(t, int64(0), original)
 	must.Eq(t, 1, ml.queryCalls)
 	must.Eq(t, 1, sr.runCalls)
 }

--- a/policy/check_test.go
+++ b/policy/check_test.go
@@ -106,6 +106,15 @@ func TestCheckHandler_getNewCountFromMetrics(t *testing.T) {
 			expectedAction: sdk.ScalingAction{},
 		},
 		{
+			name:           "default_on_check_error_from_policy",
+			checkOnError:   "",
+			runErr:         testErr,
+			policy:         testPolicy,
+			metrics:        sdk.TimestampedMetrics{},
+			expError:       nil,
+			expectedAction: sdk.ScalingAction{},
+		},
+		{
 			name:           "fail_on_check_error_from_policy",
 			checkOnError:   "",
 			runErr:         testErr,
@@ -351,4 +360,48 @@ func TestCheckHandler_runCheckAndCapCount_OutsideSchedule(t *testing.T) {
 	must.Eq(t, sdk.ScalingAction{}, action, errMsg)
 	must.Eq(t, 0, ml.queryCalls, errMsg)
 	must.Eq(t, 0, sr.runCalls, errMsg)
+}
+
+func TestCheckHandler_runCheckAndCapCount_IgnoresStrategyErrorsWithoutPanicking(t *testing.T) {
+	nowFunc = func() time.Time {
+		return time.Date(2026, 1, 1, 10, 30, 0, 0, time.UTC)
+	}
+
+	sr := &mockStrategyRunner{t: t, err: testErr}
+	ml := &mockAPMLooker{
+		t:       t,
+		query:   "query",
+		metrics: sdk.TimestampedMetrics{{Timestamp: nowFunc(), Value: 1}},
+		timeRange: sdk.TimeRange{
+			From: nowFunc().Add(-time.Minute),
+			To:   nowFunc(),
+		},
+	}
+
+	runner := newCheckRunner(&CheckRunnerConfig{
+		Log:            hclog.NewNullLogger(),
+		StrategyRunner: sr,
+		MetricsGetter:  ml,
+		Policy:         testPolicy,
+	}, &sdk.ScalingPolicyCheck{
+		Name:        "error-check",
+		Source:      "mock",
+		Query:       "query",
+		QueryWindow: time.Minute,
+		Strategy:    &sdk.ScalingPolicyStrategy{Name: "strategy"},
+	})
+
+	action, err := runner.runCheckAndCapCount(context.Background(), 5, newQueryMetricsCache())
+	must.NoError(t, err)
+	must.Eq(t, sdk.ScalingAction{
+		Count:  1,
+		Reason: "capped count from 0 to 1 to stay within limits",
+		Meta: map[string]interface{}{
+			"nomad_autoscaler.count.capped":   true,
+			"nomad_autoscaler.count.original": int64(0),
+			"nomad_autoscaler.reason_history": []string{},
+		},
+	}, action)
+	must.Eq(t, 1, ml.queryCalls)
+	must.Eq(t, 1, sr.runCalls)
 }

--- a/sdk/strategy.go
+++ b/sdk/strategy.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sdk

--- a/sdk/strategy.go
+++ b/sdk/strategy.go
@@ -88,7 +88,8 @@ func (d ScaleDirection) String() string {
 	}
 }
 
-// Canonicalize ensures Action has proper default values.
+// Canonicalize ensures the action is safe for downstream mutation by
+// initializing Meta when it is nil.
 func (a *ScalingAction) Canonicalize() {
 	a.ensureMeta()
 }

--- a/sdk/strategy.go
+++ b/sdk/strategy.go
@@ -90,15 +90,22 @@ func (d ScaleDirection) String() string {
 
 // Canonicalize ensures Action has proper default values.
 func (a *ScalingAction) Canonicalize() {
+	a.ensureMeta()
+}
+
+// ensureMeta initializes the Meta map if it is nil and returns it.
+func (a *ScalingAction) ensureMeta() map[string]interface{} {
 	if a.Meta == nil {
 		a.Meta = make(map[string]interface{})
 	}
+	return a.Meta
 }
 
 // SetDryRun marks the Action to be executed in dry-run mode. Dry-run mode is
 // indicated using Meta tags. A dry-run action doesn't modify the Target's
 // count value.
 func (a *ScalingAction) SetDryRun() {
+	a.ensureMeta()
 	a.Meta[strategyActionMetaKeyDryRun] = true
 	a.Meta[strategyActionMetaKeyDryRunCount] = a.Count
 	a.Count = StrategyActionMetaValueDryRunCount
@@ -111,6 +118,8 @@ func (a *ScalingAction) CapCount(min, max int64) {
 	if a.Count == StrategyActionMetaValueDryRunCount {
 		return
 	}
+
+	a.ensureMeta()
 
 	oldCount, newCount := a.Count, a.Count
 	if newCount < min {
@@ -129,6 +138,8 @@ func (a *ScalingAction) CapCount(min, max int64) {
 
 // PushReason updates the Reason value and stores previous Reason into Meta.
 func (a *ScalingAction) pushReason(r string) {
+	a.ensureMeta()
+
 	history := []string{}
 
 	// Check if we already have a reason stack in Meta

--- a/sdk/strategy.go
+++ b/sdk/strategy.go
@@ -46,7 +46,7 @@ type ScalingAction struct {
 	Direction ScaleDirection
 
 	// Meta
-	Meta map[string]interface{}
+	Meta map[string]any
 }
 
 // ScaleDirection is an identifier used by strategy plugins to identify how the
@@ -91,24 +91,25 @@ func (d ScaleDirection) String() string {
 // Canonicalize ensures the action is safe for downstream mutation by
 // initializing Meta when it is nil.
 func (a *ScalingAction) Canonicalize() {
-	a.ensureMeta()
+	if a.Meta == nil {
+		a.Meta = make(map[string]any)
+	}
 }
 
-// ensureMeta initializes the Meta map if it is nil and returns it.
-func (a *ScalingAction) ensureMeta() map[string]interface{} {
+// setMeta safely stores a metadata value, initializing Meta when needed.
+func (a *ScalingAction) setMeta(key string, val any) {
 	if a.Meta == nil {
-		a.Meta = make(map[string]interface{})
+		a.Meta = make(map[string]any)
 	}
-	return a.Meta
+	a.Meta[key] = val
 }
 
 // SetDryRun marks the Action to be executed in dry-run mode. Dry-run mode is
 // indicated using Meta tags. A dry-run action doesn't modify the Target's
 // count value.
 func (a *ScalingAction) SetDryRun() {
-	a.ensureMeta()
-	a.Meta[strategyActionMetaKeyDryRun] = true
-	a.Meta[strategyActionMetaKeyDryRunCount] = a.Count
+	a.setMeta(strategyActionMetaKeyDryRun, true)
+	a.setMeta(strategyActionMetaKeyDryRunCount, a.Count)
 	a.Count = StrategyActionMetaValueDryRunCount
 	a.Direction = ScaleDirectionNone
 }
@@ -120,7 +121,7 @@ func (a *ScalingAction) CapCount(min, max int64) {
 		return
 	}
 
-	a.ensureMeta()
+	a.Canonicalize()
 
 	oldCount, newCount := a.Count, a.Count
 	if newCount < min {
@@ -130,8 +131,8 @@ func (a *ScalingAction) CapCount(min, max int64) {
 	}
 
 	if newCount != oldCount {
-		a.Meta[strategyActionMetaKeyCountCapped] = true
-		a.Meta[strategyActionMetaKeyCountOriginal] = oldCount
+		a.setMeta(strategyActionMetaKeyCountCapped, true)
+		a.setMeta(strategyActionMetaKeyCountOriginal, oldCount)
 		a.pushReason(fmt.Sprintf("capped count from %d to %d to stay within limits", oldCount, newCount))
 		a.Count = newCount
 	}
@@ -139,8 +140,6 @@ func (a *ScalingAction) CapCount(min, max int64) {
 
 // PushReason updates the Reason value and stores previous Reason into Meta.
 func (a *ScalingAction) pushReason(r string) {
-	a.ensureMeta()
-
 	history := []string{}
 
 	// Check if we already have a reason stack in Meta
@@ -154,7 +153,7 @@ func (a *ScalingAction) pushReason(r string) {
 	if a.Reason != "" {
 		history = append(history, a.Reason)
 	}
-	a.Meta[strategyActionMetaKeyReasonHistory] = history
+	a.setMeta(strategyActionMetaKeyReasonHistory, history)
 	a.Reason = r
 }
 

--- a/sdk/strategy_test.go
+++ b/sdk/strategy_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sdk

--- a/sdk/strategy_test.go
+++ b/sdk/strategy_test.go
@@ -126,7 +126,7 @@ func TestAction_CapCount(t *testing.T) {
 				},
 				Reason: "capped count from 4 to 5 to stay within limits",
 			},
-			name: "empty input action canonicalized before capping",
+			name: "nil meta is canonicalized before capping",
 		},
 		{
 			inputAction: &ScalingAction{
@@ -222,7 +222,7 @@ func TestAction_pushReason(t *testing.T) {
 					"nomad_autoscaler.reason_history": []string{},
 				},
 			},
-			name: "no existing reason history",
+			name: "no existing reason history with nil meta",
 		},
 
 		{

--- a/sdk/strategy_test.go
+++ b/sdk/strategy_test.go
@@ -62,6 +62,19 @@ func TestAction_SetDryRun(t *testing.T) {
 		{
 			inputAction: &ScalingAction{
 				Count: 3,
+			},
+			expectedOutputAction: &ScalingAction{
+				Count: -1,
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.dry_run":       true,
+					"nomad_autoscaler.dry_run.count": int64(3),
+				},
+			},
+			name: "count greater than zero with nil meta",
+		},
+		{
+			inputAction: &ScalingAction{
+				Count: 3,
 				Meta:  map[string]interface{}{},
 			},
 			expectedOutputAction: &ScalingAction{
@@ -95,8 +108,25 @@ func TestAction_CapCount(t *testing.T) {
 			inputAction:          &ScalingAction{},
 			inputMin:             0,
 			inputMax:             0,
-			expectedOutputAction: &ScalingAction{},
+			expectedOutputAction: &ScalingAction{Meta: map[string]interface{}{}},
 			name:                 "empty input action",
+		},
+		{
+			inputAction: &ScalingAction{
+				Count: 4,
+			},
+			inputMin: 5,
+			inputMax: 10,
+			expectedOutputAction: &ScalingAction{
+				Count: 5,
+				Meta: map[string]interface{}{
+					"nomad_autoscaler.count.capped":   true,
+					"nomad_autoscaler.count.original": int64(4),
+					"nomad_autoscaler.reason_history": []string{},
+				},
+				Reason: "capped count from 4 to 5 to stay within limits",
+			},
+			name: "empty input action canonicalized before capping",
 		},
 		{
 			inputAction: &ScalingAction{
@@ -184,7 +214,7 @@ func TestAction_pushReason(t *testing.T) {
 		name                 string
 	}{
 		{
-			inputAction: &ScalingAction{Meta: map[string]interface{}{}},
+			inputAction: &ScalingAction{},
 			inputReason: "capped count from 0 to 1 to stay within limits",
 			expectedOutputAction: &ScalingAction{
 				Reason: "capped count from 0 to 1 to stay within limits",


### PR DESCRIPTION
This fixes a panic in policy evaluation caused by misconfigured strategy checks.

A strategy execution error on a non-fail path could fall through and return a
zero-value scaling action. That action then flowed into scaling-action mutators,
which made the panic path possible when metadata was nil.

With this change:
- non-fail strategy errors return cleanly through the normal error path
- ignored/default strategy failures no longer leak a zero-value action as a
  successful strategy result
- nil-Meta ScalingAction mutator behavior remains covered by regression tests

[Issue](https://github.com/hashicorp/nomad-autoscaler/issues/1276). [Ticket](https://hashicorp.atlassian.net/browse/NMD-1392?atlOrigin=eyJpIjoiNzJiM2NlYWNjMDhkNDVmMDg1NDZjOTlhZjZmMTc4MDMiLCJwIjoiaiJ9)
----------------------------------------------------------
**Testing**

job file:
```
job "test-scaling-bug-bad" {
  datacenters = ["dc1"]
  type        = "service"

  group "app" {
    count = 1

    scaling {
      enabled = true
      min     = 1
      max     = 5

      policy {
        cooldown            = "30s"
        evaluation_interval = "10s"

        check "cpu_check" {
          source = "nomad-apm"
          query  = "avg_cpu"

          strategy "threshold" {
            # intentionally wrong keys
            upper = 80
            lower = 10
            delta = 1
          }
        }
      }
    }

    task "sleep" {
      driver = "raw_exec"

      config {
        command = "/bin/sleep"
        args    = ["3600"]
      }

      resources {
        cpu    = 10
        memory = 10
      }
    }
  }
}
```
autoscaler-local.hcl 
```

log_level = "TRACE"

nomad {
  address = "http://127.0.0.1:4646"
}

apm "nomad-apm" {
  driver = "nomad-apm"
}

target "nomad-target" {
  driver = "nomad-target"
}

strategy "threshold" {
  driver = "threshold"
}

policy {
  source "nomad" {}
}
```

Logs when build and use autoscaler from the main branch: 

```

divyansh@Divyanshs-MacBook-Pro ~/Desktop/Hashicorp/nomad-autoscaler (main) % ./bin/nomad-autoscaler agent -config=./autoscaler-local.hcl
2026-04-17T22:10:21.226+0530 [INFO]  agent: starting Nomad Autoscaler agent
2026-04-17T22:10:21.226+0530 [INFO]  agent: Nomad Autoscaler agent configuration:
2026-04-17T22:10:21.226+0530 [INFO]  agent
2026-04-17T22:10:21.226+0530 [INFO]  agent:         Bind Addrs: 127.0.0.1
2026-04-17T22:10:21.226+0530 [INFO]  agent:  High Availability: false
2026-04-17T22:10:21.226+0530 [INFO]  agent:          Log Level: TRACE
2026-04-17T22:10:21.226+0530 [INFO]  agent:            Plugins: /Users/divyansh/Desktop/Hashicorp/nomad-autoscaler/plugins
2026-04-17T22:10:21.226+0530 [INFO]  agent:           Policies: 
2026-04-17T22:10:21.226+0530 [INFO]  agent:            Version: v0.4.10-dev (484e111)
2026-04-17T22:10:21.226+0530 [INFO]  agent
2026-04-17T22:10:21.226+0530 [INFO]  agent: Nomad Autoscaler agent started! Log data will stream in below
2026-04-17T22:10:21.227+0530 [INFO]  agent.http_server: server now listening for connections: address=127.0.0.1:8080
2026-04-17T22:10:21.305+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=nomad-apm
2026-04-17T22:10:21.305+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=pass-through
2026-04-17T22:10:21.305+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=target-value
2026-04-17T22:10:21.305+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=threshold
2026-04-17T22:10:21.305+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=fixed-value
2026-04-17T22:10:21.336+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=nomad-target
2026-04-17T22:10:21.336+0530 [INFO]  policy_manager: starting policy source: source=nomad
2026-04-17T22:10:21.336+0530 [TRACE] policy_manager:  starting to monitor policies
2026-04-17T22:10:21.336+0530 [DEBUG] nomad_policy_source: starting policy blocking query watcher
2026-04-17T22:10:21.338+0530 [TRACE] policy_manager: received policy IDs listing: num=2 policy_source=nomad
2026-04-17T22:10:21.339+0530 [TRACE] policy_manager: creating new handler: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 policy_source=nomad
2026-04-17T22:10:21.339+0530 [DEBUG] policy_manager: creating new policy handler: policy_id="&{dd09d0cf-965e-85f0-f544-87a020b64932 horizontal 0 1 5 true  30s 30s 10s <nil> [0x140003c8080] 0x140005b2330}"
2026-04-17T22:10:21.339+0530 [DEBUG] internal_plugin.nomad-target: starting job status handler: Job=test-scaling-bug
2026-04-17T22:10:21.340+0530 [TRACE] policy_manager.policy_handler: starting policy handler: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:10:21.341+0530 [TRACE] policy_manager: creating new handler: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 policy_source=nomad
2026-04-17T22:10:21.341+0530 [DEBUG] policy_manager: creating new policy handler: policy_id="&{c72a114c-5a5f-c098-95d1-704a0211e1a8 horizontal 0 1 5 true  30s 30s 10s <nil> [0x14000168200] 0x1400064a3a8}"
2026-04-17T22:10:21.341+0530 [DEBUG] internal_plugin.nomad-target: starting job status handler: Job=test-scaling-bug-bad
2026-04-17T22:10:21.342+0530 [TRACE] policy_manager.policy_handler: starting policy handler: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:10:31.341+0530 [DEBUG] policy_manager.policy_handler: received policy for evaluation: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:10:31.341+0530 [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:10:31.341+0530 [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" query=taskgroup_avg_cpu/app/test-scaling-bug@default source=nomad-apm
2026-04-17T22:10:31.341+0530 [DEBUG] internal_plugin.nomad-apm: expanded query: from=taskgroup_avg_cpu/app/test-scaling-bug@default to="&plugin.taskGroupQuery{metric:\"cpu\", namespace:\"default\", job:\"test-scaling-bug\", group:\"app\", operation:\"avg\"}"
2026-04-17T22:10:31.342+0530 [DEBUG] policy_manager.policy_handler: received policy for evaluation: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:10:31.342+0530 [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:10:31.342+0530 [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" query=taskgroup_avg_cpu/app/test-scaling-bug-bad@default source=nomad-apm
2026-04-17T22:10:31.342+0530 [DEBUG] internal_plugin.nomad-apm: expanded query: from=taskgroup_avg_cpu/app/test-scaling-bug-bad@default to="&plugin.taskGroupQuery{metric:\"cpu\", namespace:\"default\", job:\"test-scaling-bug-bad\", group:\"app\", operation:\"avg\"}"
2026-04-17T22:10:31.345+0530 [DEBUG] internal_plugin.nomad-apm: metrics found: num_data_points=1 query=taskgroup_avg_cpu/app/test-scaling-bug-bad@default
2026-04-17T22:10:31.346+0530 [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" current count=1
2026-04-17T22:10:31.346+0530 [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" strategy=threshold check=cpu_check
2026-04-17T22:10:31.346+0530 [DEBUG] internal_plugin.nomad-apm: metrics found: num_data_points=1 query=taskgroup_avg_cpu/app/test-scaling-bug@default
2026-04-17T22:10:31.346+0530 [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" current count=1
2026-04-17T22:10:31.346+0530 [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" strategy=threshold check=cpu_check
2026-04-17T22:10:31.346+0530 [WARN]  policy_manager.policy_handler.check_handler: failed to run check: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" check=cpu_check on_error="" on_check_error="" error="failed to execute strategy: missing required field, must have either \"lower_bound\" or \"upper_bound\""
2026-04-17T22:10:31.346+0530 [WARN]  policy_manager.policy_handler.check_handler: failed to run check: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" check=cpu_check on_error="" on_check_error="" error="failed to execute strategy: missing required field, must have either \"lower_bound\" or \"upper_bound\""
panic: assignment to entry in nil map

goroutine 87 [running]:
github.com/hashicorp/nomad-autoscaler/sdk.(*ScalingAction).CapCount(0x14000357a88, 0x1047c1058?, 0x140002a8cd0?)
        /Users/divyansh/Desktop/Hashicorp/nomad-autoscaler/sdk/strategy.go:123 +0x68
github.com/hashicorp/nomad-autoscaler/policy.(*checkRunner).runCheckAndCapCount(0x140000607e0, {0x1047c1058, 0x140002a8cd0}, 0x1, 0x1400014a080)
        /Users/divyansh/Desktop/Hashicorp/nomad-autoscaler/policy/check.go:279 +0x274
github.com/hashicorp/nomad-autoscaler/policy.(*Handler).calculateNewCount(0x140003ca160, {0x1047c1058, 0x140002a8cd0}, 0x1)
        /Users/divyansh/Desktop/Hashicorp/nomad-autoscaler/policy/handler.go:475 +0x20c
github.com/hashicorp/nomad-autoscaler/policy.(*Handler).Run(0x140003ca160, {0x1047c1058, 0x140002a8cd0})
        /Users/divyansh/Desktop/Hashicorp/nomad-autoscaler/policy/handler.go:318 +0x1fc
created by github.com/hashicorp/nomad-autoscaler/policy.(*Manager).processMessageAndUpdateHandlers in goroutine 56
        /Users/divyansh/Desktop/Hashicorp/nomad-autoscaler/policy/manager.go:300 +0x810
```

Logs when build the autoscaler from this branch:
```
divyansh@Divyanshs-MacBook-Pro ~/Desktop/Hashicorp/nomad-autoscaler (b-NMD-1362-guard-scalingAction-mutators-against-nil-meta) % ./bin/nomad-autoscaler agent -config=./autoscaler-local.hcl 
2026-04-17T22:23:45.081+0530 [INFO]  agent: starting Nomad Autoscaler agent
2026-04-17T22:23:45.081+0530 [INFO]  agent: Nomad Autoscaler agent configuration:
2026-04-17T22:23:45.081+0530 [INFO]  agent
2026-04-17T22:23:45.081+0530 [INFO]  agent:         Bind Addrs: 127.0.0.1
2026-04-17T22:23:45.081+0530 [INFO]  agent:  High Availability: false
2026-04-17T22:23:45.081+0530 [INFO]  agent:          Log Level: TRACE
2026-04-17T22:23:45.081+0530 [INFO]  agent:            Plugins: /Users/divyansh/Desktop/Hashicorp/nomad-autoscaler/plugins
2026-04-17T22:23:45.081+0530 [INFO]  agent:           Policies: 
2026-04-17T22:23:45.081+0530 [INFO]  agent:            Version: v0.4.10-dev (3e7d828)
2026-04-17T22:23:45.081+0530 [INFO]  agent
2026-04-17T22:23:45.081+0530 [INFO]  agent: Nomad Autoscaler agent started! Log data will stream in below
2026-04-17T22:23:45.081+0530 [INFO]  agent.http_server: server now listening for connections: address=127.0.0.1:8080
2026-04-17T22:23:45.162+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=nomad-target
2026-04-17T22:23:45.199+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=nomad-apm
2026-04-17T22:23:45.199+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=fixed-value
2026-04-17T22:23:45.199+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=pass-through
2026-04-17T22:23:45.199+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=target-value
2026-04-17T22:23:45.199+0530 [INFO]  agent.plugin_manager: successfully launched and dispensed plugin: plugin_name=threshold
2026-04-17T22:23:45.199+0530 [INFO]  policy_manager: starting policy source: source=nomad
2026-04-17T22:23:45.199+0530 [TRACE] policy_manager:  starting to monitor policies
2026-04-17T22:23:45.199+0530 [DEBUG] nomad_policy_source: starting policy blocking query watcher
2026-04-17T22:23:45.201+0530 [TRACE] policy_manager: received policy IDs listing: num=2 policy_source=nomad
2026-04-17T22:23:45.202+0530 [TRACE] policy_manager: creating new handler: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 policy_source=nomad
2026-04-17T22:23:45.202+0530 [DEBUG] policy_manager: creating new policy handler: policy_id="&{dd09d0cf-965e-85f0-f544-87a020b64932 horizontal 0 1 5 true  30s 30s 10s <nil> [0x14000294080] 0x140006900a8}"
2026-04-17T22:23:45.202+0530 [DEBUG] internal_plugin.nomad-target: starting job status handler: Job=test-scaling-bug
2026-04-17T22:23:45.203+0530 [TRACE] policy_manager.policy_handler: starting policy handler: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:23:45.204+0530 [TRACE] policy_manager: creating new handler: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 policy_source=nomad
2026-04-17T22:23:45.204+0530 [DEBUG] policy_manager: creating new policy handler: policy_id="&{c72a114c-5a5f-c098-95d1-704a0211e1a8 horizontal 0 1 5 true  30s 30s 10s <nil> [0x1400036e400] 0x140003a5938}"
2026-04-17T22:23:45.204+0530 [DEBUG] internal_plugin.nomad-target: starting job status handler: Job=test-scaling-bug-bad
2026-04-17T22:23:45.205+0530 [TRACE] policy_manager.policy_handler: starting policy handler: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:23:55.203+0530 [DEBUG] policy_manager.policy_handler: received policy for evaluation: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:23:55.203+0530 [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:23:55.203+0530 [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" query=taskgroup_avg_cpu/app/test-scaling-bug@default source=nomad-apm
2026-04-17T22:23:55.204+0530 [DEBUG] internal_plugin.nomad-apm: expanded query: from=taskgroup_avg_cpu/app/test-scaling-bug@default to="&plugin.taskGroupQuery{metric:\"cpu\", namespace:\"default\", job:\"test-scaling-bug\", group:\"app\", operation:\"avg\"}"
2026-04-17T22:23:55.205+0530 [DEBUG] policy_manager.policy_handler: received policy for evaluation: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:23:55.205+0530 [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:23:55.205+0530 [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" query=taskgroup_avg_cpu/app/test-scaling-bug-bad@default source=nomad-apm
2026-04-17T22:23:55.205+0530 [DEBUG] internal_plugin.nomad-apm: expanded query: from=taskgroup_avg_cpu/app/test-scaling-bug-bad@default to="&plugin.taskGroupQuery{metric:\"cpu\", namespace:\"default\", job:\"test-scaling-bug-bad\", group:\"app\", operation:\"avg\"}"
2026-04-17T22:23:55.216+0530 [DEBUG] internal_plugin.nomad-apm: metrics found: num_data_points=1 query=taskgroup_avg_cpu/app/test-scaling-bug-bad@default
2026-04-17T22:23:55.216+0530 [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" current count=1
2026-04-17T22:23:55.216+0530 [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" strategy=threshold check=cpu_check
2026-04-17T22:23:55.216+0530 [WARN]  policy_manager.policy_handler.check_handler: failed to run check: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" check=cpu_check on_error="" on_check_error="" error="failed to execute strategy: missing required field, must have either \"lower_bound\" or \"upper_bound\""
2026-04-17T22:23:55.216+0530 [DEBUG] policy_manager.policy_handler: check selected: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" direction=none count=1
2026-04-17T22:23:55.217+0530 [INFO]  policy_manager.policy_handler: calculating scaling target: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 from=1 to=1 reason="capped count from 0 to 1 to stay within limits" meta="map[nomad_autoscaler.count.capped:true nomad_autoscaler.count.original:0 nomad_autoscaler.reason_history:[]]"
2026-04-17T22:23:55.217+0530 [INFO]  policy_manager.policy_handler: skipping scaling, no action needed: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:23:55.217+0530 [DEBUG] internal_plugin.nomad-apm: metrics found: num_data_points=1 query=taskgroup_avg_cpu/app/test-scaling-bug@default
2026-04-17T22:23:55.217+0530 [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" current count=1
2026-04-17T22:23:55.217+0530 [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" strategy=threshold check=cpu_check
2026-04-17T22:23:55.217+0530 [WARN]  policy_manager.policy_handler.check_handler: failed to run check: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" check=cpu_check on_error="" on_check_error="" error="failed to execute strategy: missing required field, must have either \"lower_bound\" or \"upper_bound\""
2026-04-17T22:23:55.217+0530 [DEBUG] policy_manager.policy_handler: check selected: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" direction=none count=1
2026-04-17T22:23:55.218+0530 [INFO]  policy_manager.policy_handler: calculating scaling target: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 from=1 to=1 reason="capped count from 0 to 1 to stay within limits" meta="map[nomad_autoscaler.count.capped:true nomad_autoscaler.count.original:0 nomad_autoscaler.reason_history:[]]"
2026-04-17T22:23:55.218+0530 [INFO]  policy_manager.policy_handler: skipping scaling, no action needed: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:05.204+0530 [DEBUG] policy_manager.policy_handler: received policy for evaluation: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:05.204+0530 [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:05.204+0530 [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" query=taskgroup_avg_cpu/app/test-scaling-bug@default source=nomad-apm
2026-04-17T22:24:05.204+0530 [DEBUG] internal_plugin.nomad-apm: expanded query: from=taskgroup_avg_cpu/app/test-scaling-bug@default to="&plugin.taskGroupQuery{metric:\"cpu\", namespace:\"default\", job:\"test-scaling-bug\", group:\"app\", operation:\"avg\"}"
2026-04-17T22:24:05.205+0530 [DEBUG] policy_manager.policy_handler: received policy for evaluation: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:05.205+0530 [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:05.205+0530 [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" query=taskgroup_avg_cpu/app/test-scaling-bug-bad@default source=nomad-apm
2026-04-17T22:24:05.205+0530 [DEBUG] internal_plugin.nomad-apm: expanded query: from=taskgroup_avg_cpu/app/test-scaling-bug-bad@default to="&plugin.taskGroupQuery{metric:\"cpu\", namespace:\"default\", job:\"test-scaling-bug-bad\", group:\"app\", operation:\"avg\"}"
2026-04-17T22:24:05.208+0530 [DEBUG] internal_plugin.nomad-apm: metrics found: num_data_points=1 query=taskgroup_avg_cpu/app/test-scaling-bug@default
2026-04-17T22:24:05.209+0530 [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" current count=1
2026-04-17T22:24:05.209+0530 [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" strategy=threshold check=cpu_check
2026-04-17T22:24:05.209+0530 [DEBUG] internal_plugin.nomad-apm: metrics found: num_data_points=1 query=taskgroup_avg_cpu/app/test-scaling-bug-bad@default
2026-04-17T22:24:05.209+0530 [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" current count=1
2026-04-17T22:24:05.209+0530 [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" strategy=threshold check=cpu_check
2026-04-17T22:24:05.209+0530 [WARN]  policy_manager.policy_handler.check_handler: failed to run check: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" check=cpu_check on_error="" on_check_error="" error="failed to execute strategy: missing required field, must have either \"lower_bound\" or \"upper_bound\""
2026-04-17T22:24:05.210+0530 [DEBUG] policy_manager.policy_handler: check selected: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" direction=none count=1
2026-04-17T22:24:05.210+0530 [INFO]  policy_manager.policy_handler: calculating scaling target: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 from=1 to=1 reason="capped count from 0 to 1 to stay within limits" meta="map[nomad_autoscaler.count.capped:true nomad_autoscaler.count.original:0 nomad_autoscaler.reason_history:[]]"
2026-04-17T22:24:05.210+0530 [INFO]  policy_manager.policy_handler: skipping scaling, no action needed: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:05.210+0530 [WARN]  policy_manager.policy_handler.check_handler: failed to run check: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" check=cpu_check on_error="" on_check_error="" error="failed to execute strategy: missing required field, must have either \"lower_bound\" or \"upper_bound\""
2026-04-17T22:24:05.210+0530 [DEBUG] policy_manager.policy_handler: check selected: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" direction=none count=1
2026-04-17T22:24:05.210+0530 [INFO]  policy_manager.policy_handler: calculating scaling target: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 from=1 to=1 reason="capped count from 0 to 1 to stay within limits" meta="map[nomad_autoscaler.count.capped:true nomad_autoscaler.count.original:0 nomad_autoscaler.reason_history:[]]"
2026-04-17T22:24:05.210+0530 [INFO]  policy_manager.policy_handler: skipping scaling, no action needed: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:15.204+0530 [DEBUG] policy_manager.policy_handler: received policy for evaluation: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:15.204+0530 [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:15.204+0530 [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" query=taskgroup_avg_cpu/app/test-scaling-bug@default source=nomad-apm
2026-04-17T22:24:15.204+0530 [DEBUG] internal_plugin.nomad-apm: expanded query: from=taskgroup_avg_cpu/app/test-scaling-bug@default to="&plugin.taskGroupQuery{metric:\"cpu\", namespace:\"default\", job:\"test-scaling-bug\", group:\"app\", operation:\"avg\"}"
2026-04-17T22:24:15.205+0530 [DEBUG] policy_manager.policy_handler: received policy for evaluation: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:15.205+0530 [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:15.205+0530 [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" query=taskgroup_avg_cpu/app/test-scaling-bug-bad@default source=nomad-apm
2026-04-17T22:24:15.205+0530 [DEBUG] internal_plugin.nomad-apm: expanded query: from=taskgroup_avg_cpu/app/test-scaling-bug-bad@default to="&plugin.taskGroupQuery{metric:\"cpu\", namespace:\"default\", job:\"test-scaling-bug-bad\", group:\"app\", operation:\"avg\"}"
2026-04-17T22:24:15.213+0530 [DEBUG] internal_plugin.nomad-apm: metrics found: num_data_points=1 query=taskgroup_avg_cpu/app/test-scaling-bug@default
2026-04-17T22:24:15.213+0530 [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" current count=1
2026-04-17T22:24:15.213+0530 [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" strategy=threshold check=cpu_check
2026-04-17T22:24:15.214+0530 [WARN]  policy_manager.policy_handler.check_handler: failed to run check: check=cpu_check policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" check=cpu_check on_error="" on_check_error="" error="failed to execute strategy: missing required field, must have either \"lower_bound\" or \"upper_bound\""
2026-04-17T22:24:15.214+0530 [DEBUG] policy_manager.policy_handler: check selected: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" direction=none count=1
2026-04-17T22:24:15.214+0530 [INFO]  policy_manager.policy_handler: calculating scaling target: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 from=1 to=1 reason="capped count from 0 to 1 to stay within limits" meta="map[nomad_autoscaler.count.capped:true nomad_autoscaler.count.original:0 nomad_autoscaler.reason_history:[]]"
2026-04-17T22:24:15.214+0530 [INFO]  policy_manager.policy_handler: skipping scaling, no action needed: policy_id=dd09d0cf-965e-85f0-f544-87a020b64932 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
2026-04-17T22:24:15.214+0530 [DEBUG] internal_plugin.nomad-apm: metrics found: num_data_points=1 query=taskgroup_avg_cpu/app/test-scaling-bug-bad@default
2026-04-17T22:24:15.214+0530 [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" current count=1
2026-04-17T22:24:15.214+0530 [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" strategy=threshold check=cpu_check
2026-04-17T22:24:15.214+0530 [WARN]  policy_manager.policy_handler.check_handler: failed to run check: check=cpu_check policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad-apm strategy=threshold target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" check=cpu_check on_error="" on_check_error="" error="failed to execute strategy: missing required field, must have either \"lower_bound\" or \"upper_bound\""
2026-04-17T22:24:15.214+0530 [DEBUG] policy_manager.policy_handler: check selected: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" direction=none count=1
2026-04-17T22:24:15.214+0530 [INFO]  policy_manager.policy_handler: calculating scaling target: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]" policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 from=1 to=1 reason="capped count from 0 to 1 to stay within limits" meta="map[nomad_autoscaler.count.capped:true nomad_autoscaler.count.original:0 nomad_autoscaler.reason_history:[]]"
2026-04-17T22:24:15.214+0530 [INFO]  policy_manager.policy_handler: skipping scaling, no action needed: policy_id=c72a114c-5a5f-c098-95d1-704a0211e1a8 source=nomad target=nomad-target target_config="map[Group:app Job:test-scaling-bug-bad Namespace:default _nomad_autoscaler_grpc_timeout:7.5s]"
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

