### PR TITLE
feat(apm/influxdb): add JWT Bearer authentication via shared secret for influxdb 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 * **plugin/apm/influxdb**: Add new InfluxDB APM plugin with support for InfluxDB 1.x query API and InfluxQL queries. The plugin supports basic authentication, database selection, and automatic column detection for metric values.[[GH-1248](https://github.com/hashicorp/nomad-autoscaler/pull/1248)]
+* **plugin/apm/influxdb**: Add JWT Bearer authentication support via `shared_secret` and `username` config keys, matching InfluxDB 1.x shared-secret auth (`INFLUXDB_HTTP_SHARED_SECRET`).[[GH-1297](https://github.com/hashicorp/nomad-autoscaler/pull/1297)]
 * **policy/plugin/apm/prometheus**: Add `query_window = "instant"` support for checks. When set, Prometheus queries are executed as instant queries; existing range-query behavior remains unchanged for duration-based query windows. For threshold strategy with `query_window = "instant"`, `within_bounds_trigger` must be set to 1.[[GH-1256](https://github.com/hashicorp/nomad-autoscaler/pull/1256)]
 * **policy**: Add support for `schedule` blocks at policy and check level to control when evaluations have effect. Schedules are evaluated in UTC, use strict 5-field cron expressions, and support `start` with either `end` or `duration`.[[GH-1264](https://github.com/hashicorp/nomad-autoscaler/issues/1264)]
 

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.28.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.26.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.12
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.36.5
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/cronexpr v1.1.3
 	github.com/hashicorp/go-cleanhttp v0.5.2
@@ -83,7 +84,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.28.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlnd
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,6 @@ github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
-github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/plugins/builtin/apm/influxdb/plugin/auth.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth.go
@@ -30,6 +30,12 @@ const (
 	maxTokenTTL = 24 * time.Hour
 )
 
+// influxClaims are the JWT claims expected by InfluxDB 1.x shared-secret auth.
+type influxClaims struct {
+	Username string `json:"username"`
+	jwt.RegisteredClaims
+}
+
 // setAuthHeader applies the appropriate authentication method to the HTTP
 // request based on the plugin configuration:
 //   - shared_secret + username → auto-generated HS256 JWT Bearer token
@@ -85,9 +91,11 @@ func (a *APMPlugin) getOrRefreshJWT() (string, error) {
 // matching the format expected by InfluxDB's shared-secret JWT authentication.
 func (a *APMPlugin) generateJWT() (string, time.Time, error) {
 	expiry := time.Now().Add(a.cfg.TokenTTL)
-	claims := jwt.MapClaims{
-		"username": a.cfg.Username,
-		"exp":      expiry.Unix(),
+	claims := influxClaims{
+		Username: a.cfg.Username,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expiry),
+		},
 	}
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signed, err := tok.SignedString([]byte(a.cfg.SharedSecret))

--- a/plugins/builtin/apm/influxdb/plugin/auth.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth.go
@@ -35,6 +35,8 @@ const (
 )
 
 // influxClaims are the JWT claims expected by InfluxDB 1.x shared-secret auth.
+// InfluxDB only validates exp and username; the remaining fields from
+// jwt.RegisteredClaims are omitted from the token payload via omitempty.
 type influxClaims struct {
 	Username string `json:"username"`
 	jwt.RegisteredClaims

--- a/plugins/builtin/apm/influxdb/plugin/auth.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth.go
@@ -26,8 +26,12 @@ const (
 	defaultTokenTTL = time.Hour
 
 	// minTokenTTL / maxTokenTTL are the allowed bounds for token_ttl.
-	minTokenTTL = time.Minute
+	minTokenTTL = 10 * time.Minute
 	maxTokenTTL = 24 * time.Hour
+
+	// jwtRefreshBuffer is how long before expiry a new JWT is generated.
+	// Must be less than minTokenTTL to ensure the token is always cached.
+	jwtRefreshBuffer = 2 * time.Minute
 )
 
 // influxClaims are the JWT claims expected by InfluxDB 1.x shared-secret auth.
@@ -58,20 +62,13 @@ func (a *APMPlugin) setAuthHeader(req *http.Request) error {
 }
 
 // getOrRefreshJWT returns the cached JWT if it is still fresh, or generates
-// and caches a new one. The refresh window is max(30s, 10% of token_ttl),
-// so a token is regenerated slightly before it would expire.
+// and caches a new one. The token is refreshed jwtRefreshBuffer before expiry,
+// ensuring it remains valid for at least one full evaluation cycle.
 func (a *APMPlugin) getOrRefreshJWT() (string, error) {
-	var refreshWindow time.Duration
-	if w := a.cfg.TokenTTL / 10; w > 30*time.Second {
-		refreshWindow = w
-	} else {
-		refreshWindow = 30 * time.Second
-	}
-
 	a.jwtMu.Lock()
 	defer a.jwtMu.Unlock()
 
-	if a.cachedToken != "" && time.Until(a.tokenExpiry) > refreshWindow {
+	if a.cachedToken != "" && time.Until(a.tokenExpiry) > jwtRefreshBuffer {
 		return a.cachedToken, nil
 	}
 

--- a/plugins/builtin/apm/influxdb/plugin/auth.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package plugin
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	// configKeySharedSecret is the InfluxDB shared secret used to sign HS256 JWTs.
+	// Requires: username. Conflicts with: password.
+	// Corresponds to INFLUXDB_HTTP_SHARED_SECRET on the InfluxDB server.
+	configKeySharedSecret = "shared_secret"
+
+	// configKeyTokenTTL is the optional lifetime for auto-generated JWTs.
+	// Accepts Go duration strings (e.g. "30m", "2h"). Default: 1h.
+	// Range: 1m – 24h. Only used when shared_secret is set.
+	configKeyTokenTTL = "token_ttl"
+
+	// defaultTokenTTL is the JWT lifetime when token_ttl is not configured.
+	defaultTokenTTL = time.Hour
+
+	// minTokenTTL / maxTokenTTL are the allowed bounds for token_ttl.
+	minTokenTTL = time.Minute
+	maxTokenTTL = 24 * time.Hour
+)
+
+// setAuthHeader applies the appropriate authentication method to the HTTP
+// request based on the plugin configuration:
+//   - shared_secret + username → auto-generated HS256 JWT Bearer token
+//   - username + password      → HTTP Basic auth
+//   - neither                  → unauthenticated (local/dev scenarios)
+func (a *APMPlugin) setAuthHeader(req *http.Request) error {
+	if a.cfg.SharedSecret != "" {
+		token, err := a.getOrRefreshJWT()
+		if err != nil {
+			return fmt.Errorf("failed to generate JWT: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+
+	if a.cfg.Username != "" || a.cfg.Password != "" {
+		req.SetBasicAuth(a.cfg.Username, a.cfg.Password)
+	}
+	return nil
+}
+
+// getOrRefreshJWT returns the cached JWT if it is still fresh, or generates
+// and caches a new one. The refresh window is max(30s, 10% of token_ttl),
+// so a token is regenerated slightly before it would expire.
+func (a *APMPlugin) getOrRefreshJWT() (string, error) {
+	var refreshWindow time.Duration
+	if w := a.cfg.TokenTTL / 10; w > 30*time.Second {
+		refreshWindow = w
+	} else {
+		refreshWindow = 30 * time.Second
+	}
+
+	a.jwtMu.Lock()
+	defer a.jwtMu.Unlock()
+
+	if a.cachedToken != "" && time.Until(a.tokenExpiry) > refreshWindow {
+		return a.cachedToken, nil
+	}
+
+	token, expiry, err := a.generateJWT()
+	if err != nil {
+		return "", err
+	}
+
+	a.cachedToken = token
+	a.tokenExpiry = expiry
+	a.logger.Debug("generated new InfluxDB JWT", "expires_at", expiry.UTC().Format(time.RFC3339))
+	return token, nil
+}
+
+// generateJWT creates a new HS256-signed JWT for InfluxDB 1.x Bearer auth.
+// The JWT payload contains the configured username and an expiry of now+TokenTTL,
+// matching the format expected by InfluxDB's shared-secret JWT authentication.
+func (a *APMPlugin) generateJWT() (string, time.Time, error) {
+	expiry := time.Now().Add(a.cfg.TokenTTL)
+	claims := jwt.MapClaims{
+		"username": a.cfg.Username,
+		"exp":      expiry.Unix(),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString([]byte(a.cfg.SharedSecret))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return signed, expiry, nil
+}

--- a/plugins/builtin/apm/influxdb/plugin/auth.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth.go
@@ -39,7 +39,7 @@ func (a *APMPlugin) setAuthHeader(req *http.Request) error {
 	if a.cfg.SharedSecret != "" {
 		token, err := a.getOrRefreshJWT()
 		if err != nil {
-			return fmt.Errorf("failed to generate JWT: %v", err)
+			return fmt.Errorf("generating JWT: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 		return nil

--- a/plugins/builtin/apm/influxdb/plugin/auth.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth.go
@@ -19,19 +19,15 @@ const (
 
 	// configKeyTokenTTL is the optional lifetime for auto-generated JWTs.
 	// Accepts Go duration strings (e.g. "30m", "2h"). Default: 1h.
-	// Range: 1m – 24h. Only used when shared_secret is set.
+	// Controls the exp claim — shorter values limit the replay window if a
+	// token is intercepted. Only used when shared_secret is set.
 	configKeyTokenTTL = "token_ttl"
 
 	// defaultTokenTTL is the JWT lifetime when token_ttl is not configured.
 	defaultTokenTTL = time.Hour
 
-	// minTokenTTL / maxTokenTTL are the allowed bounds for token_ttl.
-	minTokenTTL = 10 * time.Minute
+	// maxTokenTTL is the upper bound for token_ttl.
 	maxTokenTTL = 24 * time.Hour
-
-	// jwtRefreshBuffer is how long before expiry a new JWT is generated.
-	// Must be less than minTokenTTL to ensure the token is always cached.
-	jwtRefreshBuffer = 2 * time.Minute
 )
 
 // influxClaims are the JWT claims expected by InfluxDB 1.x shared-secret auth.
@@ -49,7 +45,7 @@ type influxClaims struct {
 //   - neither                  → unauthenticated (local/dev scenarios)
 func (a *APMPlugin) setAuthHeader(req *http.Request) error {
 	if a.cfg.SharedSecret != "" {
-		token, err := a.getOrRefreshJWT(time.Now())
+		token, err := a.generateJWT()
 		if err != nil {
 			return fmt.Errorf("generating JWT: %w", err)
 		}
@@ -63,32 +59,16 @@ func (a *APMPlugin) setAuthHeader(req *http.Request) error {
 	return nil
 }
 
-// getOrRefreshJWT returns the cached JWT if it is still fresh, or generates
-// and caches a new one. The token is refreshed jwtRefreshBuffer before expiry,
-// ensuring it remains valid for at least one full evaluation cycle.
-func (a *APMPlugin) getOrRefreshJWT(now time.Time) (string, error) {
-	a.jwtMu.Lock()
-	defer a.jwtMu.Unlock()
-
-	if a.cachedToken != "" && a.tokenExpiry.Sub(now) > jwtRefreshBuffer {
-		return a.cachedToken, nil
-	}
-
-	token, expiry, err := a.generateJWT(now)
-	if err != nil {
-		return "", err
-	}
-
-	a.cachedToken = token
-	a.tokenExpiry = expiry
-	a.logger.Debug("generated new InfluxDB JWT", "expires_at", expiry.UTC().Format(time.RFC3339))
-	return token, nil
-}
-
 // generateJWT creates a new HS256-signed JWT for InfluxDB 1.x Bearer auth.
 // The payload contains the configured username and an expiry of now+TokenTTL.
-func (a *APMPlugin) generateJWT(now time.Time) (string, time.Time, error) {
-	expiry := now.Add(a.cfg.TokenTTL)
+//
+// A new token is generated on every call with no caching. This is intentional:
+// unlike OAuth2/OIDC or cloud-provider token flows (which require a network
+// round-trip to an external token endpoint to refresh), InfluxDB JWTs are
+// signed locally using HMAC-SHA256 — a pure CPU operation that completes in
+// under a microsecond. Caching would add mutex complexity with no benefit.
+func (a *APMPlugin) generateJWT() (string, error) {
+	expiry := time.Now().Add(a.cfg.TokenTTL)
 	claims := influxClaims{
 		Username: a.cfg.Username,
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -96,9 +76,5 @@ func (a *APMPlugin) generateJWT(now time.Time) (string, time.Time, error) {
 		},
 	}
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signed, err := tok.SignedString([]byte(a.cfg.SharedSecret))
-	if err != nil {
-		return "", time.Time{}, err
-	}
-	return signed, expiry, nil
+	return tok.SignedString([]byte(a.cfg.SharedSecret))
 }

--- a/plugins/builtin/apm/influxdb/plugin/auth.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth.go
@@ -87,8 +87,7 @@ func (a *APMPlugin) getOrRefreshJWT() (string, error) {
 }
 
 // generateJWT creates a new HS256-signed JWT for InfluxDB 1.x Bearer auth.
-// The JWT payload contains the configured username and an expiry of now+TokenTTL,
-// matching the format expected by InfluxDB's shared-secret JWT authentication.
+// The payload contains the configured username and an expiry of now+TokenTTL.
 func (a *APMPlugin) generateJWT() (string, time.Time, error) {
 	expiry := time.Now().Add(a.cfg.TokenTTL)
 	claims := influxClaims{

--- a/plugins/builtin/apm/influxdb/plugin/auth.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth.go
@@ -17,17 +17,10 @@ const (
 	// Corresponds to INFLUXDB_HTTP_SHARED_SECRET on the InfluxDB server.
 	configKeySharedSecret = "shared_secret"
 
-	// configKeyTokenTTL is the optional lifetime for auto-generated JWTs.
-	// Accepts Go duration strings (e.g. "30m", "2h"). Default: 1h.
-	// Controls the exp claim — shorter values limit the replay window if a
-	// token is intercepted. Only used when shared_secret is set.
-	configKeyTokenTTL = "token_ttl"
-
-	// defaultTokenTTL is the JWT lifetime when token_ttl is not configured.
-	defaultTokenTTL = time.Hour
-
-	// maxTokenTTL is the upper bound for token_ttl.
-	maxTokenTTL = 24 * time.Hour
+	// jwtExpiry is the lifetime of each generated JWT. Tokens are created
+	// per-request so this only needs to outlive the HTTP round-trip plus any
+	// clock skew between the autoscaler and the InfluxDB server.
+	jwtExpiry = 2 * time.Minute
 )
 
 // influxClaims are the JWT claims expected by InfluxDB 1.x shared-secret auth.
@@ -60,7 +53,7 @@ func (a *APMPlugin) setAuthHeader(req *http.Request) error {
 }
 
 // generateJWT creates a new HS256-signed JWT for InfluxDB 1.x Bearer auth.
-// The payload contains the configured username and an expiry of now+TokenTTL.
+// The payload contains the configured username and an expiry of now+jwtExpiry.
 //
 // A new token is generated on every call with no caching. This is intentional:
 // unlike OAuth2/OIDC or cloud-provider token flows (which require a network
@@ -68,7 +61,7 @@ func (a *APMPlugin) setAuthHeader(req *http.Request) error {
 // signed locally using HMAC-SHA256 — a pure CPU operation that completes in
 // under a microsecond. Caching would add mutex complexity with no benefit.
 func (a *APMPlugin) generateJWT() (string, error) {
-	expiry := time.Now().Add(a.cfg.TokenTTL)
+	expiry := time.Now().Add(jwtExpiry)
 	claims := influxClaims{
 		Username: a.cfg.Username,
 		RegisteredClaims: jwt.RegisteredClaims{

--- a/plugins/builtin/apm/influxdb/plugin/auth.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth.go
@@ -49,7 +49,7 @@ type influxClaims struct {
 //   - neither                  → unauthenticated (local/dev scenarios)
 func (a *APMPlugin) setAuthHeader(req *http.Request) error {
 	if a.cfg.SharedSecret != "" {
-		token, err := a.getOrRefreshJWT()
+		token, err := a.getOrRefreshJWT(time.Now())
 		if err != nil {
 			return fmt.Errorf("generating JWT: %w", err)
 		}
@@ -66,15 +66,15 @@ func (a *APMPlugin) setAuthHeader(req *http.Request) error {
 // getOrRefreshJWT returns the cached JWT if it is still fresh, or generates
 // and caches a new one. The token is refreshed jwtRefreshBuffer before expiry,
 // ensuring it remains valid for at least one full evaluation cycle.
-func (a *APMPlugin) getOrRefreshJWT() (string, error) {
+func (a *APMPlugin) getOrRefreshJWT(now time.Time) (string, error) {
 	a.jwtMu.Lock()
 	defer a.jwtMu.Unlock()
 
-	if a.cachedToken != "" && time.Until(a.tokenExpiry) > jwtRefreshBuffer {
+	if a.cachedToken != "" && a.tokenExpiry.Sub(now) > jwtRefreshBuffer {
 		return a.cachedToken, nil
 	}
 
-	token, expiry, err := a.generateJWT()
+	token, expiry, err := a.generateJWT(now)
 	if err != nil {
 		return "", err
 	}
@@ -87,8 +87,8 @@ func (a *APMPlugin) getOrRefreshJWT() (string, error) {
 
 // generateJWT creates a new HS256-signed JWT for InfluxDB 1.x Bearer auth.
 // The payload contains the configured username and an expiry of now+TokenTTL.
-func (a *APMPlugin) generateJWT() (string, time.Time, error) {
-	expiry := time.Now().Add(a.cfg.TokenTTL)
+func (a *APMPlugin) generateJWT(now time.Time) (string, time.Time, error) {
+	expiry := now.Add(a.cfg.TokenTTL)
 	claims := influxClaims{
 		Username: a.cfg.Username,
 		RegisteredClaims: jwt.RegisteredClaims{

--- a/plugins/builtin/apm/influxdb/plugin/auth_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth_test.go
@@ -48,7 +48,6 @@ func TestAPMPlugin_SetAuthHeader(t *testing.T) {
 			cfg: pluginConfig{
 				Username:     "autoscaler",
 				SharedSecret: "my-secret",
-				TokenTTL:     defaultTokenTTL,
 			},
 			expectBearer: true,
 		},

--- a/plugins/builtin/apm/influxdb/plugin/auth_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/shoenig/test/must"
 )
 
+// TestAPMPlugin_SetAuthHeader verifies that setAuthHeader sets the correct
+// Authorization header for each auth mode: unauthenticated, Basic (username
+// only and username+password), and JWT Bearer via shared_secret.
 func TestAPMPlugin_SetAuthHeader(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -94,6 +97,9 @@ func TestAPMPlugin_SetAuthHeader(t *testing.T) {
 	}
 }
 
+// TestAPMPlugin_JWT_Caching verifies the three JWT cache paths: cache hit
+// (token reused within TTL), proactive refresh (token regenerated when inside
+// the refresh window), and that the refreshed token is valid.
 func TestAPMPlugin_JWT_Caching(t *testing.T) {
 	p := &APMPlugin{
 		logger: hclog.NewNullLogger(),
@@ -127,9 +133,9 @@ func TestAPMPlugin_JWT_Caching(t *testing.T) {
 	tok3, err := p.getOrRefreshJWT()
 	must.NoError(t, err)
 	must.NotEq(t, "", tok3)
-	// exp is recomputed on each generation, so a fresh token is always a different string
+	// A fresh token always produces a different string because exp is derived from time.Now().
 	must.NotEq(t, tok1, tok3, must.Sprint("expected a newly generated token after entering refresh window"))
-	// make sure the new token is actually valid
+	// Verify the freshly generated token is properly signed and valid.
 	parsed, err := jwt.Parse(tok3, func(jwtTok *jwt.Token) (interface{}, error) {
 		return []byte("cache-test-secret"), nil
 	})

--- a/plugins/builtin/apm/influxdb/plugin/auth_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth_test.go
@@ -1,0 +1,141 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package plugin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPMPlugin_SetAuthHeader(t *testing.T) {
+	testCases := []struct {
+		name         string
+		cfg          pluginConfig
+		expectAuth   string // expected Authorization header value; "" means no header
+		expectBasic  bool   // true if basic auth is expected (checked via header prefix)
+		expectBearer bool   // true if bearer JWT is expected
+	}{
+		{
+			name:       "unauthenticated — no credentials set",
+			cfg:        pluginConfig{},
+			expectAuth: "",
+		},
+		{
+			name: "basic auth — username and password",
+			cfg: pluginConfig{
+				Username: "user",
+				Password: "pass",
+			},
+			expectBasic: true,
+		},
+		{
+			name: "basic auth — username only",
+			cfg: pluginConfig{
+				Username: "user",
+			},
+			expectBasic: true,
+		},
+		{
+			name: "JWT bearer — shared_secret with username",
+			cfg: pluginConfig{
+				Username:     "autoscaler",
+				SharedSecret: "my-secret",
+				TokenTTL:     time.Hour,
+			},
+			expectBearer: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &APMPlugin{
+				logger: hclog.NewNullLogger(),
+				cfg:    tc.cfg,
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "http://localhost:8086/query", nil)
+			err := p.setAuthHeader(req)
+			require.NoError(t, err)
+
+			authHeader := req.Header.Get("Authorization")
+
+			switch {
+			case tc.expectAuth == "" && !tc.expectBasic && !tc.expectBearer:
+				assert.Empty(t, authHeader, "expected no Authorization header")
+
+			case tc.expectBasic:
+				require.NotEmpty(t, authHeader)
+				assert.True(t, strings.HasPrefix(authHeader, "Basic "), "expected Basic auth scheme, got: %s", authHeader)
+
+			case tc.expectBearer:
+				require.NotEmpty(t, authHeader)
+				require.True(t, strings.HasPrefix(authHeader, "Bearer "), "expected Bearer scheme, got: %s", authHeader)
+
+				rawToken := strings.TrimPrefix(authHeader, "Bearer ")
+				tok, err := jwt.Parse(rawToken, func(jwtTok *jwt.Token) (interface{}, error) {
+					_, ok := jwtTok.Method.(*jwt.SigningMethodHMAC)
+					require.True(t, ok, "expected HS256 signing method")
+					return []byte(tc.cfg.SharedSecret), nil
+				})
+				require.NoError(t, err)
+				require.True(t, tok.Valid)
+
+				claims, ok := tok.Claims.(jwt.MapClaims)
+				require.True(t, ok)
+				assert.Equal(t, tc.cfg.Username, claims["username"])
+			}
+		})
+	}
+}
+
+func TestAPMPlugin_JWT_Caching(t *testing.T) {
+	p := &APMPlugin{
+		logger: hclog.NewNullLogger(),
+		cfg: pluginConfig{
+			Username:     "autoscaler",
+			SharedSecret: "cache-test-secret",
+			TokenTTL:     time.Hour,
+		},
+	}
+
+	// First call — token is generated.
+	tok1, err := p.getOrRefreshJWT()
+	require.NoError(t, err)
+	require.NotEmpty(t, tok1)
+
+	// Second call within TTL — same token returned (cached).
+	tok2, err := p.getOrRefreshJWT()
+	require.NoError(t, err)
+	require.Equal(t, tok1, tok2, "expected cached token to be reused")
+
+	// Sleep 1s so the next token gets a different exp. JWT timestamps are
+	// whole seconds, so same-second regeneration produces an identical string.
+	time.Sleep(time.Second)
+
+	// Simulate expiry by rewinding tokenExpiry into the refresh window.
+	p.jwtMu.Lock()
+	p.tokenExpiry = time.Now().Add(10 * time.Second) // inside 30s refresh window
+	p.jwtMu.Unlock()
+
+	// Third call — token must be refreshed with a new exp.
+	tok3, err := p.getOrRefreshJWT()
+	require.NoError(t, err)
+	require.NotEmpty(t, tok3)
+	// exp is recomputed on each generation, so a fresh token is always a different string
+	require.NotEqual(t, tok1, tok3, "expected a newly generated token after entering refresh window")
+	// make sure the new token is actually valid
+	parsed, err := jwt.Parse(tok3, func(jwtTok *jwt.Token) (interface{}, error) {
+		return []byte("cache-test-secret"), nil
+	})
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+}

--- a/plugins/builtin/apm/influxdb/plugin/auth_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	hclog "github.com/hashicorp/go-hclog"
@@ -49,7 +48,7 @@ func TestAPMPlugin_SetAuthHeader(t *testing.T) {
 			cfg: pluginConfig{
 				Username:     "autoscaler",
 				SharedSecret: "my-secret",
-				TokenTTL:     time.Hour,
+				TokenTTL:     defaultTokenTTL,
 			},
 			expectBearer: true,
 		},
@@ -95,46 +94,4 @@ func TestAPMPlugin_SetAuthHeader(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestAPMPlugin_JWT_Caching verifies the three JWT cache paths: cache hit
-// (token reused within TTL), proactive refresh (token regenerated when inside
-// the refresh window), and that the refreshed token is valid.
-func TestAPMPlugin_JWT_Caching(t *testing.T) {
-	p := &APMPlugin{
-		logger: hclog.NewNullLogger(),
-		cfg: pluginConfig{
-			Username:     "autoscaler",
-			SharedSecret: "cache-test-secret",
-			TokenTTL:     time.Hour,
-		},
-	}
-
-	now := time.Now()
-
-	// First call — token is generated.
-	tok1, err := p.getOrRefreshJWT(now)
-	must.NoError(t, err)
-	must.NotEq(t, "", tok1)
-
-	// Second call at the same time — same token returned (cached).
-	tok2, err := p.getOrRefreshJWT(now)
-	must.NoError(t, err)
-	must.Eq(t, tok1, tok2, must.Sprint("expected cached token to be reused"))
-
-	// Advance time into the refresh window: tokenExpiry - jwtRefreshBuffer + 1s.
-	insideWindow := now.Add(p.cfg.TokenTTL - jwtRefreshBuffer + time.Second)
-
-	// Third call — token must be refreshed with a new exp.
-	tok3, err := p.getOrRefreshJWT(insideWindow)
-	must.NoError(t, err)
-	must.NotEq(t, "", tok3)
-	// A fresh token always produces a different string because exp is derived from now.
-	must.NotEq(t, tok1, tok3, must.Sprint("expected a newly generated token after entering refresh window"))
-	// Verify the freshly generated token is properly signed and valid.
-	parsed, err := jwt.Parse(tok3, func(jwtTok *jwt.Token) (interface{}, error) {
-		return []byte("cache-test-secret"), nil
-	})
-	must.NoError(t, err)
-	must.True(t, parsed.Valid)
 }

--- a/plugins/builtin/apm/influxdb/plugin/auth_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth_test.go
@@ -110,30 +110,26 @@ func TestAPMPlugin_JWT_Caching(t *testing.T) {
 		},
 	}
 
+	now := time.Now()
+
 	// First call — token is generated.
-	tok1, err := p.getOrRefreshJWT()
+	tok1, err := p.getOrRefreshJWT(now)
 	must.NoError(t, err)
 	must.NotEq(t, "", tok1)
 
-	// Second call within TTL — same token returned (cached).
-	tok2, err := p.getOrRefreshJWT()
+	// Second call at the same time — same token returned (cached).
+	tok2, err := p.getOrRefreshJWT(now)
 	must.NoError(t, err)
 	must.Eq(t, tok1, tok2, must.Sprint("expected cached token to be reused"))
 
-	// Sleep 1s so the next token gets a different exp. JWT timestamps are
-	// whole seconds, so same-second regeneration produces an identical string.
-	time.Sleep(time.Second)
-
-	// Simulate expiry by rewinding tokenExpiry into the refresh window.
-	p.jwtMu.Lock()
-	p.tokenExpiry = time.Now().Add(10 * time.Second) // inside 30s refresh window
-	p.jwtMu.Unlock()
+	// Advance time into the refresh window: tokenExpiry - jwtRefreshBuffer + 1s.
+	insideWindow := now.Add(p.cfg.TokenTTL - jwtRefreshBuffer + time.Second)
 
 	// Third call — token must be refreshed with a new exp.
-	tok3, err := p.getOrRefreshJWT()
+	tok3, err := p.getOrRefreshJWT(insideWindow)
 	must.NoError(t, err)
 	must.NotEq(t, "", tok3)
-	// A fresh token always produces a different string because exp is derived from time.Now().
+	// A fresh token always produces a different string because exp is derived from now.
 	must.NotEq(t, tok1, tok3, must.Sprint("expected a newly generated token after entering refresh window"))
 	// Verify the freshly generated token is properly signed and valid.
 	parsed, err := jwt.Parse(tok3, func(jwtTok *jwt.Token) (interface{}, error) {

--- a/plugins/builtin/apm/influxdb/plugin/auth_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/auth_test.go
@@ -12,22 +12,19 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 func TestAPMPlugin_SetAuthHeader(t *testing.T) {
 	testCases := []struct {
 		name         string
 		cfg          pluginConfig
-		expectAuth   string // expected Authorization header value; "" means no header
-		expectBasic  bool   // true if basic auth is expected (checked via header prefix)
-		expectBearer bool   // true if bearer JWT is expected
+		expectBasic  bool
+		expectBearer bool
 	}{
 		{
-			name:       "unauthenticated — no credentials set",
-			cfg:        pluginConfig{},
-			expectAuth: "",
+			name: "unauthenticated — no credentials set",
+			cfg:  pluginConfig{},
 		},
 		{
 			name: "basic auth — username and password",
@@ -64,34 +61,34 @@ func TestAPMPlugin_SetAuthHeader(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodGet, "http://localhost:8086/query", nil)
 			err := p.setAuthHeader(req)
-			require.NoError(t, err)
+			must.NoError(t, err)
 
 			authHeader := req.Header.Get("Authorization")
 
 			switch {
-			case tc.expectAuth == "" && !tc.expectBasic && !tc.expectBearer:
-				assert.Empty(t, authHeader, "expected no Authorization header")
-
 			case tc.expectBasic:
-				require.NotEmpty(t, authHeader)
-				assert.True(t, strings.HasPrefix(authHeader, "Basic "), "expected Basic auth scheme, got: %s", authHeader)
+				must.NotEq(t, "", authHeader)
+				must.True(t, strings.HasPrefix(authHeader, "Basic "), must.Sprintf("expected Basic auth scheme, got: %s", authHeader))
 
 			case tc.expectBearer:
-				require.NotEmpty(t, authHeader)
-				require.True(t, strings.HasPrefix(authHeader, "Bearer "), "expected Bearer scheme, got: %s", authHeader)
+				must.NotEq(t, "", authHeader)
+				must.True(t, strings.HasPrefix(authHeader, "Bearer "), must.Sprintf("expected Bearer scheme, got: %s", authHeader))
 
 				rawToken := strings.TrimPrefix(authHeader, "Bearer ")
 				tok, err := jwt.Parse(rawToken, func(jwtTok *jwt.Token) (interface{}, error) {
 					_, ok := jwtTok.Method.(*jwt.SigningMethodHMAC)
-					require.True(t, ok, "expected HS256 signing method")
+					must.True(t, ok, must.Sprint("expected HS256 signing method"))
 					return []byte(tc.cfg.SharedSecret), nil
 				})
-				require.NoError(t, err)
-				require.True(t, tok.Valid)
+				must.NoError(t, err)
+				must.True(t, tok.Valid)
 
 				claims, ok := tok.Claims.(jwt.MapClaims)
-				require.True(t, ok)
-				assert.Equal(t, tc.cfg.Username, claims["username"])
+				must.True(t, ok)
+				must.Eq(t, tc.cfg.Username, claims["username"].(string))
+
+			default:
+				must.Eq(t, "", authHeader, must.Sprint("expected no Authorization header"))
 			}
 		})
 	}
@@ -109,13 +106,13 @@ func TestAPMPlugin_JWT_Caching(t *testing.T) {
 
 	// First call — token is generated.
 	tok1, err := p.getOrRefreshJWT()
-	require.NoError(t, err)
-	require.NotEmpty(t, tok1)
+	must.NoError(t, err)
+	must.NotEq(t, "", tok1)
 
 	// Second call within TTL — same token returned (cached).
 	tok2, err := p.getOrRefreshJWT()
-	require.NoError(t, err)
-	require.Equal(t, tok1, tok2, "expected cached token to be reused")
+	must.NoError(t, err)
+	must.Eq(t, tok1, tok2, must.Sprint("expected cached token to be reused"))
 
 	// Sleep 1s so the next token gets a different exp. JWT timestamps are
 	// whole seconds, so same-second regeneration produces an identical string.
@@ -128,14 +125,14 @@ func TestAPMPlugin_JWT_Caching(t *testing.T) {
 
 	// Third call — token must be refreshed with a new exp.
 	tok3, err := p.getOrRefreshJWT()
-	require.NoError(t, err)
-	require.NotEmpty(t, tok3)
+	must.NoError(t, err)
+	must.NotEq(t, "", tok3)
 	// exp is recomputed on each generation, so a fresh token is always a different string
-	require.NotEqual(t, tok1, tok3, "expected a newly generated token after entering refresh window")
+	must.NotEq(t, tok1, tok3, must.Sprint("expected a newly generated token after entering refresh window"))
 	// make sure the new token is actually valid
 	parsed, err := jwt.Parse(tok3, func(jwtTok *jwt.Token) (interface{}, error) {
 		return []byte("cache-test-secret"), nil
 	})
-	require.NoError(t, err)
-	require.True(t, parsed.Valid)
+	must.NoError(t, err)
+	must.True(t, parsed.Valid)
 }

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -95,12 +94,9 @@ type pluginConfig struct {
 
 // APMPlugin is the InfluxDB implementation of the APM interface.
 type APMPlugin struct {
-	cfg         pluginConfig
-	client      *http.Client
-	logger      hclog.Logger
-	jwtMu       sync.Mutex // protects cachedToken and tokenExpiry
-	cachedToken string     // most recently generated JWT; empty until first use
-	tokenExpiry time.Time  // when cachedToken expires
+	cfg    pluginConfig
+	client *http.Client
+	logger hclog.Logger
 }
 
 // NewInfluxDBPlugin returns a new InfluxDB APM plugin instance.
@@ -120,12 +116,6 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 
 	a.cfg = cfg
 	a.client = &http.Client{}
-
-	// Invalidate cached JWT on reconfigure.
-	a.jwtMu.Lock()
-	a.cachedToken = ""
-	a.tokenExpiry = time.Time{}
-	a.jwtMu.Unlock()
 
 	return nil
 }
@@ -172,8 +162,8 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 		if err != nil {
 			return cfg, fmt.Errorf("invalid %s value %q: %w", configKeyTokenTTL, raw, err)
 		}
-		if parsed < minTokenTTL || parsed > maxTokenTTL {
-			return cfg, fmt.Errorf("invalid %s value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
+		if parsed <= 0 || parsed > maxTokenTTL {
+			return cfg, fmt.Errorf("invalid %s value %q: must be a positive duration up to %s", configKeyTokenTTL, raw, maxTokenTTL)
 		}
 		cfg.TokenTTL = parsed
 	}

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -85,7 +85,7 @@ type influxQuerySeries struct {
 // pluginConfig holds the validated, normalised plugin configuration.
 // All values are trimmed and parsed once in parseConfig.
 type pluginConfig struct {
-	BaseURL      *url.URL      // parsed from the "address" config key
+	BaseURL      *url.URL // parsed from the "address" config key
 	Database     string
 	Username     string
 	Password     string
@@ -160,6 +160,10 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 		if cfg.Password != "" {
 			return cfg, fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
 		}
+	} else if cfg.Username != "" && cfg.Password == "" {
+		return cfg, fmt.Errorf("auth configuration error: %q requires %q for Basic authentication", configKeyUsername, configKeyPassword)
+	} else if cfg.Password != "" && cfg.Username == "" {
+		return cfg, fmt.Errorf("auth configuration error: %q requires %q for Basic authentication", configKeyPassword, configKeyUsername)
 	}
 
 	cfg.TokenTTL = defaultTokenTTL

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -138,7 +138,7 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 
 	address := strings.TrimSpace(config[configKeyAddress])
 	if address == "" {
-		return cfg, fmt.Errorf("%q config value cannot be empty", configKeyAddress)
+		return cfg, fmt.Errorf("%s config value cannot be empty", configKeyAddress)
 	}
 
 	cfg.Database = strings.TrimSpace(config[configKeyDatabase])
@@ -146,7 +146,7 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 		cfg.Database = strings.TrimSpace(config[configKeyDB])
 	}
 	if cfg.Database == "" {
-		return cfg, fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
+		return cfg, fmt.Errorf("%s config value cannot be empty", configKeyDatabase)
 	}
 
 	cfg.Username = strings.TrimSpace(config[configKeyUsername])
@@ -155,25 +155,25 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 
 	if cfg.SharedSecret != "" {
 		if cfg.Username == "" {
-			return cfg, fmt.Errorf("auth configuration error: %q requires %q (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
+			return cfg, fmt.Errorf("auth configuration error: %s requires %s (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
 		}
 		if cfg.Password != "" {
-			return cfg, fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
+			return cfg, fmt.Errorf("conflicting auth configuration: %s cannot be used together with %s", configKeySharedSecret, configKeyPassword)
 		}
 	} else if cfg.Username != "" && cfg.Password == "" {
-		return cfg, fmt.Errorf("auth configuration error: %q requires %q for Basic authentication", configKeyUsername, configKeyPassword)
+		return cfg, fmt.Errorf("auth configuration error: %s requires %s for Basic authentication", configKeyUsername, configKeyPassword)
 	} else if cfg.Password != "" && cfg.Username == "" {
-		return cfg, fmt.Errorf("auth configuration error: %q requires %q for Basic authentication", configKeyPassword, configKeyUsername)
+		return cfg, fmt.Errorf("auth configuration error: %s requires %s for Basic authentication", configKeyPassword, configKeyUsername)
 	}
 
 	cfg.TokenTTL = defaultTokenTTL
 	if raw := strings.TrimSpace(config[configKeyTokenTTL]); raw != "" {
 		parsed, err := time.ParseDuration(raw)
 		if err != nil {
-			return cfg, fmt.Errorf("invalid %q value %q: %w", configKeyTokenTTL, raw, err)
+			return cfg, fmt.Errorf("invalid %s value %q: %w", configKeyTokenTTL, raw, err)
 		}
 		if parsed < minTokenTTL || parsed > maxTokenTTL {
-			return cfg, fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
+			return cfg, fmt.Errorf("invalid %s value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
 		}
 		cfg.TokenTTL = parsed
 	}
@@ -190,10 +190,10 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 
 	parsedURL, err := url.Parse(address)
 	if err != nil {
-		return cfg, fmt.Errorf("failed to parse %q: %w", configKeyAddress, err)
+		return cfg, fmt.Errorf("failed to parse %s: %w", configKeyAddress, err)
 	}
 	if parsedURL.Scheme == "" || parsedURL.Host == "" {
-		return cfg, fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
+		return cfg, fmt.Errorf("%s must be a valid absolute URL", configKeyAddress)
 	}
 
 	cfg.BaseURL = parsedURL

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -93,8 +93,7 @@ type pluginConfig struct {
 	Username     string
 	Password     string
 	SharedSecret string
-	Version      string
-	TokenTTL     time.Duration // parsed from configKeyTokenTTL; defaults to defaultTokenTTL
+	TokenTTL     time.Duration // parsed JWT lifetime; defaults to 1h
 }
 
 // APMPlugin is the InfluxDB implementation of the APM interface.
@@ -159,14 +158,14 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 		cfg.TokenTTL = parsed
 	}
 
-	cfg.Version = strings.TrimSpace(config[configKeyVersion])
-	switch cfg.Version {
+	version := strings.TrimSpace(config[configKeyVersion])
+	switch version {
 	case "", configVersion1:
 		// ok — v1 is the default
 	case "2", "3":
-		return fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", cfg.Version, configVersion1)
+		return fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", version, configVersion1)
 	default:
-		return fmt.Errorf("invalid influxdb version %q: only version %q is supported", cfg.Version, configVersion1)
+		return fmt.Errorf("invalid influxdb version %q: only version %q is supported", version, configVersion1)
 	}
 
 	parsedURL, err := url.Parse(cfg.Address)

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -138,7 +138,7 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 
 	address := strings.TrimSpace(config[configKeyAddress])
 	if address == "" {
-		return pluginConfig{}, fmt.Errorf("%q config value cannot be empty", configKeyAddress)
+		return cfg, fmt.Errorf("%q config value cannot be empty", configKeyAddress)
 	}
 
 	cfg.Database = strings.TrimSpace(config[configKeyDatabase])
@@ -146,7 +146,7 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 		cfg.Database = strings.TrimSpace(config[configKeyDB])
 	}
 	if cfg.Database == "" {
-		return pluginConfig{}, fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
+		return cfg, fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
 	}
 
 	cfg.Username = strings.TrimSpace(config[configKeyUsername])
@@ -155,10 +155,10 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 
 	if cfg.SharedSecret != "" {
 		if cfg.Username == "" {
-			return pluginConfig{}, fmt.Errorf("auth configuration error: %q requires %q (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
+			return cfg, fmt.Errorf("auth configuration error: %q requires %q (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
 		}
 		if cfg.Password != "" {
-			return pluginConfig{}, fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
+			return cfg, fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
 		}
 	}
 
@@ -166,10 +166,10 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 	if raw := strings.TrimSpace(config[configKeyTokenTTL]); raw != "" {
 		parsed, err := time.ParseDuration(raw)
 		if err != nil {
-			return pluginConfig{}, fmt.Errorf("invalid %q value %q: %w", configKeyTokenTTL, raw, err)
+			return cfg, fmt.Errorf("invalid %q value %q: %w", configKeyTokenTTL, raw, err)
 		}
 		if parsed < minTokenTTL || parsed > maxTokenTTL {
-			return pluginConfig{}, fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
+			return cfg, fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
 		}
 		cfg.TokenTTL = parsed
 	}
@@ -179,17 +179,17 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 	case "", configVersion1:
 		// ok — v1 is the default
 	case "2", "3":
-		return pluginConfig{}, fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", version, configVersion1)
+		return cfg, fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", version, configVersion1)
 	default:
-		return pluginConfig{}, fmt.Errorf("invalid influxdb version %q: only version %q is supported", version, configVersion1)
+		return cfg, fmt.Errorf("invalid influxdb version %q: only version %q is supported", version, configVersion1)
 	}
 
 	parsedURL, err := url.Parse(address)
 	if err != nil {
-		return pluginConfig{}, fmt.Errorf("failed to parse %q: %w", configKeyAddress, err)
+		return cfg, fmt.Errorf("failed to parse %q: %w", configKeyAddress, err)
 	}
 	if parsedURL.Scheme == "" || parsedURL.Host == "" {
-		return pluginConfig{}, fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
+		return cfg, fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
 	}
 
 	cfg.BaseURL = parsedURL

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -23,22 +23,20 @@ import (
 )
 
 const (
-	// pluginName is the name of the plugin.
 	pluginName = "influxdb"
 
-	// configKeyAddress is the InfluxDB server address.
-	configKeyAddress = "address"
+	configKeyAddress  = "address"
 
-	// configKeyDatabase is the primary config key for the database name.
+	// Name of the InfluxDB database to query.
 	configKeyDatabase = "database"
 
-	// configKeyDB is the shorthand alias accepted for database name.
+	// "db" is accepted as a shorthand for "database".
 	configKeyDB = "db"
 
-	// configKeyUsername is the optional authentication username.
+	// configKeyUsername is the username for Basic or JWT authentication.
 	configKeyUsername = "username"
 
-	// configKeyPassword is the optional authentication password.
+	// configKeyPassword is the password for Basic authentication. Mutually exclusive with shared_secret.
 	configKeyPassword = "password"
 
 	// configKeyVersion selects the InfluxDB API version. Only "1" is
@@ -85,8 +83,7 @@ type influxQuerySeries struct {
 }
 
 // pluginConfig holds the validated, normalised plugin configuration.
-// All string values are trimmed of surrounding whitespace at parse time in
-// SetConfig, so downstream code can use them directly without re-trimming.
+// All values are trimmed and parsed once in SetConfig.
 type pluginConfig struct {
 	Address      string
 	Database     string
@@ -304,8 +301,8 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 }
 
 // parseSeries converts an InfluxDB result series into sdk.TimestampedMetrics.
-// It locates the "time" column and picks the first non-time column as the
-// metric value (preferring one literally named "value").
+// It looks for the "time" column and picks the first non-time column as the
+// metric value, preferring a column named "value" if one exists.
 func parseSeries(series influxQuerySeries) (sdk.TimestampedMetrics, error) {
 	timeIdx := indexOfColumn(series.Columns, "time")
 	if timeIdx == -1 {

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -39,11 +40,6 @@ const (
 
 	// configKeyPassword is the optional authentication password.
 	configKeyPassword = "password"
-
-	// configKeyToken is the optional authentication token. When set, it
-	// takes precedence over username/password and cannot be used together
-	// with them. Supports InfluxDB 1.x Enterprise token-based auth.
-	configKeyToken = "token"
 
 	// configKeyVersion selects the InfluxDB API version. Only "1" is
 	// currently supported; "3" is reserved for future implementation.
@@ -88,12 +84,28 @@ type influxQuerySeries struct {
 	Values  [][]interface{} `json:"values"`
 }
 
+// pluginConfig holds the validated, normalised plugin configuration.
+// All string values are trimmed of surrounding whitespace at parse time in
+// SetConfig, so downstream code can use them directly without re-trimming.
+type pluginConfig struct {
+	Address      string
+	Database     string
+	Username     string
+	Password     string
+	SharedSecret string
+	Version      string
+	TokenTTL     time.Duration // parsed from configKeyTokenTTL; defaults to defaultTokenTTL
+}
+
 // APMPlugin is the InfluxDB implementation of the APM interface.
 type APMPlugin struct {
-	client  *http.Client
-	baseURL *url.URL
-	config  map[string]string
-	logger  hclog.Logger
+	cfg         pluginConfig
+	client      *http.Client
+	baseURL     *url.URL
+	logger      hclog.Logger
+	jwtMu       sync.Mutex // protects cachedToken and tokenExpiry
+	cachedToken string     // most recently generated JWT; empty until first use
+	tokenExpiry time.Time  // when cachedToken expires
 }
 
 // NewInfluxDBPlugin returns a new InfluxDB APM plugin instance.
@@ -104,38 +116,60 @@ func NewInfluxDBPlugin(log hclog.Logger) apm.APM {
 }
 
 // SetConfig parses and validates the plugin configuration. All required fields
-// are checked before any client is stored.
+// are checked before any state is mutated, so a failed re-configuration leaves
+// the plugin in its previous working state.
 func (a *APMPlugin) SetConfig(config map[string]string) error {
-	a.config = config
+	var cfg pluginConfig
 
-	address := strings.TrimSpace(a.config[configKeyAddress])
-	if address == "" {
+	cfg.Address = strings.TrimSpace(config[configKeyAddress])
+	if cfg.Address == "" {
 		return fmt.Errorf("%q config value cannot be empty", configKeyAddress)
 	}
 
-	database := a.database()
-	if database == "" {
+	cfg.Database = strings.TrimSpace(config[configKeyDatabase])
+	if cfg.Database == "" {
+		cfg.Database = strings.TrimSpace(config[configKeyDB])
+	}
+	if cfg.Database == "" {
 		return fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
 	}
 
-	// Validate mutual exclusivity: token cannot be used with username/password.
-	token := strings.TrimSpace(a.config[configKeyToken])
-	username := strings.TrimSpace(a.config[configKeyUsername])
-	password := strings.TrimSpace(a.config[configKeyPassword])
-	if token != "" && (username != "" || password != "") {
-		return fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q or %q", configKeyToken, configKeyUsername, configKeyPassword)
+	cfg.Username = strings.TrimSpace(config[configKeyUsername])
+	cfg.Password = strings.TrimSpace(config[configKeyPassword])
+	cfg.SharedSecret = strings.TrimSpace(config[configKeySharedSecret])
+
+	if cfg.SharedSecret != "" {
+		if cfg.Username == "" {
+			return fmt.Errorf("auth configuration error: %q requires %q (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
+		}
+		if cfg.Password != "" {
+			return fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
+		}
 	}
 
-	switch version := strings.TrimSpace(a.config[configKeyVersion]); version {
+	cfg.TokenTTL = defaultTokenTTL
+	if raw := strings.TrimSpace(config[configKeyTokenTTL]); raw != "" {
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			return fmt.Errorf("invalid %q value %q: %v", configKeyTokenTTL, raw, err)
+		}
+		if parsed < minTokenTTL || parsed > maxTokenTTL {
+			return fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
+		}
+		cfg.TokenTTL = parsed
+	}
+
+	cfg.Version = strings.TrimSpace(config[configKeyVersion])
+	switch cfg.Version {
 	case "", configVersion1:
 		// ok — v1 is the default
 	case "2", "3":
-		return fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", version, configVersion1)
+		return fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", cfg.Version, configVersion1)
 	default:
-		return fmt.Errorf("invalid influxdb version %q: only version %q is supported", version, configVersion1)
+		return fmt.Errorf("invalid influxdb version %q: only version %q is supported", cfg.Version, configVersion1)
 	}
 
-	parsedURL, err := url.Parse(address)
+	parsedURL, err := url.Parse(cfg.Address)
 	if err != nil {
 		return fmt.Errorf("failed to parse %q: %v", configKeyAddress, err)
 	}
@@ -143,8 +177,16 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 		return fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
 	}
 
+	// All checks passed — commit new state.
+	a.cfg = cfg
 	a.baseURL = parsedURL
 	a.client = &http.Client{}
+
+	// Invalidate cached JWT on reconfigure.
+	a.jwtMu.Lock()
+	a.cachedToken = ""
+	a.tokenExpiry = time.Time{}
+	a.jwtMu.Unlock()
 
 	return nil
 }
@@ -193,7 +235,7 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 	queryURL.Path = strings.TrimSuffix(queryURL.Path, "/") + "/query"
 
 	queryValues := queryURL.Query()
-	queryValues.Set("db", a.database())
+	queryValues.Set("db", a.cfg.Database)
 	queryValues.Set("q", q)
 	queryValues.Set("epoch", "s")
 	queryURL.RawQuery = queryValues.Encode()
@@ -203,7 +245,9 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 		return nil, fmt.Errorf("failed to build influxdb query request: %v", err)
 	}
 
-	a.setAuthHeader(req)
+	if err := a.setAuthHeader(req); err != nil {
+		return nil, fmt.Errorf("failed to set auth header: %v", err)
+	}
 
 	resp, err := a.client.Do(req)
 	if err != nil {
@@ -247,33 +291,6 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 	}
 
 	return results, nil
-}
-
-// database returns the configured database name, checking the primary key
-// first and falling back to the shorthand alias.
-func (a *APMPlugin) database() string {
-	if db := strings.TrimSpace(a.config[configKeyDatabase]); db != "" {
-		return db
-	}
-	return strings.TrimSpace(a.config[configKeyDB])
-}
-
-// setAuthHeader applies the appropriate authentication method to the HTTP
-// request. It supports both token-based auth (for InfluxDB 1.x Enterprise)
-// and username/password basic auth (for InfluxDB 1.x OSS).
-func (a *APMPlugin) setAuthHeader(req *http.Request) {
-	if token := strings.TrimSpace(a.config[configKeyToken]); token != "" {
-		req.Header.Set("Authorization", "Token "+token)
-		return
-	}
-
-	username := strings.TrimSpace(a.config[configKeyUsername])
-	password := strings.TrimSpace(a.config[configKeyPassword])
-	if username != "" || password != "" {
-		req.SetBasicAuth(username, password)
-	}
-	// If neither token nor username/password is set, the request remains
-	// unauthenticated (for local/testing scenarios).
 }
 
 // parseSeries converts an InfluxDB result series into sdk.TimestampedMetrics.

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -25,7 +25,7 @@ import (
 const (
 	pluginName = "influxdb"
 
-	configKeyAddress  = "address"
+	configKeyAddress = "address"
 
 	// Name of the InfluxDB database to query.
 	configKeyDatabase = "database"

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -151,7 +151,7 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 	if raw := strings.TrimSpace(config[configKeyTokenTTL]); raw != "" {
 		parsed, err := time.ParseDuration(raw)
 		if err != nil {
-			return fmt.Errorf("invalid %q value %q: %v", configKeyTokenTTL, raw, err)
+			return fmt.Errorf("invalid %q value %q: %w", configKeyTokenTTL, raw, err)
 		}
 		if parsed < minTokenTTL || parsed > maxTokenTTL {
 			return fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
@@ -171,7 +171,7 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 
 	parsedURL, err := url.Parse(cfg.Address)
 	if err != nil {
-		return fmt.Errorf("failed to parse %q: %v", configKeyAddress, err)
+		return fmt.Errorf("failed to parse %q: %w", configKeyAddress, err)
 	}
 	if parsedURL.Scheme == "" || parsedURL.Host == "" {
 		return fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
@@ -242,16 +242,16 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, queryURL.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build influxdb query request: %v", err)
+		return nil, fmt.Errorf("failed to build influxdb query request: %w", err)
 	}
 
 	if err := a.setAuthHeader(req); err != nil {
-		return nil, fmt.Errorf("failed to set auth header: %v", err)
+		return nil, fmt.Errorf("failed to set auth header: %w", err)
 	}
 
 	resp, err := a.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error querying metrics from influxdb: %v", err)
+		return nil, fmt.Errorf("error querying metrics from influxdb: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -262,7 +262,7 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 
 	var queryResp influxQueryResponse
 	if err := json.NewDecoder(resp.Body).Decode(&queryResp); err != nil {
-		return nil, fmt.Errorf("failed to decode influxdb query response: %v", err)
+		return nil, fmt.Errorf("failed to decode influxdb query response: %w", err)
 	}
 
 	if queryResp.Error != "" {

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -83,9 +83,9 @@ type influxQuerySeries struct {
 }
 
 // pluginConfig holds the validated, normalised plugin configuration.
-// All values are trimmed and parsed once in SetConfig.
+// All values are trimmed and parsed once in parseConfig.
 type pluginConfig struct {
-	Address      string
+	BaseURL      *url.URL      // parsed from the "address" config key
 	Database     string
 	Username     string
 	Password     string
@@ -97,7 +97,6 @@ type pluginConfig struct {
 type APMPlugin struct {
 	cfg         pluginConfig
 	client      *http.Client
-	baseURL     *url.URL
 	logger      hclog.Logger
 	jwtMu       sync.Mutex // protects cachedToken and tokenExpiry
 	cachedToken string     // most recently generated JWT; empty until first use
@@ -112,16 +111,14 @@ func NewInfluxDBPlugin(log hclog.Logger) apm.APM {
 }
 
 // SetConfig parses and validates the plugin configuration. All required fields
-// are checked before any state is mutated, so a failed re-configuration leaves
-// the plugin in its previous working state.
+// are checked before any state is mutated
 func (a *APMPlugin) SetConfig(config map[string]string) error {
-	cfg, baseURL, err := parseConfig(config)
+	cfg, err := parseConfig(config)
 	if err != nil {
 		return err
 	}
 
 	a.cfg = cfg
-	a.baseURL = baseURL
 	a.client = &http.Client{}
 
 	// Invalidate cached JWT on reconfigure.
@@ -133,15 +130,15 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 	return nil
 }
 
-// parseConfig validates the raw config map and returns the normalised
-// pluginConfig and its parsed base URL. Returns an error if any required
-// field is missing, a field value is invalid, or auth options conflict.
-func parseConfig(config map[string]string) (pluginConfig, *url.URL, error) {
+// parseConfig validates the raw config map and returns a normalised
+// pluginConfig. Returns an error if any required field is missing, a field
+// value is invalid, or auth options conflict.
+func parseConfig(config map[string]string) (pluginConfig, error) {
 	var cfg pluginConfig
 
-	cfg.Address = strings.TrimSpace(config[configKeyAddress])
-	if cfg.Address == "" {
-		return pluginConfig{}, nil, fmt.Errorf("%q config value cannot be empty", configKeyAddress)
+	address := strings.TrimSpace(config[configKeyAddress])
+	if address == "" {
+		return pluginConfig{}, fmt.Errorf("%q config value cannot be empty", configKeyAddress)
 	}
 
 	cfg.Database = strings.TrimSpace(config[configKeyDatabase])
@@ -149,7 +146,7 @@ func parseConfig(config map[string]string) (pluginConfig, *url.URL, error) {
 		cfg.Database = strings.TrimSpace(config[configKeyDB])
 	}
 	if cfg.Database == "" {
-		return pluginConfig{}, nil, fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
+		return pluginConfig{}, fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
 	}
 
 	cfg.Username = strings.TrimSpace(config[configKeyUsername])
@@ -158,10 +155,10 @@ func parseConfig(config map[string]string) (pluginConfig, *url.URL, error) {
 
 	if cfg.SharedSecret != "" {
 		if cfg.Username == "" {
-			return pluginConfig{}, nil, fmt.Errorf("auth configuration error: %q requires %q (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
+			return pluginConfig{}, fmt.Errorf("auth configuration error: %q requires %q (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
 		}
 		if cfg.Password != "" {
-			return pluginConfig{}, nil, fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
+			return pluginConfig{}, fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
 		}
 	}
 
@@ -169,10 +166,10 @@ func parseConfig(config map[string]string) (pluginConfig, *url.URL, error) {
 	if raw := strings.TrimSpace(config[configKeyTokenTTL]); raw != "" {
 		parsed, err := time.ParseDuration(raw)
 		if err != nil {
-			return pluginConfig{}, nil, fmt.Errorf("invalid %q value %q: %w", configKeyTokenTTL, raw, err)
+			return pluginConfig{}, fmt.Errorf("invalid %q value %q: %w", configKeyTokenTTL, raw, err)
 		}
 		if parsed < minTokenTTL || parsed > maxTokenTTL {
-			return pluginConfig{}, nil, fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
+			return pluginConfig{}, fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
 		}
 		cfg.TokenTTL = parsed
 	}
@@ -182,20 +179,21 @@ func parseConfig(config map[string]string) (pluginConfig, *url.URL, error) {
 	case "", configVersion1:
 		// ok — v1 is the default
 	case "2", "3":
-		return pluginConfig{}, nil, fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", version, configVersion1)
+		return pluginConfig{}, fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", version, configVersion1)
 	default:
-		return pluginConfig{}, nil, fmt.Errorf("invalid influxdb version %q: only version %q is supported", version, configVersion1)
+		return pluginConfig{}, fmt.Errorf("invalid influxdb version %q: only version %q is supported", version, configVersion1)
 	}
 
-	parsedURL, err := url.Parse(cfg.Address)
+	parsedURL, err := url.Parse(address)
 	if err != nil {
-		return pluginConfig{}, nil, fmt.Errorf("failed to parse %q: %w", configKeyAddress, err)
+		return pluginConfig{}, fmt.Errorf("failed to parse %q: %w", configKeyAddress, err)
 	}
 	if parsedURL.Scheme == "" || parsedURL.Host == "" {
-		return pluginConfig{}, nil, fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
+		return pluginConfig{}, fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
 	}
 
-	return cfg, parsedURL, nil
+	cfg.BaseURL = parsedURL
+	return cfg, nil
 }
 
 // PluginInfo returns metadata about the plugin.
@@ -238,7 +236,7 @@ func (a *APMPlugin) QueryMultiple(q string, r sdk.TimeRange) ([]sdk.TimestampedM
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	queryURL := *a.baseURL
+	queryURL := *a.cfg.BaseURL
 	queryURL.Path = strings.TrimSuffix(queryURL.Path, "/") + "/query"
 
 	queryValues := queryURL.Query()

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -89,7 +89,6 @@ type pluginConfig struct {
 	Username     string
 	Password     string
 	SharedSecret string
-	TokenTTL     time.Duration // parsed JWT lifetime; defaults to 1h
 }
 
 // APMPlugin is the InfluxDB implementation of the APM interface.
@@ -154,18 +153,6 @@ func parseConfig(config map[string]string) (pluginConfig, error) {
 		return cfg, fmt.Errorf("auth configuration error: %s requires %s for Basic authentication", configKeyUsername, configKeyPassword)
 	} else if cfg.Password != "" && cfg.Username == "" {
 		return cfg, fmt.Errorf("auth configuration error: %s requires %s for Basic authentication", configKeyPassword, configKeyUsername)
-	}
-
-	cfg.TokenTTL = defaultTokenTTL
-	if raw := strings.TrimSpace(config[configKeyTokenTTL]); raw != "" {
-		parsed, err := time.ParseDuration(raw)
-		if err != nil {
-			return cfg, fmt.Errorf("invalid %s value %q: %w", configKeyTokenTTL, raw, err)
-		}
-		if parsed <= 0 || parsed > maxTokenTTL {
-			return cfg, fmt.Errorf("invalid %s value %q: must be a positive duration up to %s", configKeyTokenTTL, raw, maxTokenTTL)
-		}
-		cfg.TokenTTL = parsed
 	}
 
 	version := strings.TrimSpace(config[configKeyVersion])

--- a/plugins/builtin/apm/influxdb/plugin/plugin.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin.go
@@ -118,67 +118,13 @@ func NewInfluxDBPlugin(log hclog.Logger) apm.APM {
 // are checked before any state is mutated, so a failed re-configuration leaves
 // the plugin in its previous working state.
 func (a *APMPlugin) SetConfig(config map[string]string) error {
-	var cfg pluginConfig
-
-	cfg.Address = strings.TrimSpace(config[configKeyAddress])
-	if cfg.Address == "" {
-		return fmt.Errorf("%q config value cannot be empty", configKeyAddress)
-	}
-
-	cfg.Database = strings.TrimSpace(config[configKeyDatabase])
-	if cfg.Database == "" {
-		cfg.Database = strings.TrimSpace(config[configKeyDB])
-	}
-	if cfg.Database == "" {
-		return fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
-	}
-
-	cfg.Username = strings.TrimSpace(config[configKeyUsername])
-	cfg.Password = strings.TrimSpace(config[configKeyPassword])
-	cfg.SharedSecret = strings.TrimSpace(config[configKeySharedSecret])
-
-	if cfg.SharedSecret != "" {
-		if cfg.Username == "" {
-			return fmt.Errorf("auth configuration error: %q requires %q (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
-		}
-		if cfg.Password != "" {
-			return fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
-		}
-	}
-
-	cfg.TokenTTL = defaultTokenTTL
-	if raw := strings.TrimSpace(config[configKeyTokenTTL]); raw != "" {
-		parsed, err := time.ParseDuration(raw)
-		if err != nil {
-			return fmt.Errorf("invalid %q value %q: %w", configKeyTokenTTL, raw, err)
-		}
-		if parsed < minTokenTTL || parsed > maxTokenTTL {
-			return fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
-		}
-		cfg.TokenTTL = parsed
-	}
-
-	version := strings.TrimSpace(config[configKeyVersion])
-	switch version {
-	case "", configVersion1:
-		// ok — v1 is the default
-	case "2", "3":
-		return fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", version, configVersion1)
-	default:
-		return fmt.Errorf("invalid influxdb version %q: only version %q is supported", version, configVersion1)
-	}
-
-	parsedURL, err := url.Parse(cfg.Address)
+	cfg, baseURL, err := parseConfig(config)
 	if err != nil {
-		return fmt.Errorf("failed to parse %q: %w", configKeyAddress, err)
-	}
-	if parsedURL.Scheme == "" || parsedURL.Host == "" {
-		return fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
+		return err
 	}
 
-	// All checks passed — commit new state.
 	a.cfg = cfg
-	a.baseURL = parsedURL
+	a.baseURL = baseURL
 	a.client = &http.Client{}
 
 	// Invalidate cached JWT on reconfigure.
@@ -188,6 +134,71 @@ func (a *APMPlugin) SetConfig(config map[string]string) error {
 	a.jwtMu.Unlock()
 
 	return nil
+}
+
+// parseConfig validates the raw config map and returns the normalised
+// pluginConfig and its parsed base URL. Returns an error if any required
+// field is missing, a field value is invalid, or auth options conflict.
+func parseConfig(config map[string]string) (pluginConfig, *url.URL, error) {
+	var cfg pluginConfig
+
+	cfg.Address = strings.TrimSpace(config[configKeyAddress])
+	if cfg.Address == "" {
+		return pluginConfig{}, nil, fmt.Errorf("%q config value cannot be empty", configKeyAddress)
+	}
+
+	cfg.Database = strings.TrimSpace(config[configKeyDatabase])
+	if cfg.Database == "" {
+		cfg.Database = strings.TrimSpace(config[configKeyDB])
+	}
+	if cfg.Database == "" {
+		return pluginConfig{}, nil, fmt.Errorf("%q config value cannot be empty", configKeyDatabase)
+	}
+
+	cfg.Username = strings.TrimSpace(config[configKeyUsername])
+	cfg.Password = strings.TrimSpace(config[configKeyPassword])
+	cfg.SharedSecret = strings.TrimSpace(config[configKeySharedSecret])
+
+	if cfg.SharedSecret != "" {
+		if cfg.Username == "" {
+			return pluginConfig{}, nil, fmt.Errorf("auth configuration error: %q requires %q (used as the JWT username claim)", configKeySharedSecret, configKeyUsername)
+		}
+		if cfg.Password != "" {
+			return pluginConfig{}, nil, fmt.Errorf("conflicting auth configuration: %q cannot be used together with %q", configKeySharedSecret, configKeyPassword)
+		}
+	}
+
+	cfg.TokenTTL = defaultTokenTTL
+	if raw := strings.TrimSpace(config[configKeyTokenTTL]); raw != "" {
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			return pluginConfig{}, nil, fmt.Errorf("invalid %q value %q: %w", configKeyTokenTTL, raw, err)
+		}
+		if parsed < minTokenTTL || parsed > maxTokenTTL {
+			return pluginConfig{}, nil, fmt.Errorf("invalid %q value %q: must be between %s and %s", configKeyTokenTTL, raw, minTokenTTL, maxTokenTTL)
+		}
+		cfg.TokenTTL = parsed
+	}
+
+	version := strings.TrimSpace(config[configKeyVersion])
+	switch version {
+	case "", configVersion1:
+		// ok — v1 is the default
+	case "2", "3":
+		return pluginConfig{}, nil, fmt.Errorf("influxdb version %q is not yet supported: only version %q is currently implemented", version, configVersion1)
+	default:
+		return pluginConfig{}, nil, fmt.Errorf("invalid influxdb version %q: only version %q is supported", version, configVersion1)
+	}
+
+	parsedURL, err := url.Parse(cfg.Address)
+	if err != nil {
+		return pluginConfig{}, nil, fmt.Errorf("failed to parse %q: %w", configKeyAddress, err)
+	}
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return pluginConfig{}, nil, fmt.Errorf("%q must be a valid absolute URL", configKeyAddress)
+	}
+
+	return cfg, parsedURL, nil
 }
 
 // PluginInfo returns metadata about the plugin.

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -190,15 +190,11 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			actualOutput := apmPlugin.SetConfig(tc.inputConfig)
 			if tc.expectOutput == nil {
 				assert.NoError(t, actualOutput)
-			} else {
-				require.Error(t, actualOutput)
-				assert.Contains(t, actualOutput.Error(), tc.expectOutput.Error())
-			}
-
-			if tc.expectOutput == nil {
 				assert.NotNil(t, apmPlugin.client)
 				assert.NotNil(t, apmPlugin.cfg.BaseURL)
 			} else {
+				require.Error(t, actualOutput)
+				assert.Contains(t, actualOutput.Error(), tc.expectOutput.Error())
 				assert.Nil(t, apmPlugin.client)
 				assert.Nil(t, apmPlugin.cfg.BaseURL)
 			}

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -120,6 +120,24 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			expectOutput: errors.New(`conflicting auth configuration: "shared_secret" cannot be used together with "password"`),
 		},
 		{
+			name: "username without password is invalid",
+			inputConfig: map[string]string{
+				configKeyAddress:  "http://localhost:8086",
+				configKeyDatabase: "telegraf",
+				configKeyUsername: "autoscaler",
+			},
+			expectOutput: errors.New(`auth configuration error: "username" requires "password" for Basic authentication`),
+		},
+		{
+			name: "password without username is invalid",
+			inputConfig: map[string]string{
+				configKeyAddress:  "http://localhost:8086",
+				configKeyDatabase: "telegraf",
+				configKeyPassword: "hunter2",
+			},
+			expectOutput: errors.New(`auth configuration error: "password" requires "username" for Basic authentication`),
+		},
+		{
 			name: "custom token_ttl valid",
 			inputConfig: map[string]string{
 				configKeyAddress:      "http://localhost:8086",

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -155,9 +155,9 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeyDatabase:     "telegraf",
 				configKeyUsername:     "autoscaler",
 				configKeySharedSecret: "my-secret",
-				configKeyTokenTTL:     "30s",
+				configKeyTokenTTL:     "5m",
 			},
-			expectOutput: errors.New(`invalid token_ttl value "30s": must be between 1m0s and 24h0m0s`),
+			expectOutput: errors.New(`invalid token_ttl value "5m": must be between 10m0s and 24h0m0s`),
 		},
 		{
 			name: "token_ttl above maximum",
@@ -168,7 +168,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeySharedSecret: "my-secret",
 				configKeyTokenTTL:     "25h",
 			},
-			expectOutput: errors.New(`invalid token_ttl value "25h": must be between 1m0s and 24h0m0s`),
+			expectOutput: errors.New(`invalid token_ttl value "25h": must be between 10m0s and 24h0m0s`),
 		},
 		{
 			name: "token_ttl invalid string",

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -149,17 +149,6 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			expectOutput: nil,
 		},
 		{
-			name: "token_ttl below minimum",
-			inputConfig: map[string]string{
-				configKeyAddress:      "http://localhost:8086",
-				configKeyDatabase:     "telegraf",
-				configKeyUsername:     "autoscaler",
-				configKeySharedSecret: "my-secret",
-				configKeyTokenTTL:     "5m",
-			},
-			expectOutput: errors.New(`invalid token_ttl value "5m": must be between 10m0s and 24h0m0s`),
-		},
-		{
 			name: "token_ttl above maximum",
 			inputConfig: map[string]string{
 				configKeyAddress:      "http://localhost:8086",
@@ -168,7 +157,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeySharedSecret: "my-secret",
 				configKeyTokenTTL:     "25h",
 			},
-			expectOutput: errors.New(`invalid token_ttl value "25h": must be between 10m0s and 24h0m0s`),
+			expectOutput: errors.New(`invalid token_ttl value "25h": must be a positive duration up to 24h0m0s`),
 		},
 		{
 			name: "token_ttl invalid string",

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -137,39 +137,6 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			},
 			expectOutput: errors.New(`auth configuration error: password requires username for Basic authentication`),
 		},
-		{
-			name: "custom token_ttl valid",
-			inputConfig: map[string]string{
-				configKeyAddress:      "http://localhost:8086",
-				configKeyDatabase:     "telegraf",
-				configKeyUsername:     "autoscaler",
-				configKeySharedSecret: "my-secret",
-				configKeyTokenTTL:     "30m",
-			},
-			expectOutput: nil,
-		},
-		{
-			name: "token_ttl above maximum",
-			inputConfig: map[string]string{
-				configKeyAddress:      "http://localhost:8086",
-				configKeyDatabase:     "telegraf",
-				configKeyUsername:     "autoscaler",
-				configKeySharedSecret: "my-secret",
-				configKeyTokenTTL:     "25h",
-			},
-			expectOutput: errors.New(`invalid token_ttl value "25h": must be a positive duration up to 24h0m0s`),
-		},
-		{
-			name: "token_ttl invalid string",
-			inputConfig: map[string]string{
-				configKeyAddress:      "http://localhost:8086",
-				configKeyDatabase:     "telegraf",
-				configKeyUsername:     "autoscaler",
-				configKeySharedSecret: "my-secret",
-				configKeyTokenTTL:     "forever",
-			},
-			expectOutput: errors.New(`invalid token_ttl value "forever"`),
-		},
 	}
 
 	for _, tc := range testCases {

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -167,12 +167,12 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			apmPlugin := APMPlugin{logger: hclog.NewNullLogger()}
 
 			actualOutput := apmPlugin.SetConfig(tc.inputConfig)
-		if tc.expectOutput == nil {
-			assert.NoError(t, actualOutput)
-		} else {
-			require.Error(t, actualOutput)
-			assert.Contains(t, actualOutput.Error(), tc.expectOutput.Error())
-		}
+			if tc.expectOutput == nil {
+				assert.NoError(t, actualOutput)
+			} else {
+				require.Error(t, actualOutput)
+				assert.Contains(t, actualOutput.Error(), tc.expectOutput.Error())
+			}
 
 			if tc.expectOutput == nil {
 				assert.NotNil(t, apmPlugin.client)

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -179,10 +179,10 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 
 			if tc.expectOutput == nil {
 				assert.NotNil(t, apmPlugin.client)
-				assert.NotNil(t, apmPlugin.baseURL)
+				assert.NotNil(t, apmPlugin.cfg.BaseURL)
 			} else {
 				assert.Nil(t, apmPlugin.client)
-				assert.Nil(t, apmPlugin.baseURL)
+				assert.Nil(t, apmPlugin.cfg.BaseURL)
 			}
 		})
 	}

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestAPMPlugin_SetConfig verifies that SetConfig accepts valid configurations
+// and rejects invalid ones, covering required fields, URL validation, version
+// checks, and shared_secret auth constraints.
 func TestAPMPlugin_SetConfig(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -185,6 +188,10 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 	}
 }
 
+// TestAPMPlugin_Query exercises the full query path against a local test
+// server, verifying that credentials are sent via Authorization header (not
+// query params), that JWT Bearer auth works end-to-end, and that result
+// parsing handles null values and non-default column names correctly.
 func TestAPMPlugin_Query(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -214,7 +221,7 @@ func TestAPMPlugin_Query(t *testing.T) {
 				require.Equal(t, "telegraf", qp.Get("db"))
 				require.Equal(t, "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 10m", qp.Get("q"))
 				require.Equal(t, "s", qp.Get("epoch"))
-				// Verify credentials are NOT in query params (security fix)
+				// Verify credentials are sent in the Authorization header, not as query params.
 				require.Empty(t, qp.Get("u"))
 				require.Empty(t, qp.Get("p"))
 				// Verify Basic auth header is set
@@ -268,7 +275,7 @@ func TestAPMPlugin_Query(t *testing.T) {
 				require.NotEmpty(t, authHeader)
 				require.True(t, strings.HasPrefix(authHeader, "Bearer "), "expected Bearer scheme, got: %s", authHeader)
 
-				// check the JWT and its claims
+				// Verify the JWT signature and claims.
 				rawToken := strings.TrimPrefix(authHeader, "Bearer ")
 				tok, err := jwt.Parse(rawToken, func(jwtTok *jwt.Token) (interface{}, error) {
 					_, ok := jwtTok.Method.(*jwt.SigningMethodHMAC)
@@ -286,7 +293,7 @@ func TestAPMPlugin_Query(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, exp.After(time.Now()), "JWT exp should be in the future")
 
-				// no credentials in query params
+				// Credentials must not appear in query params.
 				qp := r.URL.Query()
 				require.Empty(t, qp.Get("u"))
 				require.Empty(t, qp.Get("p"))
@@ -361,6 +368,8 @@ func TestAPMPlugin_Query(t *testing.T) {
 	}
 }
 
+// TestAPMPlugin_Query_InstantNotSupported checks that a query with an instant
+// time range (From == To) returns an appropriate unsupported error.
 func TestAPMPlugin_Query_InstantNotSupported(t *testing.T) {
 	plugin := NewInfluxDBPlugin(hclog.NewNullLogger())
 	err := plugin.SetConfig(map[string]string{
@@ -375,6 +384,8 @@ func TestAPMPlugin_Query_InstantNotSupported(t *testing.T) {
 	require.Contains(t, err.Error(), `query_window = "instant" is not supported by influxdb`)
 }
 
+// TestAPMPlugin_Query_Errors covers HTTP-level and InfluxDB-level error
+// responses, as well as empty result sets that should return no error.
 func TestAPMPlugin_Query_Errors(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -31,12 +31,12 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 		{
 			name:         "no required config parameters set",
 			inputConfig:  map[string]string{},
-			expectOutput: errors.New(`"address" config value cannot be empty`),
+			expectOutput: errors.New(`address config value cannot be empty`),
 		},
 		{
 			name:         "missing database",
 			inputConfig:  map[string]string{configKeyAddress: "http://localhost:8086"},
-			expectOutput: errors.New(`"database" config value cannot be empty`),
+			expectOutput: errors.New(`database config value cannot be empty`),
 		},
 		{
 			name: "unsupported version 2",
@@ -87,7 +87,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeyAddress:  "not-a-valid-url",
 				configKeyDatabase: "telegraf",
 			},
-			expectOutput: errors.New(`"address" must be a valid absolute URL`),
+			expectOutput: errors.New(`address must be a valid absolute URL`),
 		},
 		{
 			name: "shared_secret with username is valid",
@@ -106,7 +106,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeyDatabase:     "telegraf",
 				configKeySharedSecret: "my-secret",
 			},
-			expectOutput: errors.New(`auth configuration error: "shared_secret" requires "username" (used as the JWT username claim)`),
+			expectOutput: errors.New(`auth configuration error: shared_secret requires username (used as the JWT username claim)`),
 		},
 		{
 			name: "shared_secret conflicts with password",
@@ -117,7 +117,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeyPassword:     "hunter2",
 				configKeySharedSecret: "my-secret",
 			},
-			expectOutput: errors.New(`conflicting auth configuration: "shared_secret" cannot be used together with "password"`),
+			expectOutput: errors.New(`conflicting auth configuration: shared_secret cannot be used together with password`),
 		},
 		{
 			name: "username without password is invalid",
@@ -126,7 +126,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeyDatabase: "telegraf",
 				configKeyUsername: "autoscaler",
 			},
-			expectOutput: errors.New(`auth configuration error: "username" requires "password" for Basic authentication`),
+			expectOutput: errors.New(`auth configuration error: username requires password for Basic authentication`),
 		},
 		{
 			name: "password without username is invalid",
@@ -135,7 +135,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeyDatabase: "telegraf",
 				configKeyPassword: "hunter2",
 			},
-			expectOutput: errors.New(`auth configuration error: "password" requires "username" for Basic authentication`),
+			expectOutput: errors.New(`auth configuration error: password requires username for Basic authentication`),
 		},
 		{
 			name: "custom token_ttl valid",
@@ -157,7 +157,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeySharedSecret: "my-secret",
 				configKeyTokenTTL:     "30s",
 			},
-			expectOutput: errors.New(`invalid "token_ttl" value "30s": must be between 1m0s and 24h0m0s`),
+			expectOutput: errors.New(`invalid token_ttl value "30s": must be between 1m0s and 24h0m0s`),
 		},
 		{
 			name: "token_ttl above maximum",
@@ -168,7 +168,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeySharedSecret: "my-secret",
 				configKeyTokenTTL:     "25h",
 			},
-			expectOutput: errors.New(`invalid "token_ttl" value "25h": must be between 1m0s and 24h0m0s`),
+			expectOutput: errors.New(`invalid token_ttl value "25h": must be between 1m0s and 24h0m0s`),
 		},
 		{
 			name: "token_ttl invalid string",
@@ -179,7 +179,7 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 				configKeySharedSecret: "my-secret",
 				configKeyTokenTTL:     "forever",
 			},
-			expectOutput: errors.New(`invalid "token_ttl" value "forever"`),
+			expectOutput: errors.New(`invalid token_ttl value "forever"`),
 		},
 	}
 

--- a/plugins/builtin/apm/influxdb/plugin/plugin_test.go
+++ b/plugins/builtin/apm/influxdb/plugin/plugin_test.go
@@ -8,9 +8,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
 	"github.com/stretchr/testify/assert"
@@ -85,44 +87,78 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			expectOutput: errors.New(`"address" must be a valid absolute URL`),
 		},
 		{
-			name: "token auth only",
+			name: "shared_secret with username is valid",
 			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-token-123",
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
 			},
 			expectOutput: nil,
 		},
 		{
-			name: "token conflicts with username",
+			name: "shared_secret without username is invalid",
 			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-token",
-				configKeyUsername: "user",
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeySharedSecret: "my-secret",
 			},
-			expectOutput: errors.New(`conflicting auth configuration: "token" cannot be used together with "username" or "password"`),
+			expectOutput: errors.New(`auth configuration error: "shared_secret" requires "username" (used as the JWT username claim)`),
 		},
 		{
-			name: "token conflicts with password",
+			name: "shared_secret conflicts with password",
 			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-token",
-				configKeyPassword: "pass",
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeyPassword:     "hunter2",
+				configKeySharedSecret: "my-secret",
 			},
-			expectOutput: errors.New(`conflicting auth configuration: "token" cannot be used together with "username" or "password"`),
+			expectOutput: errors.New(`conflicting auth configuration: "shared_secret" cannot be used together with "password"`),
 		},
 		{
-			name: "token conflicts with both username and password",
+			name: "custom token_ttl valid",
 			inputConfig: map[string]string{
-				configKeyAddress:  "http://localhost:8086",
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-token",
-				configKeyUsername: "user",
-				configKeyPassword: "pass",
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
+				configKeyTokenTTL:     "30m",
 			},
-			expectOutput: errors.New(`conflicting auth configuration: "token" cannot be used together with "username" or "password"`),
+			expectOutput: nil,
+		},
+		{
+			name: "token_ttl below minimum",
+			inputConfig: map[string]string{
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
+				configKeyTokenTTL:     "30s",
+			},
+			expectOutput: errors.New(`invalid "token_ttl" value "30s": must be between 1m0s and 24h0m0s`),
+		},
+		{
+			name: "token_ttl above maximum",
+			inputConfig: map[string]string{
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
+				configKeyTokenTTL:     "25h",
+			},
+			expectOutput: errors.New(`invalid "token_ttl" value "25h": must be between 1m0s and 24h0m0s`),
+		},
+		{
+			name: "token_ttl invalid string",
+			inputConfig: map[string]string{
+				configKeyAddress:      "http://localhost:8086",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "my-secret",
+				configKeyTokenTTL:     "forever",
+			},
+			expectOutput: errors.New(`invalid "token_ttl" value "forever"`),
 		},
 	}
 
@@ -131,7 +167,12 @@ func TestAPMPlugin_SetConfig(t *testing.T) {
 			apmPlugin := APMPlugin{logger: hclog.NewNullLogger()}
 
 			actualOutput := apmPlugin.SetConfig(tc.inputConfig)
-			assert.Equal(t, tc.expectOutput, actualOutput)
+		if tc.expectOutput == nil {
+			assert.NoError(t, actualOutput)
+		} else {
+			require.Error(t, actualOutput)
+			assert.Contains(t, actualOutput.Error(), tc.expectOutput.Error())
+		}
 
 			if tc.expectOutput == nil {
 				assert.NotNil(t, apmPlugin.client)
@@ -210,11 +251,12 @@ func TestAPMPlugin_Query(t *testing.T) {
 			},
 		},
 		{
-			name:    "token auth",
+			name:    "shared_secret JWT auth",
 			fixture: "query_200.json",
 			pluginConfig: map[string]string{
-				configKeyDatabase: "telegraf",
-				configKeyToken:    "my-secret-token",
+				configKeyDatabase:     "telegraf",
+				configKeyUsername:     "autoscaler",
+				configKeySharedSecret: "test-shared-secret",
 			},
 			query: "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 10m",
 			timeRange: sdk.TimeRange{
@@ -222,11 +264,29 @@ func TestAPMPlugin_Query(t *testing.T) {
 				To:   time.Unix(1610000000, 0),
 			},
 			validateRequest: func(t *testing.T, r *http.Request) {
-				require.Equal(t, "/query", r.URL.Path)
-				// Verify token is in Authorization header
 				authHeader := r.Header.Get("Authorization")
-				require.Equal(t, "Token my-secret-token", authHeader)
-				// Verify no credentials in query params
+				require.NotEmpty(t, authHeader)
+				require.True(t, strings.HasPrefix(authHeader, "Bearer "), "expected Bearer scheme, got: %s", authHeader)
+
+				// check the JWT and its claims
+				rawToken := strings.TrimPrefix(authHeader, "Bearer ")
+				tok, err := jwt.Parse(rawToken, func(jwtTok *jwt.Token) (interface{}, error) {
+					_, ok := jwtTok.Method.(*jwt.SigningMethodHMAC)
+					require.True(t, ok, "expected HS256 signing method")
+					return []byte("test-shared-secret"), nil
+				})
+				require.NoError(t, err)
+				require.True(t, tok.Valid)
+
+				claims, ok := tok.Claims.(jwt.MapClaims)
+				require.True(t, ok)
+				require.Equal(t, "autoscaler", claims["username"])
+
+				exp, err := claims.GetExpirationTime()
+				require.NoError(t, err)
+				require.True(t, exp.After(time.Now()), "JWT exp should be in the future")
+
+				// no credentials in query params
 				qp := r.URL.Query()
 				require.Empty(t, qp.Get("u"))
 				require.Empty(t, qp.Get("p"))
@@ -285,11 +345,11 @@ func TestAPMPlugin_Query(t *testing.T) {
 
 			plugin := NewInfluxDBPlugin(hclog.NewNullLogger())
 			err := plugin.SetConfig(map[string]string{
-				configKeyAddress:  srv.URL,
-				configKeyDatabase: tc.pluginConfig[configKeyDatabase],
-				configKeyUsername: tc.pluginConfig[configKeyUsername],
-				configKeyPassword: tc.pluginConfig[configKeyPassword],
-				configKeyToken:    tc.pluginConfig[configKeyToken],
+				configKeyAddress:      srv.URL,
+				configKeyDatabase:     tc.pluginConfig[configKeyDatabase],
+				configKeyUsername:     tc.pluginConfig[configKeyUsername],
+				configKeyPassword:     tc.pluginConfig[configKeyPassword],
+				configKeySharedSecret: tc.pluginConfig[configKeySharedSecret],
 			})
 			require.NoError(t, err)
 

--- a/plugins/builtin/apm/nomad/plugin/node_test.go
+++ b/plugins/builtin/apm/nomad/plugin/node_test.go
@@ -274,10 +274,10 @@ func TestAPMPlugin_getPoolResources(t *testing.T) {
 			}),
 		},
 		{
-			name:        "ready ineligible node excluded from pool totals",
-			config:      map[string]string{},
-			expectError: false,
-			expectedCPU: 20,
+			name:          "ready ineligible node excluded from pool totals",
+			config:        map[string]string{},
+			expectError:   false,
+			expectedCPU:   20,
 			expectedMemMB: 15,
 			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Adds HS256 JWT Bearer authentication to the InfluxDB APM plugin, supporting InfluxDB 1.x shared-secret auth (`INFLUXDB_HTTP_SHARED_SECRET`).

[InfluxDB Auth Documentation](https://docs.influxdata.com/influxdb/v1/administration/authentication_and_authorization/)

**Configuration Changes**
- shared_secret`  HS256 signing secret (requires `username`) 
- shared_secret` and `password` are mutually exclusive.

How

- All config is parsed into a typed `pluginConfig` struct in `SetConfig` — values are trimmed once at the boundary, not scattered across downstream methods.
- JWTs are stateless(not cached), new token will be created every time with expiry duration = 2m. 
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

