### PR TITLE
fix(aws-asg): avoid draining nodes that ASG will refuse to terminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 * plugin/apm/nomad: Exclude `ready + ineligible` nodes from pool capacity calculations [[GH-1286](https://github.com/hashicorp/nomad-autoscaler/pull/1286)]
+* plugin/target/aws-asg: Fixed a bug where nodes were drained before validating ASG constraints (Terminate suspended, DesiredCapacity at MinSize), causing unnecessary capacity loss.[[GH-1290](https://github.com/hashicorp/nomad-autoscaler/pull/1290)]
 * policy: Fixed a bug where misconfigured strategy checks could crash the autoscaler instead of following normal `on_error` and `on_check_error` behavior. [[GH-1275](https://github.com/hashicorp/nomad-autoscaler/pull/1275)]
 * policy: Fixed-value strategy checks no longer require APM source or query configuration. [[GH-1281](https://github.com/hashicorp/nomad-autoscaler/pull/1281)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 * plugin/apm/nomad: Exclude `ready + ineligible` nodes from pool capacity calculations [[GH-1286](https://github.com/hashicorp/nomad-autoscaler/pull/1286)]
-* plugin/target/aws-asg: Fixed a bug where nodes were drained before validating ASG constraints (Terminate suspended, DesiredCapacity at MinSize), causing unnecessary capacity loss.[[GH-1290](https://github.com/hashicorp/nomad-autoscaler/pull/1290)]
+* plugin/target/aws-asg: Fixed a bug where nodes were drained before validating ASG constraints (Terminate suspended, DesiredCapacity at MinSize), causing unnecessary capacity loss. [[GH-1290](https://github.com/hashicorp/nomad-autoscaler/pull/1290)]
 * policy: Fixed a bug where misconfigured strategy checks could crash the autoscaler instead of following normal `on_error` and `on_check_error` behavior. [[GH-1275](https://github.com/hashicorp/nomad-autoscaler/pull/1275)]
 * policy: Fixed-value strategy checks no longer require APM source or query configuration. [[GH-1281](https://github.com/hashicorp/nomad-autoscaler/pull/1281)]
 

--- a/plugins/builtin/target/aws-asg/plugin/aws.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/hashicorp/nomad-autoscaler/sdk"
 	"github.com/hashicorp/nomad-autoscaler/sdk/helper/scaleutils"
 	"github.com/hashicorp/nomad/api"
 )
@@ -138,7 +139,7 @@ func (t *TargetPlugin) scaleIn(ctx context.Context, asg *types.AutoScalingGroup,
 		if p.ProcessName != nil && *p.ProcessName == "Terminate" {
 			log.Warn("skipping scale-in: Terminate process is suspended on ASG",
 				"suspension_reason", aws.ToString(p.SuspensionReason))
-			return nil
+			return sdk.NewTargetScalingNoOpError("Terminate process is suspended on ASG %s", *asg.AutoScalingGroupName)
 		}
 	}
 
@@ -153,7 +154,8 @@ func (t *TargetPlugin) scaleIn(ctx context.Context, asg *types.AutoScalingGroup,
 		if headroom <= 0 {
 			log.Warn("skipping scale-in: ASG is already at or below MinSize",
 				"desired_capacity", desired, "min_size", minSize)
-			return nil
+			return sdk.NewTargetScalingNoOpError("ASG %s is already at or below MinSize (desired=%d, min=%d)",
+				*asg.AutoScalingGroupName, desired, minSize)
 		}
 		if num > headroom {
 			log.Warn("capping scale-in to respect ASG MinSize",

--- a/plugins/builtin/target/aws-asg/plugin/aws.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws.go
@@ -131,6 +131,38 @@ func (t *TargetPlugin) scaleIn(ctx context.Context, asg *types.AutoScalingGroup,
 		"scale_in_protection", scaleInProtection,
 	)
 
+	// Short-circuit if the operator has suspended the Terminate scaling
+	// process on the ASG. AWS will refuse to terminate any instance while
+	// this is suspended, so draining nodes here would only waste capacity.
+	for _, p := range asg.SuspendedProcesses {
+		if p.ProcessName != nil && *p.ProcessName == "Terminate" {
+			log.Warn("skipping scale-in: Terminate process is suspended on ASG",
+				"suspension_reason", aws.ToString(p.SuspensionReason))
+			return nil
+		}
+	}
+
+	// Cap num against the ASG's MinSize so we never drain instances that AWS
+	// would subsequently refuse to terminate. Without this check, the policy's
+	// Min can drift below the ASG's MinSize (e.g. an out-of-band edit) and
+	// nodes get drained but never deleted.
+	if asg.MinSize != nil && asg.DesiredCapacity != nil {
+		desired := int64(*asg.DesiredCapacity)
+		minSize := int64(*asg.MinSize)
+		headroom := desired - minSize
+		if headroom <= 0 {
+			log.Warn("skipping scale-in: ASG is already at or below MinSize",
+				"desired_capacity", desired, "min_size", minSize)
+			return nil
+		}
+		if num > headroom {
+			log.Warn("capping scale-in to respect ASG MinSize",
+				"requested", num, "capped_to", headroom,
+				"desired_capacity", desired, "min_size", minSize)
+			num = headroom
+		}
+	}
+
 	// Find instance IDs in the target ASG and perform pre-scale tasks.
 	remoteIDs := []string{}
 	for _, inst := range asg.Instances {

--- a/plugins/builtin/target/aws-asg/plugin/aws_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package plugin
@@ -7,8 +7,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_awsNodeIDMap(t *testing.T) {
@@ -49,6 +53,133 @@ func Test_awsNodeIDMap(t *testing.T) {
 			actualID, actualErr := awsNodeIDMap(tc.inputNode)
 			assert.Equal(t, tc.expectedOutputID, actualID, tc.name)
 			assert.Equal(t, tc.expectedOutputError, actualErr, tc.name)
+		})
+	}
+}
+
+func newTestPlugin() *TargetPlugin {
+	return &TargetPlugin{
+		logger: hclog.NewNullLogger(),
+	}
+}
+
+func asgWithName(name string) *types.AutoScalingGroup {
+	return &types.AutoScalingGroup{
+		AutoScalingGroupName: aws.String(name),
+	}
+}
+
+func TestTargetPlugin_scaleIn_TerminateSuspended(t *testing.T) {
+	testCases := []struct {
+		name               string
+		suspendedProcesses []types.SuspendedProcess
+	}{
+		{
+			name: "only_terminate_suspended",
+			suspendedProcesses: []types.SuspendedProcess{
+				{ProcessName: aws.String("Terminate"), SuspensionReason: aws.String("manual")},
+			},
+		},
+		{
+			name: "terminate_suspended_among_others",
+			suspendedProcesses: []types.SuspendedProcess{
+				{ProcessName: aws.String("Launch"), SuspensionReason: aws.String("manual")},
+				{ProcessName: aws.String("Terminate"), SuspensionReason: aws.String("manual")},
+				{ProcessName: aws.String("HealthCheck"), SuspensionReason: aws.String("manual")},
+			},
+		},
+		{
+			name: "terminate_suspended_nil_reason",
+			suspendedProcesses: []types.SuspendedProcess{
+				{ProcessName: aws.String("Terminate"), SuspensionReason: nil},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tp := newTestPlugin()
+			asg := asgWithName("test-asg")
+			asg.SuspendedProcesses = tc.suspendedProcesses
+
+			err := tp.scaleIn(t.Context(), asg, 1, map[string]string{})
+			require.NoError(t, err, "scaleIn must return nil when Terminate is suspended")
+		})
+	}
+}
+
+func TestTargetPlugin_scaleIn_NonTerminateProcessesSuspended(t *testing.T) {
+	tp := newTestPlugin()
+	asg := asgWithName("test-asg")
+	asg.SuspendedProcesses = []types.SuspendedProcess{
+		{ProcessName: aws.String("Launch"), SuspensionReason: aws.String("manual")},
+		{ProcessName: aws.String("HealthCheck"), SuspensionReason: aws.String("manual")},
+	}
+	// Set desired == minSize so the MinSize guard stops execution cleanly.
+	asg.DesiredCapacity = aws.Int32(3)
+	asg.MinSize = aws.Int32(3)
+
+	err := tp.scaleIn(t.Context(), asg, 1, map[string]string{})
+	require.NoError(t, err, "non-Terminate suspensions must not block scale-in logic")
+}
+
+func TestTargetPlugin_scaleIn_MinSizeGuard(t *testing.T) {
+	testCases := []struct {
+		name      string
+		desired   int32
+		minSize   int32
+		num       int64
+		expectNil bool
+	}{
+		{
+			name:      "desired_equals_minSize",
+			desired:   3,
+			minSize:   3,
+			num:       1,
+			expectNil: true,
+		},
+		{
+			name:      "desired_below_minSize",
+			desired:   2,
+			minSize:   3,
+			num:       1,
+			expectNil: true,
+		},
+		{
+			name:      "desired_above_minSize_num_within_headroom",
+			desired:   5,
+			minSize:   3,
+			num:       1,
+			expectNil: false,
+		},
+		{
+			name:      "desired_above_minSize_num_exceeds_headroom",
+			desired:   5,
+			minSize:   3,
+			num:       4,
+			expectNil: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tp := newTestPlugin()
+			asg := asgWithName("test-asg")
+			asg.DesiredCapacity = aws.Int32(tc.desired)
+			asg.MinSize = aws.Int32(tc.minSize)
+
+			if tc.expectNil {
+				// desired <= minSize: scaleIn returns nil without proceeding.
+				err := tp.scaleIn(t.Context(), asg, tc.num, map[string]string{})
+				require.NoError(t, err, "scaleIn must return nil when ASG is at or below MinSize")
+			} else {
+				// desired > minSize: scaleIn proceeds past the MinSize guard.
+				// Without a real clusterUtils this panics, which proves the
+				// guard did NOT block execution — i.e. scale-in was attempted.
+				require.Panics(t, func() {
+					_ = tp.scaleIn(t.Context(), asg, tc.num, map[string]string{})
+				}, "scaleIn must proceed past MinSize guard when desired > minSize")
+			}
 		})
 	}
 }

--- a/plugins/builtin/target/aws-asg/plugin/aws_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws_test.go
@@ -12,8 +12,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
 	"github.com/hashicorp/nomad/api"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 func Test_awsNodeIDMap(t *testing.T) {
@@ -52,8 +51,8 @@ func Test_awsNodeIDMap(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualID, actualErr := awsNodeIDMap(tc.inputNode)
-			assert.Equal(t, tc.expectedOutputID, actualID, tc.name)
-			assert.Equal(t, tc.expectedOutputError, actualErr, tc.name)
+			must.Eq(t, tc.expectedOutputID, actualID, must.Sprint(tc.name))
+			must.Eq(t, tc.expectedOutputError, actualErr, must.Sprint(tc.name))
 		})
 	}
 }
@@ -104,9 +103,10 @@ func TestTargetPlugin_scaleIn_TerminateSuspended(t *testing.T) {
 			asg.SuspendedProcesses = tc.suspendedProcesses
 
 			err := tp.scaleIn(t.Context(), asg, 1, map[string]string{})
-			require.Error(t, err, "scaleIn must return a no-op error when Terminate is suspended")
+			must.Error(t, err, must.Sprint("scaleIn must return a no-op error when Terminate is suspended"))
 			var noOpErr *sdk.TargetScalingNoOpError
-			require.ErrorAs(t, err, &noOpErr)
+			must.ErrorAs[*sdk.TargetScalingNoOpError](t, err, &noOpErr)
+			must.ErrorContains(t, err, "Terminate process is suspended on ASG test-asg")
 		})
 	}
 }
@@ -124,46 +124,47 @@ func TestTargetPlugin_scaleIn_NonTerminateProcessesSuspended(t *testing.T) {
 
 	err := tp.scaleIn(t.Context(), asg, 1, map[string]string{})
 	// Non-Terminate suspensions don't block, but the MinSize guard fires (desired==minSize).
-	require.Error(t, err)
+	must.Error(t, err)
 	var noOpErr *sdk.TargetScalingNoOpError
-	require.ErrorAs(t, err, &noOpErr)
+	must.ErrorAs[*sdk.TargetScalingNoOpError](t, err, &noOpErr)
+	must.ErrorContains(t, err, "ASG test-asg is already at or below MinSize (desired=3, min=3)")
 }
 
 func TestTargetPlugin_scaleIn_MinSizeGuard(t *testing.T) {
 	testCases := []struct {
-		name      string
-		desired   int32
-		minSize   int32
-		num       int64
-		expectNil bool
+		name       string
+		desired    int32
+		minSize    int32
+		num        int64
+		expectNoOp bool
 	}{
 		{
-			name:      "desired_equals_minSize",
-			desired:   3,
-			minSize:   3,
-			num:       1,
-			expectNil: true,
+			name:       "desired_equals_minSize",
+			desired:    3,
+			minSize:    3,
+			num:        1,
+			expectNoOp: true,
 		},
 		{
-			name:      "desired_below_minSize",
-			desired:   2,
-			minSize:   3,
-			num:       1,
-			expectNil: true,
+			name:       "desired_below_minSize",
+			desired:    2,
+			minSize:    3,
+			num:        1,
+			expectNoOp: true,
 		},
 		{
-			name:      "desired_above_minSize_num_within_headroom",
-			desired:   5,
-			minSize:   3,
-			num:       1,
-			expectNil: false,
+			name:       "desired_above_minSize_num_within_headroom",
+			desired:    5,
+			minSize:    3,
+			num:        1,
+			expectNoOp: false,
 		},
 		{
-			name:      "desired_above_minSize_num_exceeds_headroom",
-			desired:   5,
-			minSize:   3,
-			num:       4,
-			expectNil: false,
+			name:       "desired_above_minSize_num_exceeds_headroom",
+			desired:    5,
+			minSize:    3,
+			num:        4,
+			expectNoOp: false,
 		},
 	}
 
@@ -174,19 +175,20 @@ func TestTargetPlugin_scaleIn_MinSizeGuard(t *testing.T) {
 			asg.DesiredCapacity = aws.Int32(tc.desired)
 			asg.MinSize = aws.Int32(tc.minSize)
 
-			if tc.expectNil {
+			if tc.expectNoOp {
 				// desired <= minSize: scaleIn returns a no-op error without proceeding.
 				err := tp.scaleIn(t.Context(), asg, tc.num, map[string]string{})
-				require.Error(t, err, "scaleIn must return a no-op error when ASG is at or below MinSize")
+				must.Error(t, err, must.Sprint("scaleIn must return a no-op error when ASG is at or below MinSize"))
 				var noOpErr *sdk.TargetScalingNoOpError
-				require.ErrorAs(t, err, &noOpErr)
+				must.ErrorAs[*sdk.TargetScalingNoOpError](t, err, &noOpErr)
+				must.ErrorContains(t, err, "ASG test-asg is already at or below MinSize")
 			} else {
 				// desired > minSize: scaleIn proceeds past the MinSize guard.
 				// Without a real clusterUtils this panics, which proves the
 				// guard did NOT block execution — i.e. scale-in was attempted.
-				require.Panics(t, func() {
+				must.Panic(t, func() {
 					_ = tp.scaleIn(t.Context(), asg, tc.num, map[string]string{})
-				}, "scaleIn must proceed past MinSize guard when desired > minSize")
+				}, must.Sprint("scaleIn must proceed past MinSize guard when desired > minSize"))
 			}
 		})
 	}

--- a/plugins/builtin/target/aws-asg/plugin/aws_test.go
+++ b/plugins/builtin/target/aws-asg/plugin/aws_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/sdk"
 	"github.com/hashicorp/nomad/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -103,7 +104,9 @@ func TestTargetPlugin_scaleIn_TerminateSuspended(t *testing.T) {
 			asg.SuspendedProcesses = tc.suspendedProcesses
 
 			err := tp.scaleIn(t.Context(), asg, 1, map[string]string{})
-			require.NoError(t, err, "scaleIn must return nil when Terminate is suspended")
+			require.Error(t, err, "scaleIn must return a no-op error when Terminate is suspended")
+			var noOpErr *sdk.TargetScalingNoOpError
+			require.ErrorAs(t, err, &noOpErr)
 		})
 	}
 }
@@ -120,7 +123,10 @@ func TestTargetPlugin_scaleIn_NonTerminateProcessesSuspended(t *testing.T) {
 	asg.MinSize = aws.Int32(3)
 
 	err := tp.scaleIn(t.Context(), asg, 1, map[string]string{})
-	require.NoError(t, err, "non-Terminate suspensions must not block scale-in logic")
+	// Non-Terminate suspensions don't block, but the MinSize guard fires (desired==minSize).
+	require.Error(t, err)
+	var noOpErr *sdk.TargetScalingNoOpError
+	require.ErrorAs(t, err, &noOpErr)
 }
 
 func TestTargetPlugin_scaleIn_MinSizeGuard(t *testing.T) {
@@ -169,9 +175,11 @@ func TestTargetPlugin_scaleIn_MinSizeGuard(t *testing.T) {
 			asg.MinSize = aws.Int32(tc.minSize)
 
 			if tc.expectNil {
-				// desired <= minSize: scaleIn returns nil without proceeding.
+				// desired <= minSize: scaleIn returns a no-op error without proceeding.
 				err := tp.scaleIn(t.Context(), asg, tc.num, map[string]string{})
-				require.NoError(t, err, "scaleIn must return nil when ASG is at or below MinSize")
+				require.Error(t, err, "scaleIn must return a no-op error when ASG is at or below MinSize")
+				var noOpErr *sdk.TargetScalingNoOpError
+				require.ErrorAs(t, err, &noOpErr)
 			} else {
 				// desired > minSize: scaleIn proceeds past the MinSize guard.
 				// Without a real clusterUtils this panics, which proves the

--- a/plugins/builtin/target/aws-asg/plugin/plugin.go
+++ b/plugins/builtin/target/aws-asg/plugin/plugin.go
@@ -198,7 +198,7 @@ func (t *TargetPlugin) Scale(action sdk.ScalingAction, config map[string]string)
 	// If we received an error while scaling, format this with an outer message
 	// so its nice for the operators and then return any error to the caller.
 	if err != nil {
-		err = fmt.Errorf("failed to perform scaling action: %v", err)
+		err = fmt.Errorf("failed to perform scaling action: %w", err)
 	}
 	return err
 }

--- a/plugins/target/client.go
+++ b/plugins/target/client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/nomad-autoscaler/plugins/shared"
 	proto "github.com/hashicorp/nomad-autoscaler/plugins/target/proto/v1"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // pluginClient is the gRPC client implementation of the Target interface.
@@ -32,7 +34,13 @@ func (p *pluginClient) Scale(action sdk.ScalingAction, config map[string]string)
 		return err
 	}
 	_, err = p.client.Scale(p.doneCTX, &proto.ScaleRequest{Action: req, Config: config})
-	return err
+	if err != nil {
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Aborted {
+			return sdk.NewTargetScalingNoOpError("%s", s.Message())
+		}
+		return err
+	}
+	return nil
 }
 
 // Status is the gRPC client implementation of the Target.Status interface

--- a/plugins/target/server.go
+++ b/plugins/target/server.go
@@ -5,10 +5,14 @@ package target
 
 import (
 	"context"
+	"errors"
 
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad-autoscaler/plugins/shared"
 	proto "github.com/hashicorp/nomad-autoscaler/plugins/target/proto/v1"
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // pluginServer is the gRPC server implementation of the Target interface.
@@ -24,7 +28,15 @@ func (p *pluginServer) Scale(_ context.Context, req *proto.ScaleRequest) (*proto
 	if err != nil {
 		return nil, err
 	}
-	return &proto.ScaleResponse{}, p.impl.Scale(action, req.GetConfig())
+	err = p.impl.Scale(action, req.GetConfig())
+	if err != nil {
+		var noOpErr *sdk.TargetScalingNoOpError
+		if errors.As(err, &noOpErr) {
+			return nil, status.Error(codes.Aborted, noOpErr.Error())
+		}
+		return nil, err
+	}
+	return &proto.ScaleResponse{}, nil
 }
 
 // Status is the gRPC server implementation of the Target.Status interface

--- a/policy/handler.go
+++ b/policy/handler.go
@@ -417,6 +417,12 @@ func (h *Handler) waitAndScale(ctx context.Context) error {
 
 	err = h.runTargetScale(action)
 	if err != nil {
+		var noOpErr *sdk.TargetScalingNoOpError
+		if errors.As(err, &noOpErr) {
+			h.log.Debug("scaling action was a no-op, skipping cooldown", "reason", noOpErr.Error())
+			h.updateState(StateIdle)
+			return nil
+		}
 		return fmt.Errorf("failed to get scale target: %w", err)
 	}
 


### PR DESCRIPTION
Fixes a bug where the Nomad Autoscaler would drain Nomad client nodes before checking whether AWS would actually allow the corresponding instances to be terminated. When AWS refused (due to suspended Terminate process or DesiredCapacity already at MinSize), nodes were drained unnecessarily, removing capacity from the cluster with no way to reclaim it without manual intervention.

### Bug

During a scale-in operation, the autoscaler followed this sequence:

1. Strategy decides to scale down (e.g., 3 → 1)
2. `scaleIn()` selects nodes and **drains them** via Nomad
3. Calls `TerminateInstanceInAutoScalingGroup` on each drained instance
4. AWS rejects the termination (Terminate suspended, or would breach MinSize)
5. Nodes are already drained — workloads evicted, capacity wasted

### Solution

#### 1. Pre-drain guards in `scaleIn()` (`aws.go`)

Two new checks run **before** any node draining occurs:

- **Terminate-suspended guard**: Iterates `SuspendedProcesses` on the ASG. If `Terminate` is suspended, scale-in is skipped immediately.
- **MinSize guard**: Computes `headroom = DesiredCapacity - MinSize`. If headroom ≤ 0, scale-in is skipped. If `num > headroom`, `num` is capped to the available headroom.

Both guards return `sdk.TargetScalingNoOpError` so the caller can distinguish a no-op from a real failure.

#### 2. No-op aware cooldown handling (`handler.go`)

The policy handler now checks for `TargetScalingNoOpError` after calling the target plugin. When detected, it:
- Logs a DEBUG message with the reason
- Transitions back to `StateIdle` (avoids getting stuck in `StateScaling`)
- **Skips cooldown** — so the policy re-evaluates on the next tick

#### 3. gRPC boundary preservation (`server.go`, `client.go`)

Since builtin plugins communicate over gRPC (via `hashicorp/go-plugin`), the Go error type is lost in transit. To preserve the no-op signal:
- **Server**: Detects `TargetScalingNoOpError` and encodes it as
  `codes.Aborted` gRPC status
- **Client**: Decodes `codes.Aborted` back into `sdk.NewTargetScalingNoOpError`

#### 4. Error wrapping fix (`plugin.go`)

Changed `fmt.Errorf("failed to perform scaling action: %v", err)` to `%w` so `errors.As` can unwrap through the outer error to find `TargetScalingNoOpError`.

### Reproduction

1. Deploy Nomad Autoscaler with an AWS ASG target where `MinSize == DesiredCapacity` (e.g., both set to 3)
2. Configure a scaling policy with a target-value strategy where current utilization is well below the threshold (triggering scale-down)
3. **Before fix**: Autoscaler drains nodes, AWS refuses termination, nodes lose workloads, handler enters cooldown or gets stuck in `StateScaling`
4. **After fix**: Autoscaler logs a WARN about the MinSize constraint, skips draining entirely, and re-evaluates on the next tick

To test the Terminate-suspended guard:
```bash
aws autoscaling suspend-processes \
  --auto-scaling-group-name nomad-cluster-client-asg \
  --scaling-processes Terminate
```

### Before

```
2026-05-07T15:53:26.953Z [INFO]  policy_manager.policy_handler: calculating scaling target: policy_id=07688fd2-e357-353f-e963-0453d44f3c78 source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" policy_id=07688fd2-e357-353f-e963-0453d44f3c78 from=3 to=1 reason="scaling down because factor is 0.065010" meta=map[nomad_policy_id:07688fd2-e357-353f-e963-0453d44f3c78]
2026-05-07T15:53:26.954Z [DEBUG] policy_manager.policy_handler: requesting slot: policy_id=07688fd2-e357-353f-e963-0453d44f3c78 source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]"
2026-05-07T15:53:26.954Z [DEBUG] policy_manager.policy_handler: slot granted: policy_id=07688fd2-e357-353f-e963-0453d44f3c78 source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]"
2026-05-07T15:53:26.954Z [DEBUG] policy_manager.policy_handler: scaling target: policy_id=07688fd2-e357-353f-e963-0453d44f3c78 source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" target=aws-asg count=1
2026-05-07T15:53:27.142Z [DEBUG] internal_plugin.aws-asg: found eligible instance: action=scale_in asg_name=nomad-cluster-client-asg scale_in_protection=false instance_id=i-00dbb1f74bb63110b
2026-05-07T15:53:27.142Z [DEBUG] internal_plugin.aws-asg: found eligible instance: action=scale_in asg_name=nomad-cluster-client-asg scale_in_protection=false instance_id=i-06fdf21fc4157e27e
2026-05-07T15:53:27.142Z [DEBUG] internal_plugin.aws-asg: found eligible instance: action=scale_in asg_name=nomad-cluster-client-asg scale_in_protection=false instance_id=i-09e0e782e67d4fd7a
2026-05-07T15:53:27.142Z [DEBUG] internal_plugin.aws-asg: performing node pool filtering: node_class=hashistack
2026-05-07T15:53:27.146Z [DEBUG] internal_plugin.aws-asg: found node: node_id=60469549-96c6-9d11-57e4-50f461367a88 datacenter=dc1 node_class=hashistack node_pool=default status=ready eligibility=eligible draining=false
2026-05-07T15:53:27.146Z [DEBUG] internal_plugin.aws-asg: found node: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f datacenter=dc1 node_class=hashistack node_pool=default status=ready eligibility=eligible draining=false
2026-05-07T15:53:27.146Z [DEBUG] internal_plugin.aws-asg: found node: node_id=2b4af97c-1624-cfc7-c228-925b3f572bb7 datacenter=dc1 node_class=hashistack node_pool=default status=ready eligibility=eligible draining=false
2026-05-07T15:53:27.146Z [DEBUG] internal_plugin.aws-asg: node passed filter criteria: node_id=60469549-96c6-9d11-57e4-50f461367a88
2026-05-07T15:53:27.146Z [DEBUG] internal_plugin.aws-asg: node passed filter criteria: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f
2026-05-07T15:53:27.150Z [DEBUG] internal_plugin.aws-asg: identified remote provider ID for node: node_id=60469549-96c6-9d11-57e4-50f461367a88 remote_id=i-09e0e782e67d4fd7a
2026-05-07T15:53:27.152Z [DEBUG] internal_plugin.aws-asg: identified remote provider ID for node: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f remote_id=i-06fdf21fc4157e27e
2026-05-07T15:53:27.152Z [DEBUG] internal_plugin.aws-asg: node is part of the policy target: node_id=60469549-96c6-9d11-57e4-50f461367a88 remote_id=i-09e0e782e67d4fd7a
2026-05-07T15:53:27.152Z [DEBUG] internal_plugin.aws-asg: node is part of the policy target: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f remote_id=i-06fdf21fc4157e27e
2026-05-07T15:53:27.152Z [DEBUG] internal_plugin.aws-asg: performing node selection: selector_strategy=least_busy
2026-05-07T15:53:27.162Z [DEBUG] internal_plugin.aws-asg: node selected for removal: node_id=60469549-96c6-9d11-57e4-50f461367a88 remote_id=i-09e0e782e67d4fd7a
2026-05-07T15:53:27.162Z [DEBUG] internal_plugin.aws-asg: node selected for removal: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f remote_id=i-06fdf21fc4157e27e
2026-05-07T15:53:27.162Z [INFO]  internal_plugin.aws-asg: triggering drain on node: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f deadline=5m0s
2026-05-07T15:53:27.162Z [INFO]  internal_plugin.aws-asg: triggering drain on node: node_id=60469549-96c6-9d11-57e4-50f461367a88 deadline=5m0s
2026-05-07T15:53:27.183Z [INFO]  internal_plugin.aws-asg: received node drain message: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f msg="All allocations on node \"79eda094-1e00-340c-1e7c-c6ddf8b6d81f\" have stopped"
2026-05-07T15:53:27.186Z [INFO]  internal_plugin.aws-asg: received node drain message: node_id=60469549-96c6-9d11-57e4-50f461367a88 msg="All allocations on node \"60469549-96c6-9d11-57e4-50f461367a88\" have stopped"
2026-05-07T15:53:27.190Z [INFO]  internal_plugin.aws-asg: received node drain message: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f msg="Drain complete for node 79eda094-1e00-340c-1e7c-c6ddf8b6d81f"
2026-05-07T15:53:27.190Z [DEBUG] internal_plugin.aws-asg: node drain complete: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f
2026-05-07T15:53:27.239Z [INFO]  internal_plugin.aws-asg: received node drain message: node_id=60469549-96c6-9d11-57e4-50f461367a88 msg="Drain complete for node 60469549-96c6-9d11-57e4-50f461367a88"
2026-05-07T15:53:27.239Z [DEBUG] internal_plugin.aws-asg: node drain complete: node_id=60469549-96c6-9d11-57e4-50f461367a88
2026-05-07T15:53:27.239Z [DEBUG] internal_plugin.aws-asg: pre scale-in tasks now complete
2026-05-07T15:53:27.280Z [ERROR] internal_plugin.aws-asg: failed to update AutoScaling Group tag: error="operation error Auto Scaling: CreateOrUpdateTags, https response error StatusCode: 403, RequestID: b042d84f-7a52-4a78-a00f-3726902ad059, api error AccessDenied: User: arn:aws:sts::147785671463:assumed-role/nomad-cluster-client-role/i-00dbb1f74bb63110b is not authorized to perform: autoscaling:CreateOrUpdateTags on resource: arn:aws:autoscaling:us-east-1:147785671463:autoScalingGroup:c8234a53-55ae-4b0a-88d3-8a9e75e32cb2:autoScalingGroupName/nomad-cluster-client-asg because no identity-based policy allows the autoscaling:CreateOrUpdateTags action" event=drain
2026-05-07T15:53:27.443Z [ERROR] internal_plugin.aws-asg: failed to terminate instance in ASG: action=scale_in asg_name=nomad-cluster-client-asg scale_in_protection=false instance_id=i-09e0e782e67d4fd7a node_id=60469549-96c6-9d11-57e4-50f461367a88 error="operation error Auto Scaling: TerminateInstanceInAutoScalingGroup, https response error StatusCode: 400, RequestID: 2de24e21-3b8e-42ef-a6bf-79337ff21a84, api error ValidationError: Currently, desiredSize equals minSize (3). Terminating instance without replacement will violate group's min size constraint. Either set shouldDecrementDesiredCapacity flag to false or lower group's min size."
2026-05-07T15:53:27.443Z [ERROR] internal_plugin.aws-asg: failed to terminate instance in ASG: action=scale_in asg_name=nomad-cluster-client-asg scale_in_protection=false instance_id=i-06fdf21fc4157e27e node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f error="operation error Auto Scaling: TerminateInstanceInAutoScalingGroup, https response error StatusCode: 400, RequestID: 6942d58c-7708-426a-bcbf-035b12fb4396, api error ValidationError: Currently, desiredSize equals minSize (3). Terminating instance without replacement will violate group's min size constraint. Either set shouldDecrementDesiredCapacity flag to false or lower group's min size."
2026-05-07T15:53:27.463Z [INFO]  internal_plugin.aws-asg: successfully toggled node eligibility: node_id=60469549-96c6-9d11-57e4-50f461367a88 evals=[]
2026-05-07T15:53:27.477Z [INFO]  internal_plugin.aws-asg: successfully toggled node eligibility: node_id=79eda094-1e00-340c-1e7c-c6ddf8b6d81f evals=[]
2026-05-07T15:53:27.477Z [ERROR] policy_manager.policy_handler: unable to scale target: policy_id=07688fd2-e357-353f-e963-0453d44f3c78 source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" reason="failed to get scale target: failed to perform scaling action: failed to terminate node 60469549-96c6-9d11-57e4-50f461367a88 with AWS ID i-09e0e782e67d4fd7a: operation error Auto Scaling: TerminateInstanceInAutoScalingGroup, https response error StatusCode: 400, RequestID: 2de24e21-3b8e-42ef-a6bf-79337ff21a84, api error ValidationError: Currently, desiredSize equals minSize (3). Terminating instance without replacement will violate group's min size constraint. Either set shouldDecrementDesiredCapacity flag to false or lower group's min size., failed to terminate node 79eda094-1e00-340c-1e7c-c6ddf8b6d81f with AWS ID i-06fdf21fc4157e27e: operation error Auto Scaling: TerminateInstanceInAutoScalingGroup, https response error StatusCode: 400, RequestID: 6942d58c-7708-426a-bcbf-035b12fb4396, api error ValidationError: Currently, desiredSize equals minSize (3). Terminating instance without replacement will violate group's min size constraint. Either set shouldDecrementDesiredCapacity flag to false or lower group's min size."

```

### After

```
026-05-07T16:48:59.630Z [DEBUG] policy_manager.policy_handler: received policy for evaluation: policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]"
2026-05-07T16:48:59.630Z [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=cpu_allocated_percentage policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=nomad-apm strategy=target-value target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]"
2026-05-07T16:48:59.630Z [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=cpu_allocated_percentage policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=nomad-apm strategy=target-value target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" query=node_percentage-allocated_cpu/hashistack/class source=nomad-apm
2026-05-07T16:48:59.630Z [DEBUG] internal_plugin.nomad-apm: performing node pool APM query: query=node_percentage-allocated_cpu/hashistack/class
2026-05-07T16:48:59.656Z [DEBUG] internal_plugin.nomad-apm: collected node pool resource data: allocated_cpu=628 allocated_memory=512 allocatable_cpu=13800 allocatable_memory=11727
2026-05-07T16:48:59.656Z [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=cpu_allocated_percentage policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=nomad-apm strategy=target-value target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" current count=3
2026-05-07T16:48:59.656Z [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=cpu_allocated_percentage policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=nomad-apm strategy=target-value target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" strategy=target-value check=cpu_allocated_percentage
2026-05-07T16:48:59.656Z [DEBUG] policy_manager.policy_handler.check_handler: received policy check for evaluation: check=mem_allocated_percentage policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=nomad-apm strategy=target-value target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]"
2026-05-07T16:48:59.656Z [DEBUG] policy_manager.policy_handler.check_handler: querying source: check=mem_allocated_percentage policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=nomad-apm strategy=target-value target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" query=node_percentage-allocated_memory/hashistack/class source=nomad-apm
2026-05-07T16:48:59.656Z [DEBUG] internal_plugin.nomad-apm: performing node pool APM query: query=node_percentage-allocated_memory/hashistack/class
2026-05-07T16:48:59.684Z [DEBUG] internal_plugin.nomad-apm: collected node pool resource data: allocated_cpu=628 allocated_memory=512 allocatable_cpu=13800 allocatable_memory=11727
2026-05-07T16:48:59.685Z [DEBUG] policy_manager.policy_handler.check_handler: calculating new count: check=mem_allocated_percentage policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=nomad-apm strategy=target-value target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" current count=3
2026-05-07T16:48:59.685Z [DEBUG] policy_manager.policy_handler.check_handler: running strategy: check=mem_allocated_percentage policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=nomad-apm strategy=target-value target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" strategy=target-value check=mem_allocated_percentage
2026-05-07T16:48:59.685Z [DEBUG] policy_manager.policy_handler: check selected: policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" direction=down count=1
2026-05-07T16:48:59.685Z [INFO]  policy_manager.policy_handler: calculating scaling target: policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" policy_id=588e0691-4451-4998-8a9d-e53daca16dbf from=3 to=1 reason="scaling down because factor is 0.065010" meta=map[nomad_policy_id:588e0691-4451-4998-8a9d-e53daca16dbf]
2026-05-07T16:48:59.685Z [DEBUG] policy_manager.policy_handler: requesting slot: policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]"
2026-05-07T16:48:59.685Z [DEBUG] policy_manager.policy_handler: slot granted: policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]"
2026-05-07T16:48:59.685Z [DEBUG] policy_manager.policy_handler: scaling target: policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" target=aws-asg count=1
2026-05-07T16:48:59.798Z [WARN]  internal_plugin.aws-asg: skipping scale-in: ASG is already at or below MinSize: action=scale_in asg_name=nomad-cluster-client-asg scale_in_protection=false desired_capacity=3 min_size=3
2026-05-07T16:48:59.798Z [DEBUG] policy_manager.policy_handler: scaling action was a no-op, skipping cooldown: policy_id=588e0691-4451-4998-8a9d-e53daca16dbf source=file target=aws-asg target_config="map[_nomad_autoscaler_grpc_timeout:22.5s aws_asg_name:nomad-cluster-client-asg dry-run:false node_class:hashistack node_drain_deadline:5m]" reason="ASG nomad-cluster-client-asg is already at or below MinSize (desired=3, min=3)

```

[JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1396)
Fixes #911 
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

