### PR TITLE
fix: honor requested num in IdentifyScaleInNodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
 * build: Updated the Alpine container image used to `alpine:3.23` [[GH-1272](https://github.com/hashicorp/nomad-autoscaler/pull/1272)]
 * policy: Reuse identical APM query results within a single policy evaluation to avoid duplicate source requests for checks that share the same source, query, query window, and query window offset. [[GH-1252](https://github.com/hashicorp/nomad-autoscaler/pull/1252)] 
 * plugins: Fixed AWS-ASG plugin error handling so the underlying error is preserved when retry limit is reached. [[GH-1266](https://github.com/hashicorp/nomad-autoscaler/pull/1266)]
+* scaleutils: Fix scale-in node identification to honor requested num and avoid selecting all eligible nodes. [[GH-1282](https://github.com/hashicorp/nomad-autoscaler/pull/1282)]
 
 ## 0.4.9 (January 6, 2026)
 

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package scaleutils

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -27,6 +27,8 @@ type nodeDrainer interface {
 	MonitorDrain(ctx context.Context, nodeID string, index uint64, ignoreSys bool) <-chan *api.MonitorMessage
 }
 
+var errInvalidScaleInNum = errors.New("number of nodes requested for removal must be greater than zero")
+
 // ClusterScaleUtils provides common functionality when performing horizontal
 // cluster scaling evaluations and actions.
 type ClusterScaleUtils struct {
@@ -117,7 +119,7 @@ func (c *ClusterScaleUtils) RunPreScaleInTasksWithRemoteCheck(ctx context.Contex
 	}
 
 	if num < 1 {
-		return nil, fmt.Errorf("number of nodes requested for removal must be greater than zero")
+		return nil, errInvalidScaleInNum
 	}
 
 	// Find nodes in Nomad that match the node filtering criteria.
@@ -199,7 +201,7 @@ func (c *ClusterScaleUtils) IdentifyScaleInNodes(cfg map[string]string, num int)
 	}
 
 	if num < 1 {
-		return nil, fmt.Errorf("number of nodes requested for removal must be greater than zero")
+		return nil, errInvalidScaleInNum
 	}
 
 	// If the caller has requested more nodes than we have available once

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -167,6 +167,7 @@ func (c *ClusterScaleUtils) RunPreScaleInTasksWithRemoteCheck(ctx context.Contex
 	if num > len(filteredNodes) {
 		c.log.Warn("can only identify portion of requested nodes for removal",
 			"requested", num, "available", len(filteredNodes))
+		num = len(filteredNodes)
 	}
 
 	// Select which nodes to drain and terminate based on the policy's
@@ -195,13 +196,13 @@ func (c *ClusterScaleUtils) RunPreScaleInTasksWithRemoteCheck(ctx context.Contex
 
 func (c *ClusterScaleUtils) IdentifyScaleInNodes(cfg map[string]string, num int) ([]*api.NodeListStub, error) {
 
+	if num < 1 {
+		return nil, errInvalidScaleInNum
+	}
+
 	filteredNodes, err := c.identifyEligibleScaleInNodes(cfg)
 	if err != nil {
 		return nil, err
-	}
-
-	if num < 1 {
-		return nil, errInvalidScaleInNum
 	}
 
 	// If the caller has requested more nodes than we have available once

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -116,8 +116,12 @@ func (c *ClusterScaleUtils) RunPreScaleInTasksWithRemoteCheck(ctx context.Contex
 		return nil, errors.New("required ClusterNodeIDLookupFunc not set")
 	}
 
+	if num < 1 {
+		return nil, fmt.Errorf("number of nodes requested for removal must be greater than zero")
+	}
+
 	// Find nodes in Nomad that match the node filtering criteria.
-	nodes, err := c.IdentifyScaleInNodes(cfg, num)
+	nodes, err := c.identifyEligibleScaleInNodes(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -189,6 +193,34 @@ func (c *ClusterScaleUtils) RunPreScaleInTasksWithRemoteCheck(ctx context.Contex
 
 func (c *ClusterScaleUtils) IdentifyScaleInNodes(cfg map[string]string, num int) ([]*api.NodeListStub, error) {
 
+	filteredNodes, err := c.identifyEligibleScaleInNodes(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if num < 1 {
+		return nil, fmt.Errorf("number of nodes requested for removal must be greater than zero")
+	}
+
+	// If the caller has requested more nodes than we have available once
+	// filtered, adjust the value. This shouldn't cause the whole scaling
+	// action to fail, but we should warn.
+	if num > len(filteredNodes) {
+		c.log.Warn("can only identify portion of requested nodes for removal",
+			"requested", num, "available", len(filteredNodes))
+		num = len(filteredNodes)
+	}
+
+	selectedNodes, err := c.SelectScaleInNodes(filteredNodes, cfg, num)
+	if err != nil {
+		return nil, err
+	}
+
+	return selectedNodes, nil
+}
+
+func (c *ClusterScaleUtils) identifyEligibleScaleInNodes(cfg map[string]string) ([]*api.NodeListStub, error) {
+
 	poolID, err := nodepool.NewClusterNodePoolIdentifier(cfg)
 	if err != nil {
 		return nil, err
@@ -234,14 +266,6 @@ func (c *ClusterScaleUtils) IdentifyScaleInNodes(cfg map[string]string, num int)
 	// Ensure we have not filtered out all the available nodes.
 	if len(filteredNodes) == 0 {
 		return nil, fmt.Errorf("no nodes unfiltered for %s with value %s", poolID.Key(), poolID.Value())
-	}
-
-	// If the caller has requested more nodes than we have available once
-	// filtered, adjust the value. This shouldn't cause the whole scaling
-	// action to fail, but we should warn.
-	if num > len(filteredNodes) {
-		c.log.Warn("can only identify portion of requested nodes for removal",
-			"requested", num, "available", len(filteredNodes))
 	}
 
 	return filteredNodes, nil

--- a/sdk/helper/scaleutils/cluster_scalein_test.go
+++ b/sdk/helper/scaleutils/cluster_scalein_test.go
@@ -21,21 +21,21 @@ func TestClusterScaleUtils_IdentifyScaleInNodes(t *testing.T) {
 		inputNum            int
 		expectedNodeCount   int
 		expectedFirstNodeID string
-		expectedError       string
+		expectedError       error
 		name                string
 	}{
 		{
 			inputNum:            1,
 			expectedNodeCount:   1,
 			expectedFirstNodeID: "node-a",
-			expectedError:       "",
+			expectedError:       nil,
 			name:                "honors requested num",
 		},
 		{
 			inputNum:            0,
 			expectedNodeCount:   0,
 			expectedFirstNodeID: "",
-			expectedError:       "number of nodes requested for removal must be greater than zero",
+			expectedError:       errInvalidScaleInNum,
 			name:                "rejects non positive num",
 		},
 	}
@@ -45,15 +45,15 @@ func TestClusterScaleUtils_IdentifyScaleInNodes(t *testing.T) {
 			cu := newTestClusterScaleUtils(t)
 			nodes, err := cu.IdentifyScaleInNodes(testScaleInCfg(), tc.inputNum)
 
-			if tc.expectedError != "" {
+			if tc.expectedError != nil {
 				must.Error(t, err)
 				must.Nil(t, nodes)
-				must.ErrorContains(t, err, tc.expectedError)
+				must.ErrorIs(t, err, tc.expectedError)
 				return
 			}
 
 			must.NoError(t, err)
-			must.Eq(t, tc.expectedNodeCount, len(nodes))
+			must.Len(t, tc.expectedNodeCount, nodes)
 			must.Eq(t, tc.expectedFirstNodeID, nodes[0].ID)
 		})
 	}
@@ -65,7 +65,7 @@ func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheck(t *testing.T) {
 		inputRemoteIDs        []string
 		expectedResourceID    NodeResourceID
 		expectedResourceCount int
-		expectedError         string
+		expectedError         error
 		name                  string
 	}{
 		{
@@ -73,7 +73,7 @@ func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheck(t *testing.T) {
 			inputRemoteIDs:        []string{"node-b"},
 			expectedResourceID:    NodeResourceID{NomadNodeID: "node-b", RemoteResourceID: "node-b"},
 			expectedResourceCount: 1,
-			expectedError:         "",
+			expectedError:         nil,
 			name:                  "uses all eligible nodes before remote filtering",
 		},
 		{
@@ -81,7 +81,7 @@ func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheck(t *testing.T) {
 			inputRemoteIDs:        []string{"node-a"},
 			expectedResourceID:    NodeResourceID{},
 			expectedResourceCount: 0,
-			expectedError:         "number of nodes requested for removal must be greater than zero",
+			expectedError:         errInvalidScaleInNum,
 			name:                  "rejects non positive num",
 		},
 	}
@@ -91,15 +91,15 @@ func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheck(t *testing.T) {
 			cu := newTestClusterScaleUtilsWithRemoteCheck(t)
 			ids, err := cu.RunPreScaleInTasksWithRemoteCheck(t.Context(), testScaleInCfg(), tc.inputRemoteIDs, tc.inputNum)
 
-			if tc.expectedError != "" {
+			if tc.expectedError != nil {
 				must.Error(t, err)
 				must.Nil(t, ids)
-				must.ErrorContains(t, err, tc.expectedError)
+				must.ErrorIs(t, err, tc.expectedError)
 				return
 			}
 
 			must.NoError(t, err)
-			must.Eq(t, tc.expectedResourceCount, len(ids))
+			must.Len(t, tc.expectedResourceCount, ids)
 			must.Eq(t, tc.expectedResourceID, ids[0])
 		})
 	}
@@ -182,8 +182,9 @@ func testNomadScaleInServer(t *testing.T) *httptest.Server {
 		case "/v1/nodes":
 			must.NoError(t, json.NewEncoder(w).Encode(nodes))
 		case "/v1/node/node-a", "/v1/node/node-b":
-			n, ok := nodeInfo[r.URL.Path[len("/v1/node/"):]]
-			must.True(t, ok)
+			nID := r.URL.Path[len("/v1/node/"):]
+			n, ok := nodeInfo[nID]
+			must.True(t, ok, must.Sprintf("unknown node: %q", nID))
 			must.NoError(t, json.NewEncoder(w).Encode(n))
 		default:
 			w.WriteHeader(http.StatusNotFound)

--- a/sdk/helper/scaleutils/cluster_scalein_test.go
+++ b/sdk/helper/scaleutils/cluster_scalein_test.go
@@ -13,8 +13,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
 	"github.com/hashicorp/nomad/api"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 func TestClusterScaleUtils_IdentifyScaleInNodes(t *testing.T) {
@@ -47,15 +46,15 @@ func TestClusterScaleUtils_IdentifyScaleInNodes(t *testing.T) {
 			nodes, err := cu.IdentifyScaleInNodes(testScaleInCfg(), tc.inputNum)
 
 			if tc.expectedError != "" {
-				require.Error(t, err)
-				require.Nil(t, nodes)
-				assert.EqualError(t, err, tc.expectedError)
+				must.Error(t, err)
+				must.Nil(t, nodes)
+				must.ErrorContains(t, err, tc.expectedError)
 				return
 			}
 
-			require.NoError(t, err)
-			require.Len(t, nodes, tc.expectedNodeCount)
-			assert.Equal(t, tc.expectedFirstNodeID, nodes[0].ID)
+			must.NoError(t, err)
+			must.Eq(t, tc.expectedNodeCount, len(nodes))
+			must.Eq(t, tc.expectedFirstNodeID, nodes[0].ID)
 		})
 	}
 }
@@ -90,18 +89,18 @@ func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheck(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cu := newTestClusterScaleUtilsWithRemoteCheck(t)
-			ids, err := cu.RunPreScaleInTasksWithRemoteCheck(context.Background(), testScaleInCfg(), tc.inputRemoteIDs, tc.inputNum)
+			ids, err := cu.RunPreScaleInTasksWithRemoteCheck(t.Context(), testScaleInCfg(), tc.inputRemoteIDs, tc.inputNum)
 
 			if tc.expectedError != "" {
-				require.Error(t, err)
-				require.Nil(t, ids)
-				assert.EqualError(t, err, tc.expectedError)
+				must.Error(t, err)
+				must.Nil(t, ids)
+				must.ErrorContains(t, err, tc.expectedError)
 				return
 			}
 
-			require.NoError(t, err)
-			require.Len(t, ids, tc.expectedResourceCount)
-			assert.Equal(t, tc.expectedResourceID, ids[0])
+			must.NoError(t, err)
+			must.Eq(t, tc.expectedResourceCount, len(ids))
+			must.Eq(t, tc.expectedResourceID, ids[0])
 		})
 	}
 }
@@ -181,11 +180,11 @@ func testNomadScaleInServer(t *testing.T) *httptest.Server {
 
 		switch r.URL.Path {
 		case "/v1/nodes":
-			require.NoError(t, json.NewEncoder(w).Encode(nodes))
+			must.NoError(t, json.NewEncoder(w).Encode(nodes))
 		case "/v1/node/node-a", "/v1/node/node-b":
 			n, ok := nodeInfo[r.URL.Path[len("/v1/node/"):]]
-			require.True(t, ok)
-			require.NoError(t, json.NewEncoder(w).Encode(n))
+			must.True(t, ok)
+			must.NoError(t, json.NewEncoder(w).Encode(n))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -199,6 +198,6 @@ func testNomadClient(t *testing.T, address string) *api.Client {
 	cfg.Address = address
 
 	client, err := api.NewClient(cfg)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	return client
 }

--- a/sdk/helper/scaleutils/cluster_scalein_test.go
+++ b/sdk/helper/scaleutils/cluster_scalein_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package scaleutils

--- a/sdk/helper/scaleutils/cluster_scalein_test.go
+++ b/sdk/helper/scaleutils/cluster_scalein_test.go
@@ -17,30 +17,113 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClusterScaleUtils_IdentifyScaleInNodesHonorsNum(t *testing.T) {
+func TestClusterScaleUtils_IdentifyScaleInNodes(t *testing.T) {
+	testCases := []struct {
+		inputNum            int
+		expectedNodeCount   int
+		expectedFirstNodeID string
+		expectedError       string
+		name                string
+	}{
+		{
+			inputNum:            1,
+			expectedNodeCount:   1,
+			expectedFirstNodeID: "node-a",
+			expectedError:       "",
+			name:                "honors requested num",
+		},
+		{
+			inputNum:            0,
+			expectedNodeCount:   0,
+			expectedFirstNodeID: "",
+			expectedError:       "number of nodes requested for removal must be greater than zero",
+			name:                "rejects non positive num",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cu := newTestClusterScaleUtils(t)
+			nodes, err := cu.IdentifyScaleInNodes(testScaleInCfg(), tc.inputNum)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Nil(t, nodes)
+				assert.EqualError(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, nodes, tc.expectedNodeCount)
+			assert.Equal(t, tc.expectedFirstNodeID, nodes[0].ID)
+		})
+	}
+}
+
+func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheck(t *testing.T) {
+	testCases := []struct {
+		inputNum              int
+		inputRemoteIDs        []string
+		expectedResourceID    NodeResourceID
+		expectedResourceCount int
+		expectedError         string
+		name                  string
+	}{
+		{
+			inputNum:              1,
+			inputRemoteIDs:        []string{"node-b"},
+			expectedResourceID:    NodeResourceID{NomadNodeID: "node-b", RemoteResourceID: "node-b"},
+			expectedResourceCount: 1,
+			expectedError:         "",
+			name:                  "uses all eligible nodes before remote filtering",
+		},
+		{
+			inputNum:              0,
+			inputRemoteIDs:        []string{"node-a"},
+			expectedResourceID:    NodeResourceID{},
+			expectedResourceCount: 0,
+			expectedError:         "number of nodes requested for removal must be greater than zero",
+			name:                  "rejects non positive num",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cu := newTestClusterScaleUtilsWithRemoteCheck(t)
+			ids, err := cu.RunPreScaleInTasksWithRemoteCheck(context.Background(), testScaleInCfg(), tc.inputRemoteIDs, tc.inputNum)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Nil(t, ids)
+				assert.EqualError(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, ids, tc.expectedResourceCount)
+			assert.Equal(t, tc.expectedResourceID, ids[0])
+		})
+	}
+}
+
+func newTestClusterScaleUtils(t *testing.T) *ClusterScaleUtils {
+	t.Helper()
+
 	server := testNomadScaleInServer(t)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client := testNomadClient(t, server.URL)
-	cu := &ClusterScaleUtils{
+	return &ClusterScaleUtils{
 		log:    hclog.NewNullLogger(),
 		client: client,
 	}
-
-	cfg := map[string]string{
-		sdk.TargetConfigKeyClass:             "pool-a",
-		sdk.TargetConfigNodeSelectorStrategy: sdk.TargetNodeSelectorStrategyNewestCreateIndex,
-	}
-
-	nodes, err := cu.IdentifyScaleInNodes(cfg, 1)
-	require.NoError(t, err)
-	require.Len(t, nodes, 1)
-	assert.Equal(t, "node-a", nodes[0].ID)
 }
 
-func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheckUsesAllEligibleNodes(t *testing.T) {
+func newTestClusterScaleUtilsWithRemoteCheck(t *testing.T) *ClusterScaleUtils {
+	t.Helper()
+
 	server := testNomadScaleInServer(t)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client := testNomadClient(t, server.URL)
 	md := newMockDrainer()
@@ -53,7 +136,7 @@ func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheckUsesAllEligibleNodes
 		return outCh
 	}
 
-	cu := &ClusterScaleUtils{
+	return &ClusterScaleUtils{
 		log:    hclog.NewNullLogger(),
 		client: client,
 		ClusterNodeIDLookupFunc: func(node *api.Node) (string, error) {
@@ -61,61 +144,13 @@ func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheckUsesAllEligibleNodes
 		},
 		drainer: md,
 	}
-
-	cfg := map[string]string{
-		sdk.TargetConfigKeyClass:             "pool-a",
-		sdk.TargetConfigNodeSelectorStrategy: sdk.TargetNodeSelectorStrategyNewestCreateIndex,
-	}
-
-	ids, err := cu.RunPreScaleInTasksWithRemoteCheck(context.Background(), cfg, []string{"node-b"}, 1)
-	require.NoError(t, err)
-	require.Len(t, ids, 1)
-	assert.Equal(t, NodeResourceID{NomadNodeID: "node-b", RemoteResourceID: "node-b"}, ids[0])
 }
 
-func TestClusterScaleUtils_IdentifyScaleInNodesRejectsNonPositiveNum(t *testing.T) {
-	server := testNomadScaleInServer(t)
-	defer server.Close()
-
-	client := testNomadClient(t, server.URL)
-	cu := &ClusterScaleUtils{
-		log:    hclog.NewNullLogger(),
-		client: client,
-	}
-
-	cfg := map[string]string{
+func testScaleInCfg() map[string]string {
+	return map[string]string{
 		sdk.TargetConfigKeyClass:             "pool-a",
 		sdk.TargetConfigNodeSelectorStrategy: sdk.TargetNodeSelectorStrategyNewestCreateIndex,
 	}
-
-	nodes, err := cu.IdentifyScaleInNodes(cfg, 0)
-	require.Error(t, err)
-	require.Nil(t, nodes)
-	assert.EqualError(t, err, "number of nodes requested for removal must be greater than zero")
-}
-
-func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheckRejectsNonPositiveNum(t *testing.T) {
-	server := testNomadScaleInServer(t)
-	defer server.Close()
-
-	client := testNomadClient(t, server.URL)
-	cu := &ClusterScaleUtils{
-		log:    hclog.NewNullLogger(),
-		client: client,
-		ClusterNodeIDLookupFunc: func(node *api.Node) (string, error) {
-			return node.ID, nil
-		},
-	}
-
-	cfg := map[string]string{
-		sdk.TargetConfigKeyClass:             "pool-a",
-		sdk.TargetConfigNodeSelectorStrategy: sdk.TargetNodeSelectorStrategyNewestCreateIndex,
-	}
-
-	ids, err := cu.RunPreScaleInTasksWithRemoteCheck(context.Background(), cfg, []string{"node-a"}, 0)
-	require.Error(t, err)
-	require.Nil(t, ids)
-	assert.EqualError(t, err, "number of nodes requested for removal must be greater than zero")
 }
 
 func testNomadScaleInServer(t *testing.T) *httptest.Server {

--- a/sdk/helper/scaleutils/cluster_scalein_test.go
+++ b/sdk/helper/scaleutils/cluster_scalein_test.go
@@ -1,0 +1,169 @@
+// Copyright IBM Corp. 2020, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package scaleutils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterScaleUtils_IdentifyScaleInNodesHonorsNum(t *testing.T) {
+	server := testNomadScaleInServer(t)
+	defer server.Close()
+
+	client := testNomadClient(t, server.URL)
+	cu := &ClusterScaleUtils{
+		log:    hclog.NewNullLogger(),
+		client: client,
+	}
+
+	cfg := map[string]string{
+		sdk.TargetConfigKeyClass:             "pool-a",
+		sdk.TargetConfigNodeSelectorStrategy: sdk.TargetNodeSelectorStrategyNewestCreateIndex,
+	}
+
+	nodes, err := cu.IdentifyScaleInNodes(cfg, 1)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, "node-a", nodes[0].ID)
+}
+
+func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheckUsesAllEligibleNodes(t *testing.T) {
+	server := testNomadScaleInServer(t)
+	defer server.Close()
+
+	client := testNomadClient(t, server.URL)
+	md := newMockDrainer()
+	md.drainerMockFunc = func(_ string, _ *api.DrainOptions, _ *api.WriteOptions) (*api.NodeDrainUpdateResponse, error) {
+		return &api.NodeDrainUpdateResponse{EvalCreateIndex: 1}, nil
+	}
+	md.monitorMockFunc = func(_ context.Context, _ string, _ uint64, _ bool) <-chan *api.MonitorMessage {
+		outCh := make(chan *api.MonitorMessage)
+		close(outCh)
+		return outCh
+	}
+
+	cu := &ClusterScaleUtils{
+		log:    hclog.NewNullLogger(),
+		client: client,
+		ClusterNodeIDLookupFunc: func(node *api.Node) (string, error) {
+			return node.ID, nil
+		},
+		drainer: md,
+	}
+
+	cfg := map[string]string{
+		sdk.TargetConfigKeyClass:             "pool-a",
+		sdk.TargetConfigNodeSelectorStrategy: sdk.TargetNodeSelectorStrategyNewestCreateIndex,
+	}
+
+	ids, err := cu.RunPreScaleInTasksWithRemoteCheck(context.Background(), cfg, []string{"node-b"}, 1)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	assert.Equal(t, NodeResourceID{NomadNodeID: "node-b", RemoteResourceID: "node-b"}, ids[0])
+}
+
+func TestClusterScaleUtils_IdentifyScaleInNodesRejectsNonPositiveNum(t *testing.T) {
+	server := testNomadScaleInServer(t)
+	defer server.Close()
+
+	client := testNomadClient(t, server.URL)
+	cu := &ClusterScaleUtils{
+		log:    hclog.NewNullLogger(),
+		client: client,
+	}
+
+	cfg := map[string]string{
+		sdk.TargetConfigKeyClass:             "pool-a",
+		sdk.TargetConfigNodeSelectorStrategy: sdk.TargetNodeSelectorStrategyNewestCreateIndex,
+	}
+
+	nodes, err := cu.IdentifyScaleInNodes(cfg, 0)
+	require.Error(t, err)
+	require.Nil(t, nodes)
+	assert.EqualError(t, err, "number of nodes requested for removal must be greater than zero")
+}
+
+func TestClusterScaleUtils_RunPreScaleInTasksWithRemoteCheckRejectsNonPositiveNum(t *testing.T) {
+	server := testNomadScaleInServer(t)
+	defer server.Close()
+
+	client := testNomadClient(t, server.URL)
+	cu := &ClusterScaleUtils{
+		log:    hclog.NewNullLogger(),
+		client: client,
+		ClusterNodeIDLookupFunc: func(node *api.Node) (string, error) {
+			return node.ID, nil
+		},
+	}
+
+	cfg := map[string]string{
+		sdk.TargetConfigKeyClass:             "pool-a",
+		sdk.TargetConfigNodeSelectorStrategy: sdk.TargetNodeSelectorStrategyNewestCreateIndex,
+	}
+
+	ids, err := cu.RunPreScaleInTasksWithRemoteCheck(context.Background(), cfg, []string{"node-a"}, 0)
+	require.Error(t, err)
+	require.Nil(t, ids)
+	assert.EqualError(t, err, "number of nodes requested for removal must be greater than zero")
+}
+
+func testNomadScaleInServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	nodes := []*api.NodeListStub{
+		{
+			ID:                    "node-a",
+			NodeClass:             "pool-a",
+			Status:                api.NodeStatusReady,
+			SchedulingEligibility: api.NodeSchedulingEligible,
+		},
+		{
+			ID:                    "node-b",
+			NodeClass:             "pool-a",
+			Status:                api.NodeStatusReady,
+			SchedulingEligibility: api.NodeSchedulingEligible,
+		},
+	}
+
+	nodeInfo := map[string]*api.Node{
+		"node-a": {ID: "node-a"},
+		"node-b": {ID: "node-b"},
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/v1/nodes":
+			require.NoError(t, json.NewEncoder(w).Encode(nodes))
+		case "/v1/node/node-a", "/v1/node/node-b":
+			n, ok := nodeInfo[r.URL.Path[len("/v1/node/"):]]
+			require.True(t, ok)
+			require.NoError(t, json.NewEncoder(w).Encode(n))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func testNomadClient(t *testing.T, address string) *api.Client {
+	t.Helper()
+
+	cfg := api.DefaultConfig()
+	cfg.Address = address
+
+	client, err := api.NewClient(cfg)
+	require.NoError(t, err)
+	return client
+}


### PR DESCRIPTION
**Description**
 scale-in identification could return more nodes than requested, causing plugins to potentially drain/destroy too many nodes.

Problem
IdentifyScaleInNodes(cfg, num) was not enforcing the requested num consistently, which broke expected compatibility behavior for external plugins relying on this API.

Changes
- Ensure scale-in identification respects requested node count.
- Keep remote-check pre-scale-in behavior intact (identify eligible nodes, filter by remote IDs, then select).
- Add/extend regression coverage for:
      - honoring requested num
      - remote-check behavior
      - rejecting non-positive num inputs

[JIRA ISSUE](https://hashicorp.atlassian.net/browse/NMD-1357)

Testing:

<details>
- validated via live Nomad test-setup flow + focused test suite.

 - **Previous flow:**

<img width="777" height="691" alt="Screenshot 2026-04-22 at 12 05 07 PM" src="https://github.com/user-attachments/assets/3a805720-3991-496f-a89b-cfc9c5ad8b59" />

-

<img width="770" height="684" alt="Screenshot 2026-04-22 at 12 05 23 PM" src="https://github.com/user-attachments/assets/33ea6d01-cc34-4750-9bd7-f11ad918f427" />


-  **Current flow:**


<img width="846" height="877" alt="Screenshot 2026-04-22 at 10 56 01 AM" src="https://github.com/user-attachments/assets/d890f31a-5149-4965-9ca7-78d62f7257d7" />

-

<img width="832" height="834" alt="Screenshot 2026-04-22 at 10 56 24 AM" src="https://github.com/user-attachments/assets/3ddd84c0-88e5-443f-adca-99e8651232cc" />

-

</details>


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

