### PR TITLE
fix: exclude ineligible nodes from pool capacity calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ IMPROVEMENTS:
 * plugins: Fixed AWS-ASG plugin error handling so the underlying error is preserved when retry limit is reached. [[GH-1266](https://github.com/hashicorp/nomad-autoscaler/pull/1266)]
 
 BUG FIXES:
-* plugin/apm/nomad: Exclude `ready + ineligible` nodes from pool capacity calculations [[GH-910](https://github.com/hashicorp/nomad-autoscaler/issues/910)]
+* plugin/apm/nomad: Exclude `ready + ineligible` nodes from pool capacity calculations [[GH-1286](https://github.com/hashicorp/nomad-autoscaler/pull/1286)]
 * policy: Fixed a bug where misconfigured strategy checks could crash the autoscaler instead of following normal `on_error` and `on_check_error` behavior. [[GH-1275](https://github.com/hashicorp/nomad-autoscaler/pull/1275)]
 * policy: Fixed-value strategy checks no longer require APM source or query configuration. [[GH-1281](https://github.com/hashicorp/nomad-autoscaler/pull/1281)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ IMPROVEMENTS:
 * plugins: Fixed AWS-ASG plugin error handling so the underlying error is preserved when retry limit is reached. [[GH-1266](https://github.com/hashicorp/nomad-autoscaler/pull/1266)]
 
 BUG FIXES:
+* plugin/apm/nomad: Exclude `ready + ineligible` nodes from pool capacity calculations [[GH-910](https://github.com/hashicorp/nomad-autoscaler/issues/910)]
 * policy: Fixed a bug where misconfigured strategy checks could crash the autoscaler instead of following normal `on_error` and `on_check_error` behavior. [[GH-1275](https://github.com/hashicorp/nomad-autoscaler/pull/1275)]
 * policy: Fixed-value strategy checks no longer require APM source or query configuration. [[GH-1281](https://github.com/hashicorp/nomad-autoscaler/pull/1281)]
 

--- a/plugins/builtin/apm/nomad/plugin/node_test.go
+++ b/plugins/builtin/apm/nomad/plugin/node_test.go
@@ -222,7 +222,7 @@ func TestAPMPlugin_getPoolResources(t *testing.T) {
 				case "/v1/nodes":
 					_ = json.NewEncoder(w).Encode([]*api.NodeListStub{
 						{ID: "node-draining", NodeClass: "1", Drain: true, Status: api.NodeStatusReady},
-						{ID: "node-ready", NodeClass: "1", Drain: false, Status: api.NodeStatusReady},
+						{ID: "node-ready", NodeClass: "1", Drain: false, SchedulingEligibility: api.NodeSchedulingEligible, Status: api.NodeStatusReady},
 					})
 				default:
 					http.NotFound(w, r)
@@ -243,7 +243,7 @@ func TestAPMPlugin_getPoolResources(t *testing.T) {
 				case "/v1/nodes":
 					_ = json.NewEncoder(w).Encode([]*api.NodeListStub{
 						{ID: "node-draining", NodeClass: "1", Drain: true, Status: api.NodeStatusReady},
-						{ID: "node-ready", NodeClass: "1", Drain: false, Status: api.NodeStatusReady},
+						{ID: "node-ready", NodeClass: "1", Drain: false, SchedulingEligibility: api.NodeSchedulingEligible, Status: api.NodeStatusReady},
 					})
 				case "/v1/node/node-ready":
 					_ = json.NewEncoder(w).Encode(&api.Node{
@@ -274,6 +274,73 @@ func TestAPMPlugin_getPoolResources(t *testing.T) {
 			}),
 		},
 		{
+			name:        "ready ineligible node excluded from pool totals",
+			config:      map[string]string{},
+			expectError: false,
+			expectedCPU: 20,
+			expectedMemMB: 15,
+			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/v1/nodes":
+					_ = json.NewEncoder(w).Encode([]*api.NodeListStub{
+						{ID: "node-ready-eligible", NodeClass: "1", Drain: false, SchedulingEligibility: api.NodeSchedulingEligible, Status: api.NodeStatusReady},
+						{ID: "node-ready-ineligible", NodeClass: "1", Drain: false, SchedulingEligibility: api.NodeSchedulingIneligible, Status: api.NodeStatusReady},
+					})
+				case "/v1/node/node-ready-eligible":
+					_ = json.NewEncoder(w).Encode(&api.Node{
+						ID: "node-ready-eligible",
+						NodeResources: &api.NodeResources{
+							Cpu:    api.NodeCpuResources{CpuShares: 300},
+							Memory: api.NodeMemoryResources{MemoryMB: 256},
+						},
+						ReservedResources: &api.NodeReservedResources{
+							Cpu:    api.NodeReservedCpuResources{CpuShares: 100},
+							Memory: api.NodeReservedMemoryResources{MemoryMB: 64},
+						},
+					})
+				case "/v1/node/node-ready-eligible/allocations":
+					_ = json.NewEncoder(w).Encode([]*api.Allocation{
+						{
+							DesiredStatus: api.AllocDesiredStatusRun,
+							ClientStatus:  api.AllocClientStatusRunning,
+							Resources: &api.Resources{
+								CPU:      &cpu,
+								MemoryMB: &mem,
+							},
+						},
+					})
+				case "/v1/node/node-ready-ineligible":
+					_ = json.NewEncoder(w).Encode(&api.Node{
+						ID: "node-ready-ineligible",
+						NodeResources: &api.NodeResources{
+							Cpu:    api.NodeCpuResources{CpuShares: 1000},
+							Memory: api.NodeMemoryResources{MemoryMB: 1000},
+						},
+						ReservedResources: &api.NodeReservedResources{
+							Cpu:    api.NodeReservedCpuResources{CpuShares: 0},
+							Memory: api.NodeReservedMemoryResources{MemoryMB: 0},
+						},
+					})
+				case "/v1/node/node-ready-ineligible/allocations":
+					ineligibleCPU := 500
+					ineligibleMem := 500
+					_ = json.NewEncoder(w).Encode([]*api.Allocation{
+						{
+							DesiredStatus: api.AllocDesiredStatusRun,
+							ClientStatus:  api.AllocClientStatusRunning,
+							Resources: &api.Resources{
+								CPU:      &ineligibleCPU,
+								MemoryMB: &ineligibleMem,
+							},
+						},
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}),
+		},
+		{
 			name: "invalid node filter option",
 			config: map[string]string{
 				"node_filter_ignore_drain": "not-a-bool",
@@ -285,7 +352,7 @@ func TestAPMPlugin_getPoolResources(t *testing.T) {
 				switch r.URL.Path {
 				case "/v1/nodes":
 					_ = json.NewEncoder(w).Encode([]*api.NodeListStub{
-						{ID: "node-ready", NodeClass: "1", Status: api.NodeStatusReady},
+						{ID: "node-ready", NodeClass: "1", SchedulingEligibility: api.NodeSchedulingEligible, Status: api.NodeStatusReady},
 					})
 				default:
 					http.NotFound(w, r)
@@ -302,7 +369,7 @@ func TestAPMPlugin_getPoolResources(t *testing.T) {
 				switch r.URL.Path {
 				case "/v1/nodes":
 					_ = json.NewEncoder(w).Encode([]*api.NodeListStub{
-						{ID: "node-missing-res", NodeClass: "1", Status: api.NodeStatusReady},
+						{ID: "node-missing-res", NodeClass: "1", SchedulingEligibility: api.NodeSchedulingEligible, Status: api.NodeStatusReady},
 					})
 				case "/v1/node/node-missing-res":
 					_ = json.NewEncoder(w).Encode(&api.Node{ID: "node-missing-res"})
@@ -321,7 +388,7 @@ func TestAPMPlugin_getPoolResources(t *testing.T) {
 				switch r.URL.Path {
 				case "/v1/nodes":
 					_ = json.NewEncoder(w).Encode([]*api.NodeListStub{
-						{ID: "node-missing-alloc-res", NodeClass: "1", Status: api.NodeStatusReady},
+						{ID: "node-missing-alloc-res", NodeClass: "1", SchedulingEligibility: api.NodeSchedulingEligible, Status: api.NodeStatusReady},
 					})
 				case "/v1/node/node-missing-alloc-res":
 					_ = json.NewEncoder(w).Encode(&api.Node{

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -211,6 +211,13 @@ func (c *ClusterScaleUtils) IdentifyScaleInNodes(cfg map[string]string, num int)
 		}
 	}
 
+	// For scale-in, ineligible nodes are valid termination candidates and
+	// should not be excluded from the pool. Default to including them unless
+	// the caller has explicitly configured otherwise.
+	if _, ok := cfg[XNodeFilterOptionIgnoreIneligible]; !ok {
+		cfg[XNodeFilterOptionIgnoreIneligible] = "true"
+	}
+
 	// Filter our nodes to select only those within our identified pool.
 	filterOpts, err := NewNodeFilterOptions(cfg)
 	if err != nil {

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package scaleutils

--- a/sdk/helper/scaleutils/node_identifier.go
+++ b/sdk/helper/scaleutils/node_identifier.go
@@ -86,10 +86,15 @@ func FilterNodesWithOptions(n []*api.NodeListStub, idFn func(*api.NodeListStub) 
 		// Assuming a cluster has most, if not all nodes in a correct state for
 		// scheduling then this is the fastest route. Only append in the event
 		// we have not encountered any error to save some cycles.
-		if !node.Drain && node.Status == api.NodeStatusReady &&
-			node.SchedulingEligibility == api.NodeSchedulingEligible {
-			if err == nil {
-				out = append(out, node)
+		//
+		// Ineligible nodes are excluded from pool capacity by default. When
+		// IgnoreIneligible is set (e.g., scale-in), include them so they
+		// remain termination candidates.
+		if !node.Drain && node.Status == api.NodeStatusReady {
+			if node.SchedulingEligibility == api.NodeSchedulingEligible || opts.IgnoreIneligible() {
+				if err == nil {
+					out = append(out, node)
+				}
 			}
 			continue
 		}
@@ -143,13 +148,15 @@ func filterOutNodeID(n []*api.NodeListStub, id string) []*api.NodeListStub {
 // Enabling ignore options can reduce blocked evaluations in environments with
 // long drain/init windows, but may reduce strict readiness guarantees.
 const (
-	XNodeFilterOptionIgnoreInit  = "node_filter_ignore_init"
-	XNodeFilterOptionIgnoreDrain = "node_filter_ignore_drain"
+	XNodeFilterOptionIgnoreInit       = "node_filter_ignore_init"
+	XNodeFilterOptionIgnoreDrain      = "node_filter_ignore_drain"
+	XNodeFilterOptionIgnoreIneligible = "node_filter_ignore_ineligible"
 )
 
 type NodeFilterOptions struct {
-	ignoreInit  bool
-	ignoreDrain bool
+	ignoreInit       bool
+	ignoreDrain      bool
+	ignoreIneligible bool
 }
 
 func NewNodeFilterOptions(cfg map[string]string) (*NodeFilterOptions, error) {
@@ -179,6 +186,18 @@ func NewNodeFilterOptions(cfg map[string]string) (*NodeFilterOptions, error) {
 		opts.ignoreDrain = ignoreDrain
 	}
 
+	if str, ok := cfg[XNodeFilterOptionIgnoreIneligible]; ok {
+		ignoreIneligible, err := strconv.ParseBool(str)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to parse value %s for %s configuration: %v",
+				str, XNodeFilterOptionIgnoreIneligible, err,
+			)
+		}
+
+		opts.ignoreIneligible = ignoreIneligible
+	}
+
 	return opts, nil
 }
 
@@ -194,4 +213,11 @@ func (n *NodeFilterOptions) IgnoreDrain() bool {
 		return false
 	}
 	return n.ignoreDrain
+}
+
+func (n *NodeFilterOptions) IgnoreIneligible() bool {
+	if n == nil {
+		return false
+	}
+	return n.ignoreIneligible
 }

--- a/sdk/helper/scaleutils/node_identifier.go
+++ b/sdk/helper/scaleutils/node_identifier.go
@@ -86,7 +86,8 @@ func FilterNodesWithOptions(n []*api.NodeListStub, idFn func(*api.NodeListStub) 
 		// Assuming a cluster has most, if not all nodes in a correct state for
 		// scheduling then this is the fastest route. Only append in the event
 		// we have not encountered any error to save some cycles.
-		if !node.Drain && node.Status == api.NodeStatusReady {
+		if !node.Drain && node.Status == api.NodeStatusReady &&
+			node.SchedulingEligibility == api.NodeSchedulingEligible {
 			if err == nil {
 				out = append(out, node)
 			}

--- a/sdk/helper/scaleutils/node_identifier_test.go
+++ b/sdk/helper/scaleutils/node_identifier_test.go
@@ -185,28 +185,6 @@ func Test_FilterNodes(t *testing.T) {
 		{
 			inputNodeList: []*api.NodeListStub{
 				{
-					ID:                    "node-ready-ineligible-1",
-					NodeClass:             "lionel",
-					Drain:                 false,
-					SchedulingEligibility: api.NodeSchedulingIneligible,
-					Status:                api.NodeStatusReady,
-				},
-				{
-					ID:                    "node-ready-ineligible-2",
-					NodeClass:             "lionel",
-					Drain:                 false,
-					SchedulingEligibility: api.NodeSchedulingIneligible,
-					Status:                api.NodeStatusReady,
-				},
-			},
-			inputIDCfg:          map[string]string{"node_class": "lionel"},
-			expectedOutputNodes: nil,
-			expectedOutputError: nil,
-			name:                "filter excludes all ready ineligible nodes",
-		},
-		{
-			inputNodeList: []*api.NodeListStub{
-				{
 					ID:                    "node1",
 					NodeClass:             "lionel",
 					Drain:                 false,
@@ -372,6 +350,121 @@ func Test_FilterNodes(t *testing.T) {
 	}
 }
 
+func Test_FilterNodesWithOptions(t *testing.T) {
+	testCases := []struct {
+		inputNodeList       []*api.NodeListStub
+		inputIDCfg          map[string]string
+		inputOpts           *NodeFilterOptions
+		expectedOutputNodes []*api.NodeListStub
+		expectedOutputError error
+		name                string
+	}{
+		{
+			inputNodeList: []*api.NodeListStub{
+				{
+					ID:                    "node-ready-eligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "node-ready-ineligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			inputIDCfg: map[string]string{"node_class": "lionel"},
+			inputOpts:  &NodeFilterOptions{ignoreIneligible: true},
+			expectedOutputNodes: []*api.NodeListStub{
+				{
+					ID:                    "node-ready-eligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "node-ready-ineligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			expectedOutputError: nil,
+			name:                "ignore_ineligible includes ready ineligible nodes",
+		},
+		{
+			inputNodeList: []*api.NodeListStub{
+				{
+					ID:                    "node-ready-eligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "node-ready-ineligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			inputIDCfg: map[string]string{"node_class": "lionel"},
+			inputOpts:  &NodeFilterOptions{ignoreIneligible: false},
+			expectedOutputNodes: []*api.NodeListStub{
+				{
+					ID:                    "node-ready-eligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingEligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			expectedOutputError: nil,
+			name:                "default excludes ready ineligible nodes from output",
+		},
+		{
+			inputNodeList: []*api.NodeListStub{
+				{
+					ID:                    "node-ready-ineligible",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusReady,
+				},
+			},
+			inputIDCfg:          map[string]string{"node_class": "lionel"},
+			inputOpts:           &NodeFilterOptions{ignoreIneligible: false},
+			expectedOutputNodes: nil,
+			expectedOutputError: nil,
+			name:                "all ineligible nodes produces empty output without error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			idFn, err := nodepool.NewClusterNodePoolIdentifier(tc.inputIDCfg)
+			assert.NotNil(t, idFn, tc.name)
+			assert.Nil(t, err, tc.name)
+
+			actualNodes, actualError := FilterNodesWithOptions(tc.inputNodeList, idFn.IsPoolMember, tc.inputOpts)
+			assert.Equal(t, tc.expectedOutputNodes, actualNodes, tc.name)
+
+			if tc.expectedOutputError != nil {
+				assert.EqualError(t, actualError, tc.expectedOutputError.Error(), tc.name)
+			} else {
+				assert.NoError(t, actualError, tc.name)
+			}
+		})
+	}
+}
+
 func Test_filterOutNodeID(t *testing.T) {
 	testCases := []struct {
 		inputNodeList  []*api.NodeListStub
@@ -440,70 +533,4 @@ func Test_filterOutNodeID(t *testing.T) {
 			assert.ElementsMatch(t, tc.expectedOutput, actualOutput, tc.name)
 		})
 	}
-}
-
-func Test_NewNodeFilterOptions(t *testing.T) {
-	testCases := []struct {
-		inputConfig  map[string]string
-		expectInit   bool
-		expectDrain  bool
-		expectedErr  string
-		name         string
-	}{
-		{
-			inputConfig: map[string]string{},
-			expectInit:  false,
-			expectDrain: false,
-			expectedErr: "",
-			name:       "defaults",
-		},
-		{
-			inputConfig: map[string]string{
-				XNodeFilterOptionIgnoreInit:  "true",
-				XNodeFilterOptionIgnoreDrain: "true",
-			},
-			expectInit:  true,
-			expectDrain: true,
-			expectedErr: "",
-			name:       "valid bool values",
-		},
-		{
-			inputConfig: map[string]string{
-				XNodeFilterOptionIgnoreInit: "not-a-bool",
-			},
-			expectedErr: "failed to parse value not-a-bool for node_filter_ignore_init configuration",
-			name:       "invalid init bool",
-		},
-		{
-			inputConfig: map[string]string{
-				XNodeFilterOptionIgnoreDrain: "not-a-bool",
-			},
-			expectedErr: "failed to parse value not-a-bool for node_filter_ignore_drain configuration",
-			name:       "invalid drain bool",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			opts, err := NewNodeFilterOptions(tc.inputConfig)
-
-			if tc.expectedErr != "" {
-				assert.Error(t, err)
-				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, opts)
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.NotNil(t, opts)
-			assert.Equal(t, tc.expectInit, opts.IgnoreInit())
-			assert.Equal(t, tc.expectDrain, opts.IgnoreDrain())
-		})
-	}
-}
-
-func Test_NodeFilterOptions_IgnoreNilReceiver(t *testing.T) {
-	var opts *NodeFilterOptions
-	assert.False(t, opts.IgnoreInit())
-	assert.False(t, opts.IgnoreDrain())
 }

--- a/sdk/helper/scaleutils/node_identifier_test.go
+++ b/sdk/helper/scaleutils/node_identifier_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package scaleutils

--- a/sdk/helper/scaleutils/node_identifier_test.go
+++ b/sdk/helper/scaleutils/node_identifier_test.go
@@ -178,16 +178,31 @@ func Test_FilterNodes(t *testing.T) {
 					SchedulingEligibility: api.NodeSchedulingEligible,
 					Status:                api.NodeStatusReady,
 				},
+			},
+			expectedOutputError: nil,
+			name:                "filter of ready and eligible nodes",
+		},
+		{
+			inputNodeList: []*api.NodeListStub{
 				{
-					ID:                    "node-ready-ineligible",
+					ID:                    "node-ready-ineligible-1",
+					NodeClass:             "lionel",
+					Drain:                 false,
+					SchedulingEligibility: api.NodeSchedulingIneligible,
+					Status:                api.NodeStatusReady,
+				},
+				{
+					ID:                    "node-ready-ineligible-2",
 					NodeClass:             "lionel",
 					Drain:                 false,
 					SchedulingEligibility: api.NodeSchedulingIneligible,
 					Status:                api.NodeStatusReady,
 				},
 			},
+			inputIDCfg:          map[string]string{"node_class": "lionel"},
+			expectedOutputNodes: nil,
 			expectedOutputError: nil,
-			name:                "filter of nodes that are ready",
+			name:                "filter excludes all ready ineligible nodes",
 		},
 		{
 			inputNodeList: []*api.NodeListStub{
@@ -425,4 +440,70 @@ func Test_filterOutNodeID(t *testing.T) {
 			assert.ElementsMatch(t, tc.expectedOutput, actualOutput, tc.name)
 		})
 	}
+}
+
+func Test_NewNodeFilterOptions(t *testing.T) {
+	testCases := []struct {
+		inputConfig  map[string]string
+		expectInit   bool
+		expectDrain  bool
+		expectedErr  string
+		name         string
+	}{
+		{
+			inputConfig: map[string]string{},
+			expectInit:  false,
+			expectDrain: false,
+			expectedErr: "",
+			name:       "defaults",
+		},
+		{
+			inputConfig: map[string]string{
+				XNodeFilterOptionIgnoreInit:  "true",
+				XNodeFilterOptionIgnoreDrain: "true",
+			},
+			expectInit:  true,
+			expectDrain: true,
+			expectedErr: "",
+			name:       "valid bool values",
+		},
+		{
+			inputConfig: map[string]string{
+				XNodeFilterOptionIgnoreInit: "not-a-bool",
+			},
+			expectedErr: "failed to parse value not-a-bool for node_filter_ignore_init configuration",
+			name:       "invalid init bool",
+		},
+		{
+			inputConfig: map[string]string{
+				XNodeFilterOptionIgnoreDrain: "not-a-bool",
+			},
+			expectedErr: "failed to parse value not-a-bool for node_filter_ignore_drain configuration",
+			name:       "invalid drain bool",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := NewNodeFilterOptions(tc.inputConfig)
+
+			if tc.expectedErr != "" {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tc.expectedErr)
+				assert.Nil(t, opts)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, opts)
+			assert.Equal(t, tc.expectInit, opts.IgnoreInit())
+			assert.Equal(t, tc.expectDrain, opts.IgnoreDrain())
+		})
+	}
+}
+
+func Test_NodeFilterOptions_IgnoreNilReceiver(t *testing.T) {
+	var opts *NodeFilterOptions
+	assert.False(t, opts.IgnoreInit())
+	assert.False(t, opts.IgnoreDrain())
 }

--- a/sdk/helper/scaleutils/node_identifier_test.go
+++ b/sdk/helper/scaleutils/node_identifier_test.go
@@ -11,6 +11,7 @@ import (
 	errHelper "github.com/hashicorp/nomad-autoscaler/sdk/helper/error"
 	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils/nodepool"
 	"github.com/hashicorp/nomad/api"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -448,18 +449,17 @@ func Test_FilterNodesWithOptions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			idFn, err := nodepool.NewClusterNodePoolIdentifier(tc.inputIDCfg)
-			assert.NotNil(t, idFn, tc.name)
-			assert.Nil(t, err, tc.name)
+			must.NoError(t, err)
+			must.NotNil(t, idFn)
 
 			actualNodes, actualError := FilterNodesWithOptions(tc.inputNodeList, idFn.IsPoolMember, tc.inputOpts)
-			assert.Equal(t, tc.expectedOutputNodes, actualNodes, tc.name)
+			must.Eq(t, tc.expectedOutputNodes, actualNodes)
 
 			if tc.expectedOutputError != nil {
-				assert.EqualError(t, actualError, tc.expectedOutputError.Error(), tc.name)
+				must.ErrorContains(t, actualError, tc.expectedOutputError.Error())
 			} else {
-				assert.NoError(t, actualError, tc.name)
+				must.NoError(t, actualError)
 			}
 		})
 	}


### PR DESCRIPTION
**Description**
_Root Cause:_

FilterNodesWithOptions()  used only two conditions on the fast-path filter.

This allowed ready + ineligible nodes to pass through to getPoolResources(), which then summed their allocatable resources into the pool total. Ineligible nodes cannot receive new allocations, so their resources should not be counted as available capacity.

_Fix:_

Added node.SchedulingEligibility == api.NodeSchedulingEligible to the fast-path condition:

This is a strict check —> nodes with an empty SchedulingEligibility field are also excluded (fail-closed), which is the safe default since such nodes cannot be confirmed as schedulable.

_Additional changes (post-review):_

The eligibility check broke the scale-in path — IdentifyScaleInNodes uses the same FilterNodesWithOptions() function, and ineligible nodes are valid termination candidates during scale-in.

- Added node_filter_ignore_ineligible option (symmetry with existing node_filter_ignore_init / node_filter_ignore_drain)
- cluster.go → IdentifyScaleInNodes auto-injects node_filter_ignore_ineligible=true so ineligible nodes remain in the scale-in candidate pool
- IgnoreIneligible() accessor is nil-safe — FilterNodes() passes nil opts and defaults to false (excludes ineligible), the correct APM behavior.

[JIRA ISSUE](https://hashicorp.atlassian.net/browse/NMD-1361)

**Testing:**

<details>

Verified with a local 3-node Nomad cluster (test-setup/gh910). Two of the three ready nodes were marked ineligible.

Without fix: allocatable_memory=110592 — all 3 ready nodes counted, including the 2 ineligible ones.
With fix: allocatable_memory=36864 — only the 1 eligible node 

- Before fix:

<img width="632" height="103" alt="Screenshot 2026-04-27 at 8 38 48 PM" src="https://github.com/user-attachments/assets/80e3f490-76e2-4799-95be-75de24c54b11" />

- 
<img width="746" height="310" alt="Screenshot 2026-04-27 at 7 49 02 PM" src="https://github.com/user-attachments/assets/f0ea8075-fa87-4022-af7b-92641e76e877" />

- 
<img width="722" height="615" alt="Screenshot 2026-04-27 at 7 11 27 PM" src="https://github.com/user-attachments/assets/24e990e0-e85c-457c-9f0d-5705f53b56d2" />


- After fix:

<img width="729" height="243" alt="Screenshot 2026-04-27 at 7 52 46 PM" src="https://github.com/user-attachments/assets/527e1460-a94a-46c3-8c4f-a000b845f8e5" />



</details>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

