### PR TITLE
ci: declare permissions on ci, jira-sync, nightly-release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
     paths-ignore:
       - '*.md'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: "Run checks"

--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -10,6 +10,12 @@ on:
 
 name: Jira Issue Sync
 
+# Jira mirror only reads issue/comment metadata; writes go to Jira via
+# JIRA_API_TOKEN.
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   sync:
     runs-on: ubuntu-24.04

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -14,9 +14,13 @@ on:
 jobs:
   # Build a fresh set of artifacts
   build-artifacts:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
   github-release:
     needs: build-artifacts
+    permissions:
+      contents: write  # delete/create tags/nightly and create the prerelease
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -79,6 +83,7 @@ jobs:
       - build-artifacts
       - github-release
     if: always() && (needs.build-artifacts.result == 'failure' || needs.github-release.result == 'failure')
+    permissions: {}  # only posts to an external Slack webhook
     runs-on: ubuntu-24.04
     steps:
       - name: Send slack notification on failure


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` for the three workflows that were inheriting org defaults.

| Workflow | Job | Scope | Why |
|----------|-----|-------|-----|
| `ci.yaml` | (top-level) | `contents: read` | check / build dev / test, no API writes |
| `jira-sync.yml` | (top-level) | `contents: read` + `issues: read` | mirror to Jira; writes go through `JIRA_API_TOKEN` |
| `nightly-release.yml` | `build-artifacts` | `contents: read` | caller for the reusable build.yml |
| `nightly-release.yml` | `github-release` | `contents: write` | actions/github-script deletes/recreates the `tags/nightly` ref, ncipollo/release-action creates a prerelease, eregon/publish-release publishes it |
| `nightly-release.yml` | `slack-notify` | `permissions: {}` | only posts to `SLACK_WEBHOOK_URL` (external), no GitHub API |

YAML validated locally.