### PR TITLE
Allow fixed-value autoscaling without APM availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ IMPROVEMENTS:
 * policy: Reuse identical APM query results within a single policy evaluation to avoid duplicate source requests for checks that share the same source, query, query window, and query window offset. [[GH-1252](https://github.com/hashicorp/nomad-autoscaler/pull/1252)] 
 * plugins: Fixed AWS-ASG plugin error handling so the underlying error is preserved when retry limit is reached. [[GH-1266](https://github.com/hashicorp/nomad-autoscaler/pull/1266)]
 
+BUG FIXES:
+* policy: Fixed-value strategy checks no longer depend on APM lookup or metric query results, allowing fixed-value scaling to proceed when the configured metrics source is unavailable. [[GH-1281](https://github.com/hashicorp/nomad-autoscaler/pull/1281)]
+
 ## 0.4.9 (January 6, 2026)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 * policy: Fixed a bug where misconfigured strategy checks could crash the autoscaler instead of following normal `on_error` and `on_check_error` behavior. [[GH-1275](https://github.com/hashicorp/nomad-autoscaler/pull/1275)]
-* policy: Fixed-value strategy checks no longer depend on APM lookup or metric query results, allowing fixed-value scaling to proceed when the configured metrics source is unavailable. [[GH-1281](https://github.com/hashicorp/nomad-autoscaler/pull/1281)]
+* policy: Fixed-value strategy checks no longer require APM source or query configuration. [[GH-1281](https://github.com/hashicorp/nomad-autoscaler/pull/1281)]
 
 ## 0.4.9 (January 6, 2026)
 

--- a/policy/check.go
+++ b/policy/check.go
@@ -12,6 +12,7 @@ import (
 
 	hclog "github.com/hashicorp/go-hclog"
 	metrics "github.com/hashicorp/go-metrics"
+	"github.com/hashicorp/nomad-autoscaler/plugins"
 	"github.com/hashicorp/nomad-autoscaler/plugins/apm"
 	"github.com/hashicorp/nomad-autoscaler/plugins/strategy"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
@@ -265,9 +266,14 @@ func (ch *checkRunner) runCheckAndCapCount(ctx context.Context, currentCount int
 		return sdk.ScalingAction{}, nil
 	}
 
-	metrics, err := ch.queryMetrics(ctx, cache)
-	if err != nil {
-		return sdk.ScalingAction{}, fmt.Errorf("failed to query source: %v", err)
+	metrics := sdk.TimestampedMetrics{}
+	// Fixed-value strategy does not require APM metrics; all other strategies still do.
+	if ch.check.Strategy.Name != plugins.InternalStrategyFixedValue {
+		var err error
+		metrics, err = ch.queryMetrics(ctx, cache)
+		if err != nil {
+			return sdk.ScalingAction{}, fmt.Errorf("failed to query source: %v", err)
+		}
 	}
 
 	action, err := ch.getNewCountFromStrategy(ctx, currentCount, metrics)

--- a/policy/check_test.go
+++ b/policy/check_test.go
@@ -428,10 +428,6 @@ func TestCheckHandler_runCheckAndCapCount_IgnoredStrategyErrorsContinueEvaluatio
 }
 
 func TestCheckHandler_runCheckAndCapCount_FixedValueSkipsAPMQuery(t *testing.T) {
-	nowFunc = func() time.Time {
-		return time.Time{}
-	}
-
 	sr := &mockStrategyRunner{t: t, count: 7, direction: sdk.ScaleDirectionUp}
 	ml := &mockAPMLooker{t: t, query: "query", err: testErr}
 
@@ -441,9 +437,8 @@ func TestCheckHandler_runCheckAndCapCount_FixedValueSkipsAPMQuery(t *testing.T) 
 		MetricsGetter:  ml,
 		Policy:         testPolicy,
 	}, &sdk.ScalingPolicyCheck{
-		Name:        "fixed-value-check",
-		Source:      "mock",
-		Query:       "query",
+		Name: "fixed-value-check",
+		// source and query are not needed for fixed-value, because the APM query should be skipped entirely.
 		QueryWindow: time.Minute,
 		Strategy: &sdk.ScalingPolicyStrategy{
 			Name: plugins.InternalStrategyFixedValue,
@@ -452,8 +447,8 @@ func TestCheckHandler_runCheckAndCapCount_FixedValueSkipsAPMQuery(t *testing.T) 
 
 	action, err := runner.runCheckAndCapCount(context.Background(), 5, newQueryMetricsCache())
 	must.NoError(t, err)
-	must.Eq(t, int64(7), action.Count)
-	must.Eq(t, sdk.ScaleDirectionUp, action.Direction)
-	must.Eq(t, 0, ml.queryCalls)
-	must.Eq(t, 1, sr.runCalls)
+	test.Eq(t, int64(7), action.Count)
+	test.Eq(t, sdk.ScaleDirectionUp, action.Direction)
+	test.Eq(t, 0, ml.queryCalls, test.Sprint("should not have made any apm queries"))
+	test.Eq(t, 1, sr.runCalls)
 }

--- a/policy/check_test.go
+++ b/policy/check_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/plugins"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
@@ -351,4 +352,35 @@ func TestCheckHandler_runCheckAndCapCount_OutsideSchedule(t *testing.T) {
 	must.Eq(t, sdk.ScalingAction{}, action, errMsg)
 	must.Eq(t, 0, ml.queryCalls, errMsg)
 	must.Eq(t, 0, sr.runCalls, errMsg)
+}
+
+func TestCheckHandler_runCheckAndCapCount_FixedValueSkipsAPMQuery(t *testing.T) {
+	nowFunc = func() time.Time {
+		return time.Time{}
+	}
+
+	sr := &mockStrategyRunner{t: t, count: 7, direction: sdk.ScaleDirectionUp}
+	ml := &mockAPMLooker{t: t, query: "query", err: testErr}
+
+	runner := newCheckRunner(&CheckRunnerConfig{
+		Log:            hclog.NewNullLogger(),
+		StrategyRunner: sr,
+		MetricsGetter:  ml,
+		Policy:         testPolicy,
+	}, &sdk.ScalingPolicyCheck{
+		Name:        "fixed-value-check",
+		Source:      "mock",
+		Query:       "query",
+		QueryWindow: time.Minute,
+		Strategy: &sdk.ScalingPolicyStrategy{
+			Name: plugins.InternalStrategyFixedValue,
+		},
+	})
+
+	action, err := runner.runCheckAndCapCount(context.Background(), 5, newQueryMetricsCache())
+	must.NoError(t, err)
+	must.Eq(t, int64(7), action.Count)
+	must.Eq(t, sdk.ScaleDirectionUp, action.Direction)
+	must.Eq(t, 0, ml.queryCalls)
+	must.Eq(t, 1, sr.runCalls)
 }

--- a/policy/handler.go
+++ b/policy/handler.go
@@ -14,6 +14,7 @@ import (
 
 	hclog "github.com/hashicorp/go-hclog"
 	metrics "github.com/hashicorp/go-metrics"
+	"github.com/hashicorp/nomad-autoscaler/plugins"
 	"github.com/hashicorp/nomad-autoscaler/plugins/apm"
 	"github.com/hashicorp/nomad-autoscaler/plugins/strategy"
 	targetpkg "github.com/hashicorp/nomad-autoscaler/plugins/target"
@@ -228,21 +229,34 @@ func (h *Handler) loadCheckRunners(policy *sdk.ScalingPolicy) ([]checker, error)
 
 	switch policy.Type {
 	case sdk.ScalingPolicyTypeCluster, sdk.ScalingPolicyTypeHorizontal:
-		for _, check := range policy.Checks {
-
-			s, err := h.pm.GetStrategyRunner(check.Strategy.Name)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get strategy %s: %w", check.Strategy.Name, err)
+		for i, check := range policy.Checks {
+			if check == nil {
+				return nil, fmt.Errorf("invalid check at index %d: check cannot be nil", i)
 			}
 
-			mg, err := h.pm.GetAPMLooker(check.Source)
+			if check.Strategy == nil || check.Strategy.Name == "" {
+				return nil, fmt.Errorf("invalid check %q: missing strategy value", check.Name)
+			}
+
+			strategyName := check.Strategy.Name
+
+			s, err := h.pm.GetStrategyRunner(strategyName)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get APM for strategy %s: %w", check.Strategy.Name, err)
+				return nil, fmt.Errorf("failed to get strategy %s: %w", strategyName, err)
+			}
+
+			var mg apm.Looker
+			// Fixed-value strategy does not need APM; keep looker nil and skip APM lookup.
+			if strategyName != plugins.InternalStrategyFixedValue {
+				mg, err = h.pm.GetAPMLooker(check.Source)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get APM for strategy %s: %w", strategyName, err)
+				}
 			}
 
 			runner := newCheckRunner(&CheckRunnerConfig{
 				Log: h.log.Named("check_handler").With("check", check.Name,
-					"source", check.Source, "strategy", check.Strategy.Name),
+					"source", check.Source, "strategy", strategyName),
 				StrategyRunner: s,
 				MetricsGetter:  mg,
 				Policy:         policy,

--- a/policy/handler_test.go
+++ b/policy/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/plugins"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
@@ -461,6 +462,39 @@ func TestHandler_Run_PolicyOutsideSchedule_Integration(t *testing.T) {
 			t.Errorf("expected only 'outside schedule window' logs, got: %q", line)
 		}
 	}
+}
+
+func TestHandler_applyPolicyState_FixedValueDoesNotRequireAPM(t *testing.T) {
+	fixedValuePolicy := &sdk.ScalingPolicy{
+		ID:                 "fixed-value-policy",
+		Type:               sdk.ScalingPolicyTypeHorizontal,
+		EvaluationInterval: time.Second,
+		Target:             &sdk.ScalingPolicyTarget{Name: "mock-target", Config: map[string]string{}},
+		Checks: []*sdk.ScalingPolicyCheck{
+			{
+				Name:   "check-fixed-value",
+				Source: "missing-apm",
+				Strategy: &sdk.ScalingPolicyStrategy{
+					Name:   plugins.InternalStrategyFixedValue,
+					Config: map[string]string{"value": "3"},
+				},
+			},
+		},
+	}
+
+	h := &Handler{
+		log: hclog.NewNullLogger(),
+		pm: &MockDependencyGetter{
+			APMLookerErr: testErr,
+			StrategyRunner: &mockStrategyRunner{
+				t: t,
+			},
+		},
+	}
+
+	err := h.applyPolicyState(fixedValuePolicy)
+	must.NoError(t, err)
+	must.Eq(t, 1, len(h.checkRunners))
 }
 
 var policy = &sdk.ScalingPolicy{

--- a/policy/handler_test.go
+++ b/policy/handler_test.go
@@ -472,8 +472,8 @@ func TestHandler_applyPolicyState_FixedValueDoesNotRequireAPM(t *testing.T) {
 		Target:             &sdk.ScalingPolicyTarget{Name: "mock-target", Config: map[string]string{}},
 		Checks: []*sdk.ScalingPolicyCheck{
 			{
-				Name:   "check-fixed-value",
-				Source: "missing-apm",
+				Name: "check-fixed-value",
+				// source and query are not needed for fixed-value, because the APM query should be skipped entirely.
 				Strategy: &sdk.ScalingPolicyStrategy{
 					Name:   plugins.InternalStrategyFixedValue,
 					Config: map[string]string{"value": "3"},


### PR DESCRIPTION

- Remove APM dependency from fixed-value strategy scaling checks
- We were checking whether the user provided the APM source and query; however, we weren't actually using the query values since the required action was already determined in case of fixed-value.

[Ticket](https://hashicorp.atlassian.net/browse/NMD-1397?atlOrigin=eyJpIjoiYWVhODA1OTM0NTU2NGI3NGIxNTM0N2IwMTE2M2UxMDEiLCJwIjoiaiJ9)

**Testing**
```
job "fixed-value-no-apm-test" {
  datacenters = ["dc1"]
  type = "service"

  group "app" {
    count = 1

    scaling {
      enabled = true
      min     = 1
      max     = 5

      policy {
        cooldown            = "30s"
        evaluation_interval = "10s"

        check "force-count-3" {
          # Now source and query not required in case of fix-value strategies
          # source = "prometheus-not-configured"
          # query  = "this_query_should_be_ignored_for_fixed_value"

          strategy "fixed-value" {
            value = 3
          }
        }
      }
    }

task "sleep" {
  driver = "docker"

  config {
    image   = "busybox:1"
    command = "sleep"
    args    = ["3600"]
  }

  resources {
    cpu    = 50
    memory = 64
  }
}
  }
}
```
**Eairlier:** failed to get APM for strategy fixed-value: apm plugin "prometheus-not-configured" not initialized.
**After this PR fix:**  No error; simply it will scale to 3 instances.

-----------------------------------------------------------------
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

