### PR TITLE
feat(apm/influxdb): JWT auth fixes, env var credential fallback, and plugin hardening

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.26.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.12
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.36.5
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/cronexpr v1.1.3
 	github.com/hashicorp/go-cleanhttp v0.5.2
@@ -83,7 +84,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.28.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
-github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -10,10 +10,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	jwtlib "github.com/golang-jwt/jwt/v5"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/plugins"
 	"github.com/hashicorp/nomad-autoscaler/plugins/apm"
@@ -22,37 +25,69 @@ import (
 )
 
 const (
-	// pluginName is the name of the plugin.
 	pluginName = "influxdb"
 
 	// configKeyAddress is the InfluxDB server address.
+	// Falls back to INFLUXDB_ADDRESS if not set in the config map.
 	configKeyAddress = "address"
 
 	// configKeyDatabase is the primary config key for the database name.
+	// Falls back to INFLUXDB_DATABASE if neither "database" nor "db" is set.
 	configKeyDatabase = "database"
 
 	// configKeyDB is the shorthand alias accepted for database name.
+	// Lower priority than "database"; takes precedence over INFLUXDB_DATABASE.
 	configKeyDB = "db"
 
 	// configKeyUsername is the optional authentication username.
+	// Required when shared_secret is set (used as the JWT "username" claim).
+	// Falls back to INFLUXDB_USERNAME if not set in the config map.
 	configKeyUsername = "username"
 
 	// configKeyPassword is the optional authentication password.
+	// Used together with username for HTTP Basic auth.
+	// Cannot be used together with shared_secret.
+	// Falls back to INFLUXDB_PASSWORD if not set in the config map.
 	configKeyPassword = "password"
 
-	// configKeyToken is the optional JWT authentication token. When set, it
-	// takes precedence over username/password and cannot be used together
-	// with them. The token is sent as "Authorization: Bearer <token>" and
-	// supports InfluxDB 1.x JWT auth (requires shared-secret configured on
-	// the InfluxDB server via INFLUXDB_HTTP_SHARED_SECRET or [http] shared-secret).
-	configKeyToken = "token"
+	// configKeySharedSecret is the InfluxDB shared secret used to sign
+	// auto-generated HS256 JWTs. When set, the plugin generates and refreshes
+	// Bearer JWTs internally — no manual token management required.
+	// Requires: username. Conflicts with: password.
+	// Corresponds to INFLUXDB_HTTP_SHARED_SECRET on the InfluxDB server.
+	// Falls back to INFLUXDB_SHARED_SECRET if not set in the config map.
+	configKeySharedSecret = "shared_secret"
+
+	// configKeyTokenTTL is the optional lifetime for auto-generated JWTs.
+	// Accepts Go duration strings (e.g. "30m", "2h"). Default: 1h.
+	// Range: 1m – 24h. Only meaningful when shared_secret is set.
+	configKeyTokenTTL = "token_ttl"
 
 	// configKeyVersion selects the InfluxDB API version. Only "1" is
-	// currently supported; "3" is reserved for future implementation.
+	// currently supported; "2" and "3" are reserved for future implementation.
 	configKeyVersion = "version"
 
 	// configVersion1 is the default and only supported version today.
 	configVersion1 = "1"
+
+	// defaultTokenTTL is the JWT lifetime when token_ttl is not configured.
+	defaultTokenTTL = time.Hour
+
+	// minTokenTTL / maxTokenTTL are the allowed bounds for token_ttl.
+	minTokenTTL = time.Minute
+	maxTokenTTL = 24 * time.Hour
+
+	// queryTimeout is the per-request deadline for InfluxDB HTTP queries.
+	queryTimeout = 10 * time.Second
+
+	// Environment variable names for credential fallback.
+	// The config map always takes precedence; these are checked only when the
+	// corresponding config key is absent or empty.
+	envVarAddress      = "INFLUXDB_ADDRESS"
+	envVarDatabase     = "INFLUXDB_DATABASE"
+	envVarUsername     = "INFLUXDB_USERNAME"
+	envVarPassword     = "INFLUXDB_PASSWORD"
+	envVarSharedSecret = "INFLUXDB_SHARED_SECRET"
 )
 
 var (
@@ -62,7 +97,7 @@ var (
 	}
 
 	PluginConfig = &plugins.InternalPluginConfig{
-		Factory: func(l hclog.Logger) interface{} { return NewInfluxDBPlugin(l) },
+		Factory: func(l hclog.Logger) any { return NewInfluxDBPlugin(l) },
 	}
 
 	pluginInfo = &base.PluginInfo{
@@ -78,24 +113,32 @@ type influxQueryResponse struct {
 	Error   string              `json:"error,omitempty"`
 }
 
+// influxQueryResult holds the series and optional error for a single
+// InfluxQL statement within a query response.
 type influxQueryResult struct {
 	StatementID int                 `json:"statement_id"`
 	Series      []influxQuerySeries `json:"series"`
 	Error       string              `json:"error,omitempty"`
 }
 
+// influxQuerySeries holds the column names and row values for one named
+// measurement series returned by an InfluxQL query.
 type influxQuerySeries struct {
-	Name    string          `json:"name"`
-	Columns []string        `json:"columns"`
-	Values  [][]interface{} `json:"values"`
+	Name    string   `json:"name"`
+	Columns []string `json:"columns"`
+	Values  [][]any  `json:"values"`
 }
 
 // APMPlugin is the InfluxDB implementation of the APM interface.
 type APMPlugin struct {
-	client  *http.Client
-	baseURL *url.URL
-	config  map[string]string
-	logger  hclog.Logger
+	client      *http.Client
+	baseURL     *url.URL
+	config      map[string]string
+	logger      hclog.Logger
+	tokenTTL    time.Duration // parsed from configKeyTokenTTL; set during SetConfig
+	jwtMu       sync.Mutex    // protects cachedToken and tokenExpiry
+	cachedToken string        // most recently generated JWT; empty until first use
+	tokenExpiry time.Time     // when cachedToken expires
 }
 
 // NewInfluxDBPlugin returns a new InfluxDB APM plugin instance.
@@ -106,29 +149,64 @@ func NewInfluxDBPlugin(log hclog.Logger) apm.APM {
 }
 
 // SetConfig parses and validates the plugin configuration. All required fields
-// are checked before any client is stored.
+// are checked before any state is mutated, so a failed re-configuration leaves
+// the plugin in its previous working state.
 func (a *APMPlugin) SetConfig(config map[string]string) error {
-	a.config = config
+	// Copy the config map so we can write resolved values back without
+	// mutating the caller's map. All validation runs on this copy, and it
+	// becomes a.config only after all checks pass.
+	cfg := make(map[string]string, len(config))
+	for k, v := range config {
+		cfg[k] = v
+	}
 
-	address := strings.TrimSpace(a.config[configKeyAddress])
+	address := configOrEnv(cfg, configKeyAddress, envVarAddress)
 	if address == "" {
 		return fmt.Errorf("%q config value cannot be empty", configKeyAddress)
 	}
 
-	database := a.database()
+	// Resolve database: "database" key → "db" alias → INFLUXDB_DATABASE env var.
+	database := strings.TrimSpace(cfg[configKeyDatabase])
+	if database == "" {
+		database = strings.TrimSpace(cfg[configKeyDB])
+	}
+	if database == "" {
+		if v := strings.TrimSpace(os.Getenv(envVarDatabase)); v != "" {
+			database = v
+		}
+	}
 	if database == "" {
 		return fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
 	}
 
-	// Validate mutual exclusivity: token cannot be used with username/password.
-	token := strings.TrimSpace(a.config[configKeyToken])
-	username := strings.TrimSpace(a.config[configKeyUsername])
-	password := strings.TrimSpace(a.config[configKeyPassword])
-	if token != "" && (username != "" || password != "") {
-		return fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q or %q", configKeyToken, configKeyUsername, configKeyPassword)
+	// Validate auth configuration mutual exclusivity.
+	username := configOrEnv(cfg, configKeyUsername, envVarUsername)
+	password := configOrEnv(cfg, configKeyPassword, envVarPassword)
+	sharedSecret := configOrEnv(cfg, configKeySharedSecret, envVarSharedSecret)
+
+	if sharedSecret != "" {
+		if username == "" {
+			return fmt.Errorf("auth configuration error: %q requires %q (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
+		}
+		if password != "" {
+			return fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
+		}
 	}
 
-	switch version := strings.TrimSpace(a.config[configKeyVersion]); version {
+	// Parse and validate token_ttl.
+	ttl := defaultTokenTTL
+	if raw := strings.TrimSpace(cfg[configKeyTokenTTL]); raw != "" {
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			return fmt.Errorf("invalid %q value %q: %v", configKeyTokenTTL, raw, err)
+		}
+		if parsed < minTokenTTL || parsed > maxTokenTTL {
+			return fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
+		}
+		ttl = parsed
+	}
+
+	switch version := strings.TrimSpace(cfg[configKeyVersion]); version {
 	case "", configVersion1:
 		// ok — v1 is the default
 	case "2", "3":
@@ -145,13 +223,31 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 		return fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
 	}
 
+	// Write resolved values back so downstream methods (setAuthHeader,
+	// generateJWT) can read them from a.config without needing env var awareness.
+	cfg[configKeyAddress] = address
+	cfg[configKeyDatabase] = database
+	cfg[configKeyUsername] = username
+	cfg[configKeyPassword] = password
+	cfg[configKeySharedSecret] = sharedSecret
+
+	// All validation passed — atomically update plugin state.
+	a.config = cfg
 	a.baseURL = parsedURL
 	a.client = &http.Client{}
+	a.tokenTTL = ttl
+
+	// Reset cached JWT so any previously generated token is not reused after
+	// a config change.
+	a.jwtMu.Lock()
+	a.cachedToken = ""
+	a.tokenExpiry = time.Time{}
+	a.jwtMu.Unlock()
 
 	return nil
 }
 
-// PluginInfo returns metadata about the plugin.
+// PluginInfo returns the plugin name and type.
 func (a *APMPlugin) PluginInfo() (*base.PluginInfo, error) {
 	return pluginInfo, nil
 }
@@ -188,7 +284,7 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 
 	a.logger.Debug("querying InfluxDB", "query", q, "range", r)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
 
 	queryURL := *a.baseURL
@@ -205,7 +301,9 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 		return nil, fmt.Errorf("failed to build influxdb query request: %v", err)
 	}
 
-	a.setAuthHeader(req)
+	if err := a.setAuthHeader(req); err != nil {
+		return nil, fmt.Errorf("failed to set auth header: %v", err)
+	}
 
 	resp, err := a.client.Do(req)
 	if err != nil {
@@ -227,7 +325,7 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 		return nil, fmt.Errorf("influxdb query error: %s", queryResp.Error)
 	}
 
-	results := make([]sdk.TimestampedMetrics, 0)
+	var results []sdk.TimestampedMetrics
 	for _, result := range queryResp.Results {
 		if result.Error != "" {
 			return nil, fmt.Errorf("influxdb query error: %s", result.Error)
@@ -251,22 +349,24 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 	return results, nil
 }
 
-// database returns the configured database name, checking the primary key
-// first and falling back to the shorthand alias.
+// database returns the resolved database name from the plugin configuration.
 func (a *APMPlugin) database() string {
-	if db := strings.TrimSpace(a.config[configKeyDatabase]); db != "" {
-		return db
-	}
-	return strings.TrimSpace(a.config[configKeyDB])
+	return strings.TrimSpace(a.config[configKeyDatabase])
 }
 
 // setAuthHeader applies the appropriate authentication method to the HTTP
-// request. It supports JWT Bearer token auth (for InfluxDB 1.x shared-secret
-// JWT auth) and username/password basic auth (for InfluxDB 1.x OSS/Enterprise).
-func (a *APMPlugin) setAuthHeader(req *http.Request) {
-	if token := strings.TrimSpace(a.config[configKeyToken]); token != "" {
+// request based on the plugin configuration:
+//   - shared_secret + username → auto-generated HS256 JWT Bearer token
+//   - username + password      → HTTP Basic auth
+//   - neither                  → unauthenticated (local/dev scenarios)
+func (a *APMPlugin) setAuthHeader(req *http.Request) error {
+	if sharedSecret := strings.TrimSpace(a.config[configKeySharedSecret]); sharedSecret != "" {
+		token, err := a.getOrRefreshJWT()
+		if err != nil {
+			return fmt.Errorf("failed to generate JWT: %v", err)
+		}
 		req.Header.Set("Authorization", "Bearer "+token)
-		return
+		return nil
 	}
 
 	username := strings.TrimSpace(a.config[configKeyUsername])
@@ -274,8 +374,48 @@ func (a *APMPlugin) setAuthHeader(req *http.Request) {
 	if username != "" || password != "" {
 		req.SetBasicAuth(username, password)
 	}
-	// If neither token nor username/password is set, the request remains
-	// unauthenticated (for local/testing scenarios).
+	return nil
+}
+
+// getOrRefreshJWT returns the cached JWT if it is still fresh, or generates
+// and caches a new one. The refresh window is max(30s, 10% of token_ttl),
+// so a token is regenerated slightly before it would expire.
+func (a *APMPlugin) getOrRefreshJWT() (string, error) {
+	refreshWindow := max(a.tokenTTL/10, 30*time.Second)
+
+	a.jwtMu.Lock()
+	defer a.jwtMu.Unlock()
+
+	if a.cachedToken != "" && time.Until(a.tokenExpiry) > refreshWindow {
+		return a.cachedToken, nil
+	}
+
+	token, expiry, err := a.generateJWT()
+	if err != nil {
+		return "", err
+	}
+
+	a.cachedToken = token
+	a.tokenExpiry = expiry
+	a.logger.Debug("generated new InfluxDB JWT", "expires_at", expiry.UTC().Format(time.RFC3339))
+	return token, nil
+}
+
+// generateJWT creates a new HS256-signed JWT for InfluxDB 1.x Bearer auth.
+// The JWT payload contains the configured username and an expiry of now+tokenTTL,
+// matching the format expected by InfluxDB's shared-secret JWT authentication.
+func (a *APMPlugin) generateJWT() (string, time.Time, error) {
+	expiry := time.Now().Add(a.tokenTTL)
+	claims := jwtlib.MapClaims{
+		"username": strings.TrimSpace(a.config[configKeyUsername]),
+		"exp":      expiry.Unix(),
+	}
+	tok := jwtlib.NewWithClaims(jwtlib.SigningMethodHS256, claims)
+	signed, err := tok.SignedString([]byte(strings.TrimSpace(a.config[configKeySharedSecret])))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return signed, expiry, nil
 }
 
 // parseSeries converts an InfluxDB result series into sdk.TimestampedMetrics.
@@ -329,9 +469,9 @@ func parseSeries(series influxQuerySeries) (sdk.TimestampedMetrics, error) {
 	return metrics, nil
 }
 
-// parseEpochSeconds converts an interface{} (typically a JSON number) into an
+// parseEpochSeconds converts an any value (typically a JSON number) into an
 // int64 Unix epoch in seconds.
-func parseEpochSeconds(v interface{}) (int64, error) {
+func parseEpochSeconds(v any) (int64, error) {
 	switch t := v.(type) {
 	case float64:
 		return int64(t), nil
@@ -348,9 +488,9 @@ func parseEpochSeconds(v interface{}) (int64, error) {
 	}
 }
 
-// parseFloatValue converts an interface{} (typically a JSON number) into a
+// parseFloatValue converts an any value (typically a JSON number) into a
 // float64 metric value.
-func parseFloatValue(v interface{}) (float64, error) {
+func parseFloatValue(v any) (float64, error) {
 	switch t := v.(type) {
 	case float64:
 		return t, nil
@@ -371,4 +511,15 @@ func indexOfColumn(columns []string, key string) int {
 		}
 	}
 	return -1
+}
+
+// configOrEnv returns the trimmed value of config[key] if non-empty, otherwise
+// the trimmed value of the environment variable envVar. Returns "" if neither
+// is set. The config map always takes precedence over the environment variable.
+func configOrEnv(config map[string]string, key, envVar string) string {
+	if v := strings.TrimSpace(config[key]); v != "" {
+		return v
+	}
+	v, _ := os.LookupEnv(envVar)
+	return strings.TrimSpace(v)
 }

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -28,39 +28,30 @@ const (
 	pluginName = "influxdb"
 
 	// configKeyAddress is the InfluxDB server address.
-	// Falls back to INFLUXDB_ADDRESS if not set in the config map.
 	configKeyAddress = "address"
 
 	// configKeyDatabase is the primary config key for the database name.
-	// Falls back to INFLUXDB_DATABASE if neither "database" nor "db" is set.
 	configKeyDatabase = "database"
 
-	// configKeyDB is the shorthand alias accepted for database name.
-	// Lower priority than "database"; takes precedence over INFLUXDB_DATABASE.
+	// configKeyDB is the shorthand alias for database name; lower priority than "database".
 	configKeyDB = "db"
 
-	// configKeyUsername is the optional authentication username.
+	// configKeyUsername is the authentication username.
 	// Required when shared_secret is set (used as the JWT "username" claim).
-	// Falls back to INFLUXDB_USERNAME if not set in the config map.
 	configKeyUsername = "username"
 
-	// configKeyPassword is the optional authentication password.
-	// Used together with username for HTTP Basic auth.
+	// configKeyPassword is the authentication password for HTTP Basic auth.
 	// Cannot be used together with shared_secret.
-	// Falls back to INFLUXDB_PASSWORD if not set in the config map.
 	configKeyPassword = "password"
 
-	// configKeySharedSecret is the InfluxDB shared secret used to sign
-	// auto-generated HS256 JWTs. When set, the plugin generates and refreshes
-	// Bearer JWTs internally — no manual token management required.
+	// configKeySharedSecret is the InfluxDB shared secret used to sign HS256 JWTs.
 	// Requires: username. Conflicts with: password.
 	// Corresponds to INFLUXDB_HTTP_SHARED_SECRET on the InfluxDB server.
-	// Falls back to INFLUXDB_SHARED_SECRET if not set in the config map.
 	configKeySharedSecret = "shared_secret"
 
 	// configKeyTokenTTL is the optional lifetime for auto-generated JWTs.
 	// Accepts Go duration strings (e.g. "30m", "2h"). Default: 1h.
-	// Range: 1m – 24h. Only meaningful when shared_secret is set.
+	// Range: 1m – 24h. Only used when shared_secret is set.
 	configKeyTokenTTL = "token_ttl"
 
 	// configKeyVersion selects the InfluxDB API version. Only "1" is
@@ -80,9 +71,7 @@ const (
 	// queryTimeout is the per-request deadline for InfluxDB HTTP queries.
 	queryTimeout = 10 * time.Second
 
-	// Environment variable names for credential fallback.
-	// The config map always takes precedence; these are checked only when the
-	// corresponding config key is absent or empty.
+	// env var fallback for credentials; config map values take precedence.
 	envVarAddress      = "INFLUXDB_ADDRESS"
 	envVarDatabase     = "INFLUXDB_DATABASE"
 	envVarUsername     = "INFLUXDB_USERNAME"
@@ -148,13 +137,10 @@ func NewInfluxDBPlugin(log hclog.Logger) apm.APM {
 	}
 }
 
-// SetConfig parses and validates the plugin configuration. All required fields
-// are checked before any state is mutated, so a failed re-configuration leaves
-// the plugin in its previous working state.
+// SetConfig parses and validates the plugin configuration. A failed
+// reconfigure leaves the previous state untouched.
 func (a *APMPlugin) SetConfig(config map[string]string) error {
-	// Copy the config map so we can write resolved values back without
-	// mutating the caller's map. All validation runs on this copy, and it
-	// becomes a.config only after all checks pass.
+	// don't mutate the caller's map; cfg becomes a.config only after all checks pass
 	cfg := make(map[string]string, len(config))
 	for k, v := range config {
 		cfg[k] = v
@@ -179,7 +165,7 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 		return fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
 	}
 
-	// Validate auth configuration mutual exclusivity.
+	// password and shared_secret are mutually exclusive
 	username := configOrEnv(cfg, configKeyUsername, envVarUsername)
 	password := configOrEnv(cfg, configKeyPassword, envVarPassword)
 	sharedSecret := configOrEnv(cfg, configKeySharedSecret, envVarSharedSecret)
@@ -223,22 +209,20 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 		return fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
 	}
 
-	// Write resolved values back so downstream methods (setAuthHeader,
-	// generateJWT) can read them from a.config without needing env var awareness.
+	// write resolved values back so setAuthHeader/generateJWT don't need env var awareness
 	cfg[configKeyAddress] = address
 	cfg[configKeyDatabase] = database
 	cfg[configKeyUsername] = username
 	cfg[configKeyPassword] = password
 	cfg[configKeySharedSecret] = sharedSecret
 
-	// All validation passed — atomically update plugin state.
+	// all checks passed, commit new state
 	a.config = cfg
 	a.baseURL = parsedURL
 	a.client = &http.Client{}
 	a.tokenTTL = ttl
 
-	// Reset cached JWT so any previously generated token is not reused after
-	// a config change.
+	// invalidate cached JWT on reconfigure
 	a.jwtMu.Lock()
 	a.cachedToken = ""
 	a.tokenExpiry = time.Time{}
@@ -420,7 +404,7 @@ func (a *APMPlugin) generateJWT() (string, time.Time, error) {
 
 // parseSeries converts an InfluxDB result series into sdk.TimestampedMetrics.
 // It locates the "time" column and picks the first non-time column as the
-// metric value (preferring one literally named "value").
+// metric value (prefers a column named "value").
 func parseSeries(series influxQuerySeries) (sdk.TimestampedMetrics, error) {
 	timeIdx := indexOfColumn(series.Columns, "time")
 	if timeIdx == -1 {
@@ -514,8 +498,7 @@ func indexOfColumn(columns []string, key string) int {
 }
 
 // configOrEnv returns the trimmed value of config[key] if non-empty, otherwise
-// the trimmed value of the environment variable envVar. Returns "" if neither
-// is set. The config map always takes precedence over the environment variable.
+// the trimmed value of the environment variable envVar.
 func configOrEnv(config map[string]string, key, envVar string) string {
 	if v := strings.TrimSpace(config[key]); v != "" {
 		return v

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -40,9 +40,11 @@ const (
 	// configKeyPassword is the optional authentication password.
 	configKeyPassword = "password"
 
-	// configKeyToken is the optional authentication token. When set, it
+	// configKeyToken is the optional JWT authentication token. When set, it
 	// takes precedence over username/password and cannot be used together
-	// with them. Supports InfluxDB 1.x Enterprise token-based auth.
+	// with them. The token is sent as "Authorization: Bearer <token>" and
+	// supports InfluxDB 1.x JWT auth (requires shared-secret configured on
+	// the InfluxDB server via INFLUXDB_HTTP_SHARED_SECRET or [http] shared-secret).
 	configKeyToken = "token"
 
 	// configKeyVersion selects the InfluxDB API version. Only "1" is
@@ -259,11 +261,11 @@ func (a *APMPlugin) database() string {
 }
 
 // setAuthHeader applies the appropriate authentication method to the HTTP
-// request. It supports both token-based auth (for InfluxDB 1.x Enterprise)
-// and username/password basic auth (for InfluxDB 1.x OSS).
+// request. It supports JWT Bearer token auth (for InfluxDB 1.x shared-secret
+// JWT auth) and username/password basic auth (for InfluxDB 1.x OSS/Enterprise).
 func (a *APMPlugin) setAuthHeader(req *http.Request) {
 	if token := strings.TrimSpace(a.config[configKeyToken]); token != "" {
-		req.Header.Set("Authorization", "Token "+token)
+		req.Header.Set("Authorization", "Bearer "+token)
 		return
 	}
 

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -33,9 +33,6 @@ const (
 	// configKeyDatabase is the primary config key for the database name.
 	configKeyDatabase = "database"
 
-	// configKeyDB is the shorthand alias for database name; lower priority than "database".
-	configKeyDB = "db"
-
 	// configKeyUsername is the authentication username.
 	// Required when shared_secret is set (used as the JWT "username" claim).
 	configKeyUsername = "username"
@@ -53,13 +50,6 @@ const (
 	// Accepts Go duration strings (e.g. "30m", "2h"). Default: 1h.
 	// Range: 1m – 24h. Only used when shared_secret is set.
 	configKeyTokenTTL = "token_ttl"
-
-	// configKeyVersion selects the InfluxDB API version. Only "1" is
-	// currently supported; "2" and "3" are reserved for future implementation.
-	configKeyVersion = "version"
-
-	// configVersion1 is the default and only supported version today.
-	configVersion1 = "1"
 
 	// defaultTokenTTL is the JWT lifetime when token_ttl is not configured.
 	defaultTokenTTL = time.Hour
@@ -151,11 +141,8 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 		return fmt.Errorf("%q config value cannot be empty", configKeyAddress)
 	}
 
-	// Resolve database: "database" key → "db" alias → INFLUXDB_DATABASE env var.
+	// Resolve database: "database" key → INFLUXDB_DATABASE env var.
 	database := strings.TrimSpace(cfg[configKeyDatabase])
-	if database == "" {
-		database = strings.TrimSpace(cfg[configKeyDB])
-	}
 	if database == "" {
 		if v := strings.TrimSpace(os.Getenv(envVarDatabase)); v != "" {
 			database = v
@@ -190,15 +177,6 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 			return fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
 		}
 		ttl = parsed
-	}
-
-	switch version := strings.TrimSpace(cfg[configKeyVersion]); version {
-	case "", configVersion1:
-		// ok — v1 is the default
-	case "2", "3":
-		return fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", version, configVersion1)
-	default:
-		return fmt.Errorf("invalid influxdb version %q: only version %q is supported", version, configVersion1)
 	}
 
 	parsedURL, err := url.Parse(address)

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -41,45 +41,10 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			expectOutput: errors.New(`"database" config value cannot be empty`),
 		},
 		{
-			name: "unsupported version 2",
-			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyVersion:  "2",
-			},
-			expectOutput: errors.New(`influxdb version "2" is not yet supported: only version "1" is currently implemented`),
-		},
-		{
-			name: "unsupported version 3",
-			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyVersion:  "3",
-			},
-			expectOutput: errors.New(`influxdb version "3" is not yet supported: only version "1" is currently implemented`),
-		},
-		{
-			name: "invalid version",
-			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyVersion:  "invalid",
-			},
-			expectOutput: errors.New(`invalid influxdb version "invalid": only version "1" is supported`),
-		},
-		{
 			name: "all required config parameters set by database",
 			inputConfig: map[string]string{
 				configKeyAddress:  "http://localhost:8086",
 				configKeyDatabase: "telegraf",
-			},
-			expectOutput: nil,
-		},
-		{
-			name: "all required config parameters set by db",
-			inputConfig: map[string]string{
-				configKeyAddress: "http://localhost:8086",
-				configKeyDB:      "telegraf",
 			},
 			expectOutput: nil,
 		},
@@ -230,18 +195,6 @@ func TestAPMPlugin_SetConfig_EnvFallback(t *testing.T) {
 			configKeyDatabase: "config-db",
 		}))
 		must.Eq(t, "config-db", p.config[configKeyDatabase])
-	})
-
-	t.Run("db alias takes priority over database env var", func(t *testing.T) {
-		t.Setenv(envVarAddress, "http://localhost:8086")
-		t.Setenv(envVarDatabase, "env-db")
-		p := APMPlugin{logger: hclog.NewNullLogger()}
-		must.NoError(t, p.SetConfig(map[string]string{
-			configKeyAddress: "http://localhost:8086",
-			configKeyDB:      "alias-db",
-		}))
-		// db alias should win over the env var; resolved into configKeyDatabase
-		must.Eq(t, "alias-db", p.config[configKeyDatabase])
 	})
 
 	t.Run("username and password from env vars", func(t *testing.T) {

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestAPMPlugin_SetConfig(t *testing.T) {
-	// Clear credential env vars so test outcomes are not affected by whatever
-	// the developer's (or CI) environment happens to have set.
+	// avoid picking up stale values from the local or CI environment
 	for _, ev := range []string{envVarAddress, envVarDatabase, envVarUsername, envVarPassword, envVarSharedSecret} {
 		t.Setenv(ev, "")
 	}
@@ -192,11 +191,8 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 	}
 }
 
-// TestAPMPlugin_SetConfig_EnvFallback verifies that SetConfig resolves
-// credentials from environment variables when the corresponding HCL config
-// keys are absent or empty. It also confirms that config map values always
-// take priority over env vars, and that empty env vars still trigger the
-// required-field validation error.
+// TestAPMPlugin_SetConfig_EnvFallback tests env var credential fallback:
+// config map wins when both are set, empty env var still fails validation.
 func TestAPMPlugin_SetConfig_EnvFallback(t *testing.T) {
 	t.Run("address from env var", func(t *testing.T) {
 		t.Setenv(envVarAddress, "http://influxdb-env:8086")
@@ -300,9 +296,7 @@ func TestAPMPlugin_SetConfig_EnvFallback(t *testing.T) {
 	})
 }
 
-// TestAPMPlugin_Query exercises the full HTTP query path against a test server,
-// covering credential transmission (Basic auth, JWT Bearer), null value handling,
-// multi-stream error, and non-time column selection.
+// TestAPMPlugin_Query tests the HTTP query path against a local test server.
 func TestAPMPlugin_Query(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -332,7 +326,7 @@ func TestAPMPlugin_Query(t *testing.T) {
 				must.Eq(t, "telegraf", qp.Get("db"))
 				must.Eq(t, "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 10m", qp.Get("q"))
 				must.Eq(t, "s", qp.Get("epoch"))
-				// Verify credentials are NOT in query params (security fix)
+				// credentials must not leak into query params
 				must.Eq(t, "", qp.Get("u"))
 				must.Eq(t, "", qp.Get("p"))
 				// Verify Basic auth header is set
@@ -386,7 +380,7 @@ func TestAPMPlugin_Query(t *testing.T) {
 				must.NotEq(t, "", authHeader)
 				must.True(t, strings.HasPrefix(authHeader, "Bearer "), must.Sprintf("expected Bearer scheme, got: %s", authHeader))
 
-				// Parse and verify the JWT structure and claims.
+				// check the JWT and its claims
 				rawToken := strings.TrimPrefix(authHeader, "Bearer ")
 				tok, err := jwtlib.Parse(rawToken, func(jwtTok *jwtlib.Token) (any, error) {
 					_, ok := jwtTok.Method.(*jwtlib.SigningMethodHMAC)
@@ -480,9 +474,8 @@ func TestAPMPlugin_Query(t *testing.T) {
 	}
 }
 
-// TestAPMPlugin_JWT_Caching verifies that getOrRefreshJWT returns a cached
-// token on repeated calls within the TTL, and generates a new token once
-// the cached token enters the refresh window.
+// TestAPMPlugin_JWT_Caching tests that tokens are reused within the TTL
+// and refreshed once they enter the expiry window.
 func TestAPMPlugin_JWT_Caching(t *testing.T) {
 	p := &APMPlugin{
 		logger: hclog.NewNullLogger(),
@@ -516,11 +509,9 @@ func TestAPMPlugin_JWT_Caching(t *testing.T) {
 	tok3, err := p.getOrRefreshJWT()
 	must.NoError(t, err)
 	must.NotEq(t, "", tok3)
-	// A genuinely new token always produces a different string because exp = now+ttl
-	// is re-computed at generation time. Without this assertion the refresh path
-	// would pass even if getOrRefreshJWT returned the stale cached token.
+	// exp is recomputed on each generation, so a fresh token is always a different string
 	must.NotEq(t, tok1, tok3, must.Sprint("expected a newly generated token after entering refresh window"))
-	// Verify the refreshed token is cryptographically valid.
+	// make sure the new token is actually valid
 	parsed, err := jwtlib.Parse(tok3, func(jwtTok *jwtlib.Token) (any, error) {
 		return []byte("cache-test-secret"), nil
 	})
@@ -542,8 +533,7 @@ func TestAPMPlugin_Query_InstantNotSupported(t *testing.T) {
 	must.StrContains(t, err.Error(), `query_window = "instant" is not supported by influxdb`)
 }
 
-// TestAPMPlugin_Query_Errors covers HTTP-level errors, InfluxDB-level query
-// errors, and empty result sets returned from the /query endpoint.
+// TestAPMPlugin_Query_Errors tests HTTP errors, InfluxDB query errors, and empty results.
 func TestAPMPlugin_Query_Errors(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -8,16 +8,24 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
+	jwtlib "github.com/golang-jwt/jwt/v5"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
 )
 
 func TestAPMPlugin_SetConfig(t *testing.T) {
+	// Clear credential env vars so test outcomes are not affected by whatever
+	// the developer's (or CI) environment happens to have set.
+	for _, ev := range []string{envVarAddress, envVarDatabase, envVarUsername, envVarPassword, envVarSharedSecret} {
+		t.Setenv(ev, "")
+	}
+
 	testCases := []struct {
 		name         string
 		inputConfig  map[string]string
@@ -85,44 +93,78 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			expectOutput: errors.New(`"address" must be a valid absolute URL`),
 		},
 		{
-			name: "token auth only",
+			name: "shared_secret with username is valid",
 			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-token-123",
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
 			},
 			expectOutput: nil,
 		},
 		{
-			name: "token conflicts with username",
+			name: "shared_secret without username is invalid",
 			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-token",
-				configKeyUsername: "user",
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeySharedSecret: "my-secret",
 			},
-			expectOutput: errors.New(`conflicting auth configuration: "token" cannot be used together with "username" or "password"`),
+			expectOutput: errors.New(`auth configuration error: "shared_secret" requires "username" (used as the JWT username claim)`),
 		},
 		{
-			name: "token conflicts with password",
+			name: "shared_secret conflicts with password",
 			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-token",
-				configKeyPassword: "pass",
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeyPassword:     "hunter2",
+				configKeySharedSecret: "my-secret",
 			},
-			expectOutput: errors.New(`conflicting auth configuration: "token" cannot be used together with "username" or "password"`),
+			expectOutput: errors.New(`conflicting auth configuration: "shared_secret" cannot be used together with "password"`),
 		},
 		{
-			name: "token conflicts with both username and password",
+			name: "custom token_ttl valid",
 			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-token",
-				configKeyUsername: "user",
-				configKeyPassword: "pass",
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
+				configKeyTokenTTL:     "30m",
 			},
-			expectOutput: errors.New(`conflicting auth configuration: "token" cannot be used together with "username" or "password"`),
+			expectOutput: nil,
+		},
+		{
+			name: "token_ttl below minimum",
+			inputConfig: map[string]string{
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
+				configKeyTokenTTL:     "30s",
+			},
+			expectOutput: errors.New(`invalid "token_ttl" value "30s": must be between 1m0s and 24h0m0s`),
+		},
+		{
+			name: "token_ttl above maximum",
+			inputConfig: map[string]string{
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
+				configKeyTokenTTL:     "25h",
+			},
+			expectOutput: errors.New(`invalid "token_ttl" value "25h": must be between 1m0s and 24h0m0s`),
+		},
+		{
+			name: "token_ttl invalid string",
+			inputConfig: map[string]string{
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
+				configKeyTokenTTL:     "forever",
+			},
+			expectOutput: errors.New(`invalid "token_ttl" value "forever"`),
 		},
 	}
 
@@ -131,19 +173,136 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			apmPlugin := APMPlugin{logger: hclog.NewNullLogger()}
 
 			actualOutput := apmPlugin.SetConfig(tc.inputConfig)
-			assert.Equal(t, tc.expectOutput, actualOutput)
 
 			if tc.expectOutput == nil {
-				assert.NotNil(t, apmPlugin.client)
-				assert.NotNil(t, apmPlugin.baseURL)
+				test.NoError(t, actualOutput)
 			} else {
-				assert.Nil(t, apmPlugin.client)
-				assert.Nil(t, apmPlugin.baseURL)
+				must.Error(t, actualOutput)
+				test.StrContains(t, actualOutput.Error(), tc.expectOutput.Error())
+			}
+
+			if tc.expectOutput == nil {
+				test.NotNil(t, apmPlugin.client)
+				test.NotNil(t, apmPlugin.baseURL)
+			} else {
+				test.Nil(t, apmPlugin.client)
+				test.Nil(t, apmPlugin.baseURL)
 			}
 		})
 	}
 }
 
+// TestAPMPlugin_SetConfig_EnvFallback verifies that SetConfig resolves
+// credentials from environment variables when the corresponding HCL config
+// keys are absent or empty. It also confirms that config map values always
+// take priority over env vars, and that empty env vars still trigger the
+// required-field validation error.
+func TestAPMPlugin_SetConfig_EnvFallback(t *testing.T) {
+	t.Run("address from env var", func(t *testing.T) {
+		t.Setenv(envVarAddress, "http://influxdb-env:8086")
+		t.Setenv(envVarDatabase, "telegraf-env")
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		must.NoError(t, p.SetConfig(map[string]string{}))
+		must.Eq(t, "http://influxdb-env:8086", p.baseURL.String())
+	})
+
+	t.Run("database from env var", func(t *testing.T) {
+		t.Setenv(envVarAddress, "http://localhost:8086")
+		t.Setenv(envVarDatabase, "telegraf-env")
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		must.NoError(t, p.SetConfig(map[string]string{}))
+		must.Eq(t, "telegraf-env", p.config[configKeyDatabase])
+	})
+
+	t.Run("config map overrides address env var", func(t *testing.T) {
+		t.Setenv(envVarAddress, "http://env-host:8086")
+		t.Setenv(envVarDatabase, "telegraf")
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		must.NoError(t, p.SetConfig(map[string]string{
+			configKeyAddress:  "http://config-host:8086",
+			configKeyDatabase: "telegraf",
+		}))
+		must.Eq(t, "http://config-host:8086", p.baseURL.String())
+	})
+
+	t.Run("config map overrides database env var", func(t *testing.T) {
+		t.Setenv(envVarAddress, "http://localhost:8086")
+		t.Setenv(envVarDatabase, "env-db")
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		must.NoError(t, p.SetConfig(map[string]string{
+			configKeyAddress:  "http://localhost:8086",
+			configKeyDatabase: "config-db",
+		}))
+		must.Eq(t, "config-db", p.config[configKeyDatabase])
+	})
+
+	t.Run("db alias takes priority over database env var", func(t *testing.T) {
+		t.Setenv(envVarAddress, "http://localhost:8086")
+		t.Setenv(envVarDatabase, "env-db")
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		must.NoError(t, p.SetConfig(map[string]string{
+			configKeyAddress: "http://localhost:8086",
+			configKeyDB:      "alias-db",
+		}))
+		// db alias should win over the env var; resolved into configKeyDatabase
+		must.Eq(t, "alias-db", p.config[configKeyDatabase])
+	})
+
+	t.Run("username and password from env vars", func(t *testing.T) {
+		t.Setenv(envVarAddress, "http://localhost:8086")
+		t.Setenv(envVarDatabase, "telegraf")
+		t.Setenv(envVarUsername, "env-user")
+		t.Setenv(envVarPassword, "env-pass")
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		must.NoError(t, p.SetConfig(map[string]string{}))
+		must.Eq(t, "env-user", p.config[configKeyUsername])
+		must.Eq(t, "env-pass", p.config[configKeyPassword])
+	})
+
+	t.Run("shared_secret and username from env vars", func(t *testing.T) {
+		t.Setenv(envVarAddress, "http://localhost:8086")
+		t.Setenv(envVarDatabase, "telegraf")
+		t.Setenv(envVarUsername, "env-user")
+		t.Setenv(envVarSharedSecret, "env-secret")
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		must.NoError(t, p.SetConfig(map[string]string{}))
+		must.Eq(t, "env-user", p.config[configKeyUsername])
+		must.Eq(t, "env-secret", p.config[configKeySharedSecret])
+	})
+
+	t.Run("shared_secret from env requires username", func(t *testing.T) {
+		t.Setenv(envVarAddress, "http://localhost:8086")
+		t.Setenv(envVarDatabase, "telegraf")
+		t.Setenv(envVarSharedSecret, "env-secret")
+		// no username in config or env
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		err := p.SetConfig(map[string]string{})
+		must.Error(t, err)
+		test.StrContains(t, err.Error(), `"shared_secret" requires "username"`)
+	})
+
+	t.Run("empty address env var still fails required check", func(t *testing.T) {
+		t.Setenv(envVarAddress, "")
+		t.Setenv(envVarDatabase, "telegraf")
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		err := p.SetConfig(map[string]string{})
+		must.Error(t, err)
+		test.StrContains(t, err.Error(), `"address" config value cannot be empty`)
+	})
+
+	t.Run("empty database env var still fails required check", func(t *testing.T) {
+		t.Setenv(envVarAddress, "http://localhost:8086")
+		t.Setenv(envVarDatabase, "")
+		p := APMPlugin{logger: hclog.NewNullLogger()}
+		err := p.SetConfig(map[string]string{})
+		must.Error(t, err)
+		test.StrContains(t, err.Error(), `"database" config value cannot be empty`)
+	})
+}
+
+// TestAPMPlugin_Query exercises the full HTTP query path against a test server,
+// covering credential transmission (Basic auth, JWT Bearer), null value handling,
+// multi-stream error, and non-time column selection.
 func TestAPMPlugin_Query(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -168,22 +327,22 @@ func TestAPMPlugin_Query(t *testing.T) {
 				To:   time.Unix(1610000000, 0),
 			},
 			validateRequest: func(t *testing.T, r *http.Request) {
-				require.Equal(t, "/query", r.URL.Path)
+				must.Eq(t, "/query", r.URL.Path)
 				qp := r.URL.Query()
-				require.Equal(t, "telegraf", qp.Get("db"))
-				require.Equal(t, "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 10m", qp.Get("q"))
-				require.Equal(t, "s", qp.Get("epoch"))
+				must.Eq(t, "telegraf", qp.Get("db"))
+				must.Eq(t, "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 10m", qp.Get("q"))
+				must.Eq(t, "s", qp.Get("epoch"))
 				// Verify credentials are NOT in query params (security fix)
-				require.Empty(t, qp.Get("u"))
-				require.Empty(t, qp.Get("p"))
+				must.Eq(t, "", qp.Get("u"))
+				must.Eq(t, "", qp.Get("p"))
 				// Verify Basic auth header is set
 				authHeader := r.Header.Get("Authorization")
-				require.NotEmpty(t, authHeader)
-				require.Equal(t, "Basic dXNlcjpwYXNz", authHeader) // base64(user:pass)
+				must.NotEq(t, "", authHeader)
+				must.Eq(t, "Basic dXNlcjpwYXNz", authHeader) // base64(user:pass)
 			},
 			validateMetrics: func(t *testing.T, m sdk.TimestampedMetrics, err error) {
-				require.NoError(t, err)
-				require.Len(t, m, 3)
+				must.NoError(t, err)
+				must.Len(t, 3, m)
 			},
 		},
 		{
@@ -199,22 +358,23 @@ func TestAPMPlugin_Query(t *testing.T) {
 			},
 			validateRequest: func(t *testing.T, r *http.Request) {
 				// Verify no auth header when credentials not provided
-				require.Empty(t, r.Header.Get("Authorization"))
+				must.Eq(t, "", r.Header.Get("Authorization"))
 				// Verify no credentials in query params
-				require.Empty(t, r.URL.Query().Get("u"))
-				require.Empty(t, r.URL.Query().Get("p"))
+				must.Eq(t, "", r.URL.Query().Get("u"))
+				must.Eq(t, "", r.URL.Query().Get("p"))
 			},
 			validateMetrics: func(t *testing.T, m sdk.TimestampedMetrics, err error) {
-				require.NoError(t, err)
-				require.Len(t, m, 2)
+				must.NoError(t, err)
+				must.Len(t, 2, m)
 			},
 		},
 		{
-			name:    "token auth",
+			name:    "shared_secret JWT auth",
 			fixture: "query_200.json",
 			pluginConfig: map[string]string{
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-secret-token",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "test-shared-secret",
 			},
 			query: "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 10m",
 			timeRange: sdk.TimeRange{
@@ -222,18 +382,37 @@ func TestAPMPlugin_Query(t *testing.T) {
 				To:   time.Unix(1610000000, 0),
 			},
 			validateRequest: func(t *testing.T, r *http.Request) {
-				require.Equal(t, "/query", r.URL.Path)
-				// Verify token is in Authorization header as Bearer scheme
 				authHeader := r.Header.Get("Authorization")
-				require.Equal(t, "Bearer my-secret-token", authHeader)
-				// Verify no credentials in query params
+				must.NotEq(t, "", authHeader)
+				must.True(t, strings.HasPrefix(authHeader, "Bearer "), must.Sprintf("expected Bearer scheme, got: %s", authHeader))
+
+				// Parse and verify the JWT structure and claims.
+				rawToken := strings.TrimPrefix(authHeader, "Bearer ")
+				tok, err := jwtlib.Parse(rawToken, func(jwtTok *jwtlib.Token) (any, error) {
+					_, ok := jwtTok.Method.(*jwtlib.SigningMethodHMAC)
+					must.True(t, ok, must.Sprint("expected HS256 signing method"))
+					return []byte("test-shared-secret"), nil
+				})
+				must.NoError(t, err)
+				must.True(t, tok.Valid)
+
+				claims, ok := tok.Claims.(jwtlib.MapClaims)
+				must.True(t, ok)
+				must.Eq(t, "autoscaler", claims["username"])
+
+				// exp must be in the future.
+				exp, err := claims.GetExpirationTime()
+				must.NoError(t, err)
+				must.True(t, exp.After(time.Now()), must.Sprint("JWT exp should be in the future"))
+
+				// No credentials in query params.
 				qp := r.URL.Query()
-				require.Empty(t, qp.Get("u"))
-				require.Empty(t, qp.Get("p"))
+				must.Eq(t, "", qp.Get("u"))
+				must.Eq(t, "", qp.Get("p"))
 			},
 			validateMetrics: func(t *testing.T, m sdk.TimestampedMetrics, err error) {
-				require.NoError(t, err)
-				require.Len(t, m, 3)
+				must.NoError(t, err)
+				must.Len(t, 3, m)
 			},
 		},
 		{
@@ -248,8 +427,8 @@ func TestAPMPlugin_Query(t *testing.T) {
 				To:   time.Unix(1670000000, 0),
 			},
 			validateMetrics: func(t *testing.T, m sdk.TimestampedMetrics, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "only 1 is expected")
+				must.Error(t, err)
+				must.StrContains(t, err.Error(), "only 1 is expected")
 			},
 		},
 		{
@@ -264,11 +443,11 @@ func TestAPMPlugin_Query(t *testing.T) {
 				To:   time.Unix(1600000200, 0),
 			},
 			validateMetrics: func(t *testing.T, m sdk.TimestampedMetrics, err error) {
-				require.NoError(t, err)
-				require.Len(t, m, 4)
+				must.NoError(t, err)
+				must.Len(t, 4, m)
 				// Verify values are parsed correctly from "mean" column
-				require.Equal(t, 75.5, m[0].Value)
-				require.Equal(t, 78.2, m[1].Value)
+				must.Eq(t, 75.5, m[0].Value)
+				must.Eq(t, 78.2, m[1].Value)
 			},
 		},
 	}
@@ -285,13 +464,13 @@ func TestAPMPlugin_Query(t *testing.T) {
 
 			plugin := NewInfluxDBPlugin(hclog.NewNullLogger())
 			err := plugin.SetConfig(map[string]string{
-				configKeyAddress:  srv.URL,
-				configKeyDatabase: tc.pluginConfig[configKeyDatabase],
-				configKeyUsername: tc.pluginConfig[configKeyUsername],
-				configKeyPassword: tc.pluginConfig[configKeyPassword],
-				configKeyToken:    tc.pluginConfig[configKeyToken],
+				configKeyAddress:      srv.URL,
+				configKeyDatabase:     tc.pluginConfig[configKeyDatabase],
+				configKeyUsername:     tc.pluginConfig[configKeyUsername],
+				configKeyPassword:     tc.pluginConfig[configKeyPassword],
+				configKeySharedSecret: tc.pluginConfig[configKeySharedSecret],
 			})
-			require.NoError(t, err)
+			must.NoError(t, err)
 
 			metrics, err := plugin.Query(tc.query, tc.timeRange)
 			if tc.validateMetrics != nil {
@@ -301,20 +480,70 @@ func TestAPMPlugin_Query(t *testing.T) {
 	}
 }
 
+// TestAPMPlugin_JWT_Caching verifies that getOrRefreshJWT returns a cached
+// token on repeated calls within the TTL, and generates a new token once
+// the cached token enters the refresh window.
+func TestAPMPlugin_JWT_Caching(t *testing.T) {
+	p := &APMPlugin{
+		logger: hclog.NewNullLogger(),
+		config: map[string]string{
+			configKeyUsername:     "autoscaler",
+			configKeySharedSecret: "cache-test-secret",
+		},
+		tokenTTL: time.Hour,
+	}
+
+	// First call — token is generated.
+	tok1, err := p.getOrRefreshJWT()
+	must.NoError(t, err)
+	must.NotEq(t, "", tok1)
+
+	// Second call within TTL — same token returned (cached).
+	tok2, err := p.getOrRefreshJWT()
+	must.NoError(t, err)
+	must.Eq(t, tok1, tok2, must.Sprint("expected cached token to be reused"))
+
+	// Sleep 1s so the next token gets a different exp. JWT timestamps are
+	// whole seconds, so same-second regeneration produces an identical string.
+	time.Sleep(time.Second)
+
+	// Simulate expiry by rewinding tokenExpiry into the refresh window.
+	p.jwtMu.Lock()
+	p.tokenExpiry = time.Now().Add(10 * time.Second) // inside 30s refresh window
+	p.jwtMu.Unlock()
+
+	// Third call — token must be refreshed with a new exp.
+	tok3, err := p.getOrRefreshJWT()
+	must.NoError(t, err)
+	must.NotEq(t, "", tok3)
+	// A genuinely new token always produces a different string because exp = now+ttl
+	// is re-computed at generation time. Without this assertion the refresh path
+	// would pass even if getOrRefreshJWT returned the stale cached token.
+	must.NotEq(t, tok1, tok3, must.Sprint("expected a newly generated token after entering refresh window"))
+	// Verify the refreshed token is cryptographically valid.
+	parsed, err := jwtlib.Parse(tok3, func(jwtTok *jwtlib.Token) (any, error) {
+		return []byte("cache-test-secret"), nil
+	})
+	must.NoError(t, err)
+	must.True(t, parsed.Valid)
+}
+
 func TestAPMPlugin_Query_InstantNotSupported(t *testing.T) {
 	plugin := NewInfluxDBPlugin(hclog.NewNullLogger())
 	err := plugin.SetConfig(map[string]string{
 		configKeyAddress:  "http://localhost:8086",
 		configKeyDatabase: "telegraf",
 	})
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	now := time.Now().UTC()
 	_, err = plugin.Query("SELECT mean(usage_idle) FROM cpu", sdk.TimeRange{From: now, To: now})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), `query_window = "instant" is not supported by influxdb`)
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), `query_window = "instant" is not supported by influxdb`)
 }
 
+// TestAPMPlugin_Query_Errors covers HTTP-level errors, InfluxDB-level query
+// errors, and empty result sets returned from the /query endpoint.
 func TestAPMPlugin_Query_Errors(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -373,7 +602,7 @@ func TestAPMPlugin_Query_Errors(t *testing.T) {
 				configKeyAddress:  srv.URL,
 				configKeyDatabase: tc.pluginConfig[configKeyDatabase],
 			})
-			require.NoError(t, err)
+			must.NoError(t, err)
 
 			metrics, err := plugin.Query(tc.query, sdk.TimeRange{
 				From: time.Unix(1600000000, 0),
@@ -381,11 +610,11 @@ func TestAPMPlugin_Query_Errors(t *testing.T) {
 			})
 
 			if tc.expectError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectError)
+				must.Error(t, err)
+				must.StrContains(t, err.Error(), tc.expectError)
 			} else {
-				require.NoError(t, err)
-				require.Empty(t, metrics)
+				must.NoError(t, err)
+				must.Len(t, 0, metrics)
 			}
 		})
 	}

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -223,9 +223,9 @@ func TestAPMPlugin_Query(t *testing.T) {
 			},
 			validateRequest: func(t *testing.T, r *http.Request) {
 				require.Equal(t, "/query", r.URL.Path)
-				// Verify token is in Authorization header
+				// Verify token is in Authorization header as Bearer scheme
 				authHeader := r.Header.Get("Authorization")
-				require.Equal(t, "Token my-secret-token", authHeader)
+				require.Equal(t, "Bearer my-secret-token", authHeader)
 				// Verify no credentials in query params
 				qp := r.URL.Query()
 				require.Empty(t, qp.Get("u"))

--- a/plugins/builtin/apm/nomad/plugin/node_test.go
+++ b/plugins/builtin/apm/nomad/plugin/node_test.go
@@ -274,10 +274,10 @@ func TestAPMPlugin_getPoolResources(t *testing.T) {
 			}),
 		},
 		{
-			name:        "ready ineligible node excluded from pool totals",
-			config:      map[string]string{},
-			expectError: false,
-			expectedCPU: 20,
+			name:          "ready ineligible node excluded from pool totals",
+			config:        map[string]string{},
+			expectError:   false,
+			expectedCPU:   20,
 			expectedMemMB: 15,
 			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This PR improves the InfluxDB APM plugin in three areas: fixing JWT-based authentication, adding environment variable credential fallback, and a broad set of code quality improvements.

**Changes:**

**JWT Token Authentication Fix**
- This PR improves the InfluxDB APM plugin in three areas: fixing JWT-based authentication, adding environment variable credential fallback, and a broad set of code quality improvements.
- Corrected the auth header format and token transmission.

**Environment Variable Credential Fallback**
- Credentials can now be supplied via environment variables, eliminating the need to hardcode them in HCL config files. The config map always takes priority; env vars are only consulted when a key is absent or empty.


[PR which introduces this new APM plugin](https://github.com/hashicorp/nomad-autoscaler/pull/1248)

[InfluxDB Documentation](https://docs.influxdata.com/influxdb/v1/administration/authentication_and_authorization/)
[
Autoscaler APM plugin doc for Influxdb](https://github.com/hashicorp/web-unified-docs/blob/update-nomad-autoscaler-docs-release-v0.5.0/content/nomad/v2.0.x/content/tools/autoscaling/plugins/apm/influxdb.mdx)
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

