### PR TITLE
Fix: added support for datacenter, combined query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+* plugin/apm/nomad: Add support for grouping nodes by `datacenter`, `node_pool`, or a combination of multiple pool identifiers in node pool APM queries. Previously only `node_class` was supported. [[GH-1300](https://github.com/hashicorp/nomad-autoscaler/pull/1300)]
+
 ## 0.5.0 (May 18, 2026)
 
 FEATURES:
@@ -17,7 +20,6 @@ IMPROVEMENTS:
 * plugin/apm/nomad: Support continued scaling during node drain (node_filter_ignore_drain) with safety and test hardening. [[GH-1271](https://github.com/hashicorp/nomad-autoscaler/pull/1271)]
 * plugins: Fixed AWS-ASG plugin error handling so the underlying error is preserved when retry limit is reached. [[GH-1266](https://github.com/hashicorp/nomad-autoscaler/pull/1266)]
 * scaleutils: Fix scale-in node identification to honor requested num and avoid selecting all eligible nodes. [[GH-1282](https://github.com/hashicorp/nomad-autoscaler/pull/1282)]
-* plugin/apm/nomad: Add support for grouping nodes by `datacenter`, `node_pool`, or a combination of multiple pool identifiers in node pool APM queries. Previously only `node_class` was supported. [[GH-1300](https://github.com/hashicorp/nomad-autoscaler/pull/1300)]
 
 BUG FIXES:
 * plugin/apm/nomad: Exclude `ready + ineligible` nodes from pool capacity calculations [[GH-1286](https://github.com/hashicorp/nomad-autoscaler/pull/1286)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ IMPROVEMENTS:
 * plugin/apm/nomad: Support continued scaling during node drain (node_filter_ignore_drain) with safety and test hardening. [[GH-1271](https://github.com/hashicorp/nomad-autoscaler/pull/1271)]
 * plugins: Fixed AWS-ASG plugin error handling so the underlying error is preserved when retry limit is reached. [[GH-1266](https://github.com/hashicorp/nomad-autoscaler/pull/1266)]
 * scaleutils: Fix scale-in node identification to honor requested num and avoid selecting all eligible nodes. [[GH-1282](https://github.com/hashicorp/nomad-autoscaler/pull/1282)]
+* plugin/apm/nomad: Add support for grouping nodes by `datacenter`, `node_pool`, or a combination of multiple pool identifiers in node pool APM queries. Previously only `node_class` was supported. [[GH-1300](https://github.com/hashicorp/nomad-autoscaler/pull/1300)]
 
 BUG FIXES:
 * plugin/apm/nomad: Exclude `ready + ineligible` nodes from pool capacity calculations [[GH-1286](https://github.com/hashicorp/nomad-autoscaler/pull/1286)]

--- a/plugins/builtin/apm/nomad/plugin/node.go
+++ b/plugins/builtin/apm/nomad/plugin/node.go
@@ -180,6 +180,10 @@ func (a *APMPlugin) getNodeAllocatedResources(client *api.Client, nodeID string,
 	return nil
 }
 
+// parseNodePoolQuery decodes a node pool query in the internal wire format:
+// node_<op>_<metric>/key1=val1[,key2=val2...]
+//
+// The inverse operation is formatNodePoolQuery in policy/policy.go.
 func parseNodePoolQuery(q string) (*nodePoolQuery, error) {
 
 	// Split into query prefix and pool identifier part.

--- a/plugins/builtin/apm/nomad/plugin/node.go
+++ b/plugins/builtin/apm/nomad/plugin/node.go
@@ -6,6 +6,7 @@ package plugin
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -18,9 +19,9 @@ import (
 // nodePoolQuery is the plugins internal representation of a query and contains
 // all the information needed to perform a Nomad APM query for a node pool.
 type nodePoolQuery struct {
-	metric         string
-	poolIdentifier nodepool.ClusterNodePoolIdentifier
-	operation      string
+	metric    string
+	poolIDs   nodepool.ClusterNodePoolIdentifierList
+	operation string
 }
 
 type nodePoolResources struct {
@@ -46,11 +47,12 @@ func (a *APMPlugin) queryNodePool(q string) (sdk.TimestampedMetrics, error) {
 	a.logger.Debug("performing node pool APM query", "query", q)
 
 	// Identify the resource available and consumed within the target pool.
-	resources, err := a.getPoolResources(query.poolIdentifier)
+	resources, err := a.getPoolResources(query.poolIDs)
 	if err != nil {
 		return nil, err
 	}
 	a.logger.Debug("collected node pool resource data",
+		"query", q,
 		"allocated_cpu", resources.allocated.cpu, "allocated_memory", resources.allocated.mem,
 		"allocatable_cpu", resources.allocatable.cpu, "allocatable_memory", resources.allocatable.mem)
 
@@ -82,7 +84,7 @@ func (a *APMPlugin) queryNodePool(q string) (sdk.TimestampedMetrics, error) {
 // specified node pool. Any error in calling the Nomad API for details will
 // result in an error. This is because with missing data, we cannot reliably
 // make calculations.
-func (a *APMPlugin) getPoolResources(id nodepool.ClusterNodePoolIdentifier) (*nodePoolResources, error) {
+func (a *APMPlugin) getPoolResources(ids nodepool.ClusterNodePoolIdentifierList) (*nodePoolResources, error) {
 
 	client, config := a.getClientAndConfigSnapshot()
 	if client == nil {
@@ -101,7 +103,7 @@ func (a *APMPlugin) getPoolResources(id nodepool.ClusterNodePoolIdentifier) (*no
 
 	// Perform our node filtering so we are left with a list of nodes that form
 	// our pool and that are in the correct state.
-	nodePoolList, err := scaleutils.FilterNodesWithOptions(nodes, id.IsPoolMember, filterOpts)
+	nodePoolList, err := scaleutils.FilterNodesWithOptions(nodes, ids.IsPoolMember, filterOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to identify nodes within pool: %v", err)
 	}
@@ -180,13 +182,36 @@ func (a *APMPlugin) getNodeAllocatedResources(client *api.Client, nodeID string,
 
 func parseNodePoolQuery(q string) (*nodePoolQuery, error) {
 
-	mainParts := strings.SplitN(q, "/", 3)
-	if len(mainParts) != 3 {
-		return nil, fmt.Errorf("expected <query>/<pool_identifier_value>/<pool_identifier_key>, received %s", q)
+	// Split into query prefix and pool identifier part.
+	mainParts := strings.SplitN(q, "/", 2)
+	if len(mainParts) != 2 || mainParts[1] == "" {
+		return nil, fmt.Errorf("expected <query>/<key>=<value>[,<key>=<value>...], received %q", q)
 	}
 
-	query := nodePoolQuery{
-		poolIdentifier: nodepool.NewNodeClassPoolIdentifier(mainParts[1]),
+	var query nodePoolQuery
+
+	// Parse the combined format: key1=val1[,key2=val2...]
+	for _, pair := range strings.Split(mainParts[1], ",") {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 || kv[0] == "" || kv[1] == "" {
+			return nil, fmt.Errorf("invalid pool identifier %q: expected key=value", pair)
+		}
+
+		value, err := url.QueryUnescape(kv[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode value in %q: %v", pair, err)
+		}
+
+		switch kv[0] {
+		case sdk.TargetConfigKeyClass:
+			query.poolIDs = append(query.poolIDs, nodepool.NewNodeClassPoolIdentifier(value))
+		case sdk.TargetConfigKeyDatacenter:
+			query.poolIDs = append(query.poolIDs, nodepool.NewNodeDatacenterPoolIdentifier(value))
+		case sdk.TargetConfigKeyNodePool:
+			query.poolIDs = append(query.poolIDs, nodepool.NewNodePoolClusterPoolIdentifier(value))
+		default:
+			return nil, fmt.Errorf("unknown pool key %q: must be node_class, datacenter, or node_pool", kv[0])
+		}
 	}
 
 	opMetricParts := strings.SplitN(mainParts[0], "_", 3)

--- a/plugins/builtin/apm/nomad/plugin/node_test.go
+++ b/plugins/builtin/apm/nomad/plugin/node_test.go
@@ -23,61 +23,133 @@ func Test_parseNodePoolQuery(t *testing.T) {
 		name                string
 	}{
 		{
-			inputQuery: "node_percentage-allocated_memory/high-memory/class",
+			inputQuery: "node_percentage-allocated_memory/node_class=high-memory",
 			expectedOutputQuery: &nodePoolQuery{
-				metric:         "memory",
-				poolIdentifier: nodepool.NewNodeClassPoolIdentifier("high-memory"),
-				operation:      "percentage-allocated",
+				metric: "memory",
+				poolIDs: nodepool.ClusterNodePoolIdentifierList{
+					nodepool.NewNodeClassPoolIdentifier("high-memory"),
+				},
+				operation: "percentage-allocated",
 			},
 			expectError: nil,
-			name:        "node percentage-allocated memory",
+			name:        "single node_class identifier",
 		},
 		{
-			inputQuery: "node_percentage-allocated_cpu/high-compute/class",
+			inputQuery: "node_percentage-allocated_cpu/datacenter=dc1",
 			expectedOutputQuery: &nodePoolQuery{
-				metric:         "cpu",
-				poolIdentifier: nodepool.NewNodeClassPoolIdentifier("high-compute"),
-				operation:      "percentage-allocated",
+				metric: "cpu",
+				poolIDs: nodepool.ClusterNodePoolIdentifierList{
+					nodepool.NewNodeDatacenterPoolIdentifier("dc1"),
+				},
+				operation: "percentage-allocated",
 			},
 			expectError: nil,
-			name:        "node percentage-allocated cpu",
+			name:        "single datacenter identifier",
 		},
-
+		{
+			inputQuery: "node_percentage-allocated_cpu/node_pool=gpu",
+			expectedOutputQuery: &nodePoolQuery{
+				metric: "cpu",
+				poolIDs: nodepool.ClusterNodePoolIdentifierList{
+					nodepool.NewNodePoolClusterPoolIdentifier("gpu"),
+				},
+				operation: "percentage-allocated",
+			},
+			expectError: nil,
+			name:        "single node_pool identifier",
+		},
+		{
+			inputQuery: "node_percentage-allocated_memory/node_class=hashistack,datacenter=dc1",
+			expectedOutputQuery: &nodePoolQuery{
+				metric: "memory",
+				poolIDs: nodepool.ClusterNodePoolIdentifierList{
+					nodepool.NewNodeClassPoolIdentifier("hashistack"),
+					nodepool.NewNodeDatacenterPoolIdentifier("dc1"),
+				},
+				operation: "percentage-allocated",
+			},
+			expectError: nil,
+			name:        "combined node_class and datacenter",
+		},
+		{
+			inputQuery: "node_percentage-allocated_cpu/datacenter=us-east-1a,node_pool=gpu",
+			expectedOutputQuery: &nodePoolQuery{
+				metric: "cpu",
+				poolIDs: nodepool.ClusterNodePoolIdentifierList{
+					nodepool.NewNodeDatacenterPoolIdentifier("us-east-1a"),
+					nodepool.NewNodePoolClusterPoolIdentifier("gpu"),
+				},
+				operation: "percentage-allocated",
+			},
+			expectError: nil,
+			name:        "combined datacenter and node_pool",
+		},
+		{
+			inputQuery: "node_percentage-allocated_cpu/datacenter=us+east+1",
+			expectedOutputQuery: &nodePoolQuery{
+				metric: "cpu",
+				poolIDs: nodepool.ClusterNodePoolIdentifierList{
+					nodepool.NewNodeDatacenterPoolIdentifier("us east 1"),
+				},
+				operation: "percentage-allocated",
+			},
+			expectError: nil,
+			name:        "URL-encoded value with space",
+		},
+		{
+			inputQuery: "node_percentage-allocated_cpu/node_class=special%2Cclass,datacenter=dc1",
+			expectedOutputQuery: &nodePoolQuery{
+				metric: "cpu",
+				poolIDs: nodepool.ClusterNodePoolIdentifierList{
+					nodepool.NewNodeClassPoolIdentifier("special,class"),
+					nodepool.NewNodeDatacenterPoolIdentifier("dc1"),
+				},
+				operation: "percentage-allocated",
+			},
+			expectError: nil,
+			name:        "URL-encoded value containing comma",
+		},
 		{
 			inputQuery:          "",
 			expectedOutputQuery: nil,
-			expectError:         errors.New("expected <query>/<pool_identifier_value>/<pool_identifier_key>, received "),
+			expectError:         errors.New("expected <query>/<key>=<value>[,<key>=<value>...], received \"\""),
 			name:                "empty input query",
 		},
 		{
 			inputQuery:          "invalid",
 			expectedOutputQuery: nil,
-			expectError:         errors.New("expected <query>/<pool_identifier_value>/<pool_identifier_key>, received invalid"),
+			expectError:         errors.New("expected <query>/<key>=<value>[,<key>=<value>...], received \"invalid\""),
 			name:                "invalid input query format",
 		},
 		{
-			inputQuery:          "node_percentage-allocated_cpu/class",
-			expectedOutputQuery: nil,
-			expectError:         errors.New("expected <query>/<pool_identifier_value>/<pool_identifier_key>, received node_percentage-allocated_cpu/class"),
-			name:                "missing node pool identifier value",
-		},
-		{
-			inputQuery:          "node_percentage-allocated_invalid/class/high-compute",
+			inputQuery:          "node_percentage-allocated_invalid/node_class=high-compute",
 			expectedOutputQuery: nil,
 			expectError:         errors.New("invalid metric \"invalid\", allowed values are: cpu, memory"),
 			name:                "invalid metric",
 		},
 		{
-			inputQuery:          "node_percentage-allocated_cpu-allocated/class/high-compute",
+			inputQuery:          "node_percentage-allocated_cpu-allocated/node_class=high-compute",
 			expectedOutputQuery: nil,
 			expectError:         errors.New("invalid metric \"cpu-allocated\", allowed values are: cpu, memory"),
 			name:                "metric for task group queries only",
 		},
 		{
-			inputQuery:          "node_invalid_cpu/class/high-compute",
+			inputQuery:          "node_invalid_cpu/node_class=high-compute",
 			expectedOutputQuery: nil,
 			expectError:         errors.New("invalid operation \"invalid\", allowed value is percentage-allocated"),
 			name:                "invalid operation",
+		},
+		{
+			inputQuery:          "node_percentage-allocated_cpu/invalid_key=value,datacenter=dc1",
+			expectedOutputQuery: nil,
+			expectError:         errors.New("unknown pool key \"invalid_key\": must be node_class, datacenter, or node_pool"),
+			name:                "unknown pool key",
+		},
+		{
+			inputQuery:          "node_percentage-allocated_cpu/node_class=,datacenter=dc1",
+			expectedOutputQuery: nil,
+			expectError:         errors.New("invalid pool identifier \"node_class=\": expected key=value"),
+			name:                "empty value",
 		},
 	}
 
@@ -198,7 +270,9 @@ func Test_isClientTerminalStatus(t *testing.T) {
 }
 
 func TestAPMPlugin_getPoolResources(t *testing.T) {
-	id := nodepool.NewNodeClassPoolIdentifier("1")
+	ids := nodepool.ClusterNodePoolIdentifierList{
+		nodepool.NewNodeClassPoolIdentifier("1"),
+	}
 	cpu := 20
 	mem := 15
 
@@ -419,7 +493,7 @@ func TestAPMPlugin_getPoolResources(t *testing.T) {
 			assert.NoError(t, err)
 
 			p := &APMPlugin{client: client, config: tc.config}
-			resp, err := p.getPoolResources(id)
+			resp, err := p.getPoolResources(ids)
 
 			if tc.expectError {
 				assert.Error(t, err)

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -85,11 +85,15 @@ func (pr *Processor) ValidatePolicy(p *sdk.ScalingPolicy) error {
 
 	// Validate that Nomad APM queries for node pool targets use the short format.
 	// Long-form queries are internal only and must not be written by operators.
-	if p.Target != nil && p.Target.IsNodePoolTarget() {
-		for _, c := range p.Checks {
-			if c == nil {
-				continue
-			}
+	isNodePool := p.Target != nil && p.Target.IsNodePoolTarget()
+
+	for _, c := range p.Checks {
+		if c == nil {
+			continue
+		}
+
+		// Node pool APM query format validation.
+		if isNodePool {
 			source := c.Source
 			if source == "" {
 				source = plugins.InternalAPMNomad
@@ -100,37 +104,30 @@ func (pr *Processor) ValidatePolicy(p *sdk.ScalingPolicy) error {
 					c.Name))
 			}
 		}
-	}
 
-	for _, c := range p.Checks {
-		if c == nil || !c.QueryInstant || c.Strategy == nil {
-			continue
-		}
+		// Threshold strategy with instant queries validation.
+		if c.QueryInstant && c.Strategy != nil && c.Strategy.Name == plugins.InternalStrategyThreshold {
+			triggerRaw, ok := c.Strategy.Config[thresholdWithinBoundsTriggerConfigKey]
+			if !ok {
+				mErr = multierror.Append(mErr,
+					fmt.Errorf("check %q: %q must be set to 1 when query_window = %q",
+						c.Name, thresholdWithinBoundsTriggerConfigKey, "instant"))
+				continue
+			}
 
-		if c.Strategy.Name != plugins.InternalStrategyThreshold {
-			continue
-		}
+			triggerValue, err := strconv.Atoi(triggerRaw)
+			if err != nil {
+				mErr = multierror.Append(mErr,
+					fmt.Errorf("check %q: %q must be set to 1 when query_window = %q",
+						c.Name, thresholdWithinBoundsTriggerConfigKey, "instant"))
+				continue
+			}
 
-		triggerRaw, ok := c.Strategy.Config[thresholdWithinBoundsTriggerConfigKey]
-		if !ok {
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("check %q: %q must be set to 1 when query_window = %q",
-					c.Name, thresholdWithinBoundsTriggerConfigKey, "instant"))
-			continue
-		}
-
-		triggerValue, err := strconv.Atoi(triggerRaw)
-		if err != nil {
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("check %q: %q must be set to 1 when query_window = %q",
-					c.Name, thresholdWithinBoundsTriggerConfigKey, "instant"))
-			continue
-		}
-
-		if triggerValue != 1 {
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("check %q: %q must be set to 1 when query_window = %q",
-					c.Name, thresholdWithinBoundsTriggerConfigKey, "instant"))
+			if triggerValue != 1 {
+				mErr = multierror.Append(mErr,
+					fmt.Errorf("check %q: %q must be set to 1 when query_window = %q",
+						c.Name, thresholdWithinBoundsTriggerConfigKey, "instant"))
+			}
 		}
 	}
 
@@ -186,17 +183,26 @@ func (pr *Processor) CanonicalizeAPMQuery(c *sdk.ScalingPolicyCheck, t *sdk.Scal
 	}
 
 	// If the target is a Nomad client node pool, format the query in the
-	// combined format: node_<op>_<metric>/key1=val1,key2=val2
+	// internal wire format.
 	if t.IsNodePoolTarget() {
-		var parts []string
-		for _, k := range []string{sdk.TargetConfigKeyClass, sdk.TargetConfigKeyDatacenter, sdk.TargetConfigKeyNodePool} {
-			if v, ok := t.Config[k]; ok {
-				parts = append(parts, k+"="+url.QueryEscape(v))
-			}
-		}
-		c.Query = fmt.Sprintf("%s_%s/%s",
-			nomadAPM.QueryTypeNode, c.Query, strings.Join(parts, ","))
+		c.Query = formatNodePoolQuery(c.Query, t.Config)
 	}
+}
+
+// formatNodePoolQuery encodes a short-form node pool query into the internal
+// wire format: node_<op>_<metric>/key1=url.QueryEscape(val1)[,key2=url.QueryEscape(val2)...]
+//
+// The inverse operation is parseNodePoolQuery in
+// plugins/builtin/apm/nomad/plugin/node.go.
+func formatNodePoolQuery(shortQuery string, cfg map[string]string) string {
+	var parts []string
+	for _, k := range []string{sdk.TargetConfigKeyClass, sdk.TargetConfigKeyDatacenter, sdk.TargetConfigKeyNodePool} {
+		if v, ok := cfg[k]; ok {
+			parts = append(parts, k+"="+url.QueryEscape(v))
+		}
+	}
+	return fmt.Sprintf("%s_%s/%s",
+		nomadAPM.QueryTypeNode, shortQuery, strings.Join(parts, ","))
 }
 
 // isNomadAPMQuery helps identify whether the policy query is aligned with a

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -83,6 +83,25 @@ func (pr *Processor) ValidatePolicy(p *sdk.ScalingPolicy) error {
 		mErr = multierror.Append(mErr, errors.New("policy Min must not be greater Max"))
 	}
 
+	// Validate that Nomad APM queries for node pool targets use the short format.
+	// Long-form queries are internal only and must not be written by operators.
+	if p.Target != nil && p.Target.IsNodePoolTarget() {
+		for _, c := range p.Checks {
+			if c == nil {
+				continue
+			}
+			source := c.Source
+			if source == "" {
+				source = plugins.InternalAPMNomad
+			}
+			if pr.isNomadAPMQuery(source) && !isShortQuery(c.Query) {
+				mErr = multierror.Append(mErr, fmt.Errorf(
+					"check %q: query must be in short format (<operation>_<metric>) for Nomad APM node pool targets",
+					c.Name))
+			}
+		}
+	}
+
 	for _, c := range p.Checks {
 		if c == nil || !c.QueryInstant || c.Strategy == nil {
 			continue
@@ -146,9 +165,8 @@ func (pr *Processor) CanonicalizeAPMQuery(c *sdk.ScalingPolicyCheck, t *sdk.Scal
 		return
 	}
 
-	// If the query is not formatted in the short manner we do not have any
-	// work to do. Operators can add this if they want/know the autoscaler
-	// internal model.
+	// If the query already contains a slash it is in full internal form and
+	// does not need further processing.
 	if !isShortQuery(c.Query) {
 		return
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -167,12 +168,16 @@ func (pr *Processor) CanonicalizeAPMQuery(c *sdk.ScalingPolicyCheck, t *sdk.Scal
 	}
 
 	// If the target is a Nomad client node pool, format the query in the
-	// expected manner. Once the autoscaler supports more than just class
-	// identification of pools this func and logic will need to be updated. For
-	// now keep it simple.
+	// combined format: node_<op>_<metric>/key1=val1,key2=val2
 	if t.IsNodePoolTarget() {
-		c.Query = fmt.Sprintf("%s_%s/%s/class",
-			nomadAPM.QueryTypeNode, c.Query, t.Config[sdk.TargetConfigKeyClass])
+		var parts []string
+		for _, k := range []string{sdk.TargetConfigKeyClass, sdk.TargetConfigKeyDatacenter, sdk.TargetConfigKeyNodePool} {
+			if v, ok := t.Config[k]; ok {
+				parts = append(parts, k+"="+url.QueryEscape(v))
+			}
+		}
+		c.Query = fmt.Sprintf("%s_%s/%s",
+			nomadAPM.QueryTypeNode, c.Query, strings.Join(parts, ","))
 	}
 }
 

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -311,9 +311,77 @@ func TestProcessor_CanonicalizeAPMQuery(t *testing.T) {
 			expectedOutputCheck: &sdk.ScalingPolicyCheck{
 				Name:   "random-check",
 				Source: "nomad-apm",
-				Query:  "node_percentage-allocated_memory/hashistack/class",
+				Query:  "node_percentage-allocated_memory/node_class=hashistack",
 			},
-			name: "correctly formatted node target short query",
+			name: "node target short query with node_class",
+		},
+		{
+			inputCheck: &sdk.ScalingPolicyCheck{
+				Name:   "random-check",
+				Source: "nomad-apm",
+				Query:  "percentage-allocated_cpu",
+			},
+			inputAPMNames: []string{"nomad-apm"},
+			inputTarget: &sdk.ScalingPolicyTarget{
+				Config: map[string]string{"datacenter": "us-east-1"},
+			},
+			expectedOutputCheck: &sdk.ScalingPolicyCheck{
+				Name:   "random-check",
+				Source: "nomad-apm",
+				Query:  "node_percentage-allocated_cpu/datacenter=us-east-1",
+			},
+			name: "node target short query with datacenter",
+		},
+		{
+			inputCheck: &sdk.ScalingPolicyCheck{
+				Name:   "random-check",
+				Source: "nomad-apm",
+				Query:  "percentage-allocated_cpu",
+			},
+			inputAPMNames: []string{"nomad-apm"},
+			inputTarget: &sdk.ScalingPolicyTarget{
+				Config: map[string]string{"node_pool": "gpu"},
+			},
+			expectedOutputCheck: &sdk.ScalingPolicyCheck{
+				Name:   "random-check",
+				Source: "nomad-apm",
+				Query:  "node_percentage-allocated_cpu/node_pool=gpu",
+			},
+			name: "node target short query with node_pool",
+		},
+		{
+			inputCheck: &sdk.ScalingPolicyCheck{
+				Name:   "random-check",
+				Source: "nomad-apm",
+				Query:  "percentage-allocated_memory",
+			},
+			inputAPMNames: []string{"nomad-apm"},
+			inputTarget: &sdk.ScalingPolicyTarget{
+				Config: map[string]string{"node_class": "hashistack", "datacenter": "dc1"},
+			},
+			expectedOutputCheck: &sdk.ScalingPolicyCheck{
+				Name:   "random-check",
+				Source: "nomad-apm",
+				Query:  "node_percentage-allocated_memory/node_class=hashistack,datacenter=dc1",
+			},
+			name: "node target short query with node_class and datacenter combined",
+		},
+		{
+			inputCheck: &sdk.ScalingPolicyCheck{
+				Name:   "random-check",
+				Source: "nomad-apm",
+				Query:  "percentage-allocated_cpu",
+			},
+			inputAPMNames: []string{"nomad-apm"},
+			inputTarget: &sdk.ScalingPolicyTarget{
+				Config: map[string]string{"datacenter": "us east 1"},
+			},
+			expectedOutputCheck: &sdk.ScalingPolicyCheck{
+				Name:   "random-check",
+				Source: "nomad-apm",
+				Query:  "node_percentage-allocated_cpu/datacenter=us+east+1",
+			},
+			name: "node target short query with space in value",
 		},
 		{
 			inputCheck: &sdk.ScalingPolicyCheck{

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -224,6 +224,153 @@ func TestProcessor_ValidatePolicy(t *testing.T) {
 	}
 }
 
+func TestProcessor_ValidatePolicy_QueryFormat(t *testing.T) {
+	testCases := []struct {
+		inputPolicy    *sdk.ScalingPolicy
+		expectedOutput error
+		name           string
+	}{
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
+				Min: 1,
+				Max: 10,
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"node_class": "hashistack"},
+				},
+				Checks: []*sdk.ScalingPolicyCheck{
+					{
+						Name:   "mem",
+						Source: "nomad-apm",
+						Query:  "percentage-allocated_memory",
+					},
+				},
+			},
+			expectedOutput: nil,
+			name:           "valid short query for node pool target passes",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
+				Min: 1,
+				Max: 10,
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"node_class": "hashistack"},
+				},
+				Checks: []*sdk.ScalingPolicyCheck{
+					{
+						Name:   "mem",
+						Source: "nomad-apm",
+						Query:  "node_percentage-allocated_memory/hashistack/class",
+					},
+				},
+			},
+			expectedOutput: &multierror.Error{
+				Errors: []error{
+					errors.New("check \"mem\": query must be in short format (<operation>_<metric>) for Nomad APM node pool targets"),
+				},
+			},
+			name: "legacy long-form query rejected for node pool target",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
+				Min: 1,
+				Max: 10,
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"node_class": "hashistack"},
+				},
+				Checks: []*sdk.ScalingPolicyCheck{
+					{
+						Name:   "mem",
+						Source: "nomad-apm",
+						Query:  "node_percentage-allocated_memory/node_class=hashistack",
+					},
+				},
+			},
+			expectedOutput: &multierror.Error{
+				Errors: []error{
+					errors.New("check \"mem\": query must be in short format (<operation>_<metric>) for Nomad APM node pool targets"),
+				},
+			},
+			name: "full internal-form query rejected for node pool target",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
+				Min: 1,
+				Max: 10,
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"node_class": "hashistack"},
+				},
+				Checks: []*sdk.ScalingPolicyCheck{
+					{
+						Name:  "mem",
+						Query: "node_percentage-allocated_memory/hashistack/class",
+					},
+				},
+			},
+			expectedOutput: &multierror.Error{
+				Errors: []error{
+					errors.New("check \"mem\": query must be in short format (<operation>_<metric>) for Nomad APM node pool targets"),
+				},
+			},
+			name: "empty source defaults to nomad-apm and rejects long-form",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
+				Min: 1,
+				Max: 10,
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{"node_class": "hashistack"},
+				},
+				Checks: []*sdk.ScalingPolicyCheck{
+					{
+						Name:   "mem",
+						Source: "prometheus",
+						Query:  "node_percentage-allocated_memory/hashistack/class",
+					},
+				},
+			},
+			expectedOutput: nil,
+			name:           "non-nomad-apm source skips query format validation",
+		},
+		{
+			inputPolicy: &sdk.ScalingPolicy{
+				ID:  "ce888afe-3dd2-144c-7227-74644434f708",
+				Min: 1,
+				Max: 10,
+				Target: &sdk.ScalingPolicyTarget{
+					Config: map[string]string{
+						"Job":       "example",
+						"Group":     "cache",
+						"Namespace": "default",
+					},
+				},
+				Checks: []*sdk.ScalingPolicyCheck{
+					{
+						Name:   "mem",
+						Source: "nomad-apm",
+						Query:  "node_percentage-allocated_memory/hashistack/class",
+					},
+				},
+			},
+			expectedOutput: nil,
+			name:           "non-node-pool target skips query format validation",
+		},
+	}
+
+	pr := Processor{nomadAPMs: []string{"nomad-apm"}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := pr.ValidatePolicy(tc.inputPolicy)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}
+
 func TestProcessor_CanonicalizeAPMQuery(t *testing.T) {
 	testCases := []struct {
 		inputCheck          *sdk.ScalingPolicyCheck

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -224,11 +224,11 @@ func (c *ClusterScaleUtils) IdentifyScaleInNodes(cfg map[string]string, num int)
 
 func (c *ClusterScaleUtils) identifyEligibleScaleInNodes(cfg map[string]string) ([]*api.NodeListStub, error) {
 
-	poolID, err := nodepool.NewClusterNodePoolIdentifier(cfg)
+	ids, err := nodepool.NewClusterNodePoolIdentifierList(cfg)
 	if err != nil {
 		return nil, err
 	}
-	c.log.Debug("performing node pool filtering", poolID.Key(), poolID.Value())
+	c.log.Debug("performing node pool filtering", "identifiers", fmt.Sprintf("%v", ids))
 
 	// Pull a current list of Nomad nodes from the API including populated
 	// resource fields.
@@ -259,7 +259,7 @@ func (c *ClusterScaleUtils) identifyEligibleScaleInNodes(cfg map[string]string) 
 		return nil, err
 	}
 
-	filteredNodes, err := FilterNodesWithOptions(nodes, poolID.IsPoolMember, filterOpts)
+	filteredNodes, err := FilterNodesWithOptions(nodes, ids.IsPoolMember, filterOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (c *ClusterScaleUtils) identifyEligibleScaleInNodes(cfg map[string]string) 
 
 	// Ensure we have not filtered out all the available nodes.
 	if len(filteredNodes) == 0 {
-		return nil, fmt.Errorf("no nodes unfiltered for %s with value %s", poolID.Key(), poolID.Value())
+		return nil, fmt.Errorf("no nodes unfiltered for pool identifiers %v", ids)
 	}
 
 	return filteredNodes, nil
@@ -398,7 +398,7 @@ func (c *ClusterScaleUtils) RunPostScaleInTasks(_ context.Context, cfg map[strin
 // there was a problem performing the check.
 func (c *ClusterScaleUtils) IsPoolReady(cfg map[string]string) (bool, error) {
 
-	poolID, err := nodepool.NewClusterNodePoolIdentifier(cfg)
+	ids, err := nodepool.NewClusterNodePoolIdentifierList(cfg)
 	if err != nil {
 		return false, err
 	}
@@ -412,7 +412,7 @@ func (c *ClusterScaleUtils) IsPoolReady(cfg map[string]string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if _, err := FilterNodesWithOptions(nodes, poolID.IsPoolMember, filterOpts); err != nil {
+	if _, err := FilterNodesWithOptions(nodes, ids.IsPoolMember, filterOpts); err != nil {
 		c.log.Warn("node pool status readiness check failed", "error", err)
 		return false, nil
 	}

--- a/sdk/helper/scaleutils/cluster.go
+++ b/sdk/helper/scaleutils/cluster.go
@@ -228,7 +228,7 @@ func (c *ClusterScaleUtils) identifyEligibleScaleInNodes(cfg map[string]string) 
 	if err != nil {
 		return nil, err
 	}
-	c.log.Debug("performing node pool filtering", "identifiers", fmt.Sprintf("%v", ids))
+	c.log.Debug("performing node pool filtering", "identifiers", ids.String())
 
 	// Pull a current list of Nomad nodes from the API including populated
 	// resource fields.
@@ -275,7 +275,7 @@ func (c *ClusterScaleUtils) identifyEligibleScaleInNodes(cfg map[string]string) 
 
 	// Ensure we have not filtered out all the available nodes.
 	if len(filteredNodes) == 0 {
-		return nil, fmt.Errorf("no nodes unfiltered for pool identifiers %v", ids)
+		return nil, fmt.Errorf("no nodes unfiltered for pool identifiers: %v", ids)
 	}
 
 	return filteredNodes, nil

--- a/sdk/helper/scaleutils/node_identifier_test.go
+++ b/sdk/helper/scaleutils/node_identifier_test.go
@@ -337,7 +337,7 @@ func Test_FilterNodes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			idFn, err := nodepool.NewClusterNodePoolIdentifier(tc.inputIDCfg)
+			idFn, err := nodepool.NewClusterNodePoolIdentifierList(tc.inputIDCfg)
 			assert.NotNil(t, idFn, tc.name)
 			assert.Nil(t, err, tc.name)
 
@@ -449,7 +449,7 @@ func Test_FilterNodesWithOptions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			idFn, err := nodepool.NewClusterNodePoolIdentifier(tc.inputIDCfg)
+			idFn, err := nodepool.NewClusterNodePoolIdentifierList(tc.inputIDCfg)
 			must.NoError(t, err)
 			must.NotNil(t, idFn)
 

--- a/sdk/helper/scaleutils/nodepool/combined.go
+++ b/sdk/helper/scaleutils/nodepool/combined.go
@@ -3,7 +3,11 @@
 
 package nodepool
 
-import "github.com/hashicorp/nomad/api"
+import (
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+)
 
 // ClusterNodePoolIdentifierList is a list of ClusterNodePoolIdentifier
 // values that filters nodes using AND logic. A node must match every
@@ -18,4 +22,14 @@ func (l ClusterNodePoolIdentifierList) IsPoolMember(n *api.NodeListStub) bool {
 		}
 	}
 	return true
+}
+
+// String implements fmt.Stringer so that formatted printing produces a
+// human-readable representation instead of pointer addresses.
+func (l ClusterNodePoolIdentifierList) String() string {
+	parts := make([]string, len(l))
+	for i, id := range l {
+		parts[i] = id.Key() + "=" + id.Value()
+	}
+	return strings.Join(parts, ", ")
 }

--- a/sdk/helper/scaleutils/nodepool/combined.go
+++ b/sdk/helper/scaleutils/nodepool/combined.go
@@ -3,70 +3,19 @@
 
 package nodepool
 
-import (
-	"fmt"
-	"strings"
+import "github.com/hashicorp/nomad/api"
 
-	"github.com/hashicorp/nomad/api"
-)
+// ClusterNodePoolIdentifierList is a list of ClusterNodePoolIdentifier
+// values that filters nodes using AND logic. A node must match every
+// identifier in the list to be considered a pool member.
+type ClusterNodePoolIdentifierList []ClusterNodePoolIdentifier
 
-const (
-	// CombinedClusterPoolIdentifierAnd requires all identifiers to return true.
-	CombinedClusterPoolIdentifierAnd CombinedClusterPoolIdentifierMode = "and"
-
-	// CombinedClusterPoolIdentifierOr requires at least one identifier to
-	// return true.
-	CombinedClusterPoolIdentifierOr CombinedClusterPoolIdentifierMode = "or"
-)
-
-// CombinedClusterPoolIdentifierMode defines how different
-// ClusterNodePoolIdentifiers are combined.
-type CombinedClusterPoolIdentifierMode string
-
-// combinedClusterPoolIdentifier is an implementation of the
-// ClusterNodePoolIdentifier interface that filters Nomad nodes by combining
-// multiple filters.
-type combinedClusterPoolIdentifier struct {
-	poolIdentifiers []ClusterNodePoolIdentifier
-	mode            CombinedClusterPoolIdentifierMode
-}
-
-// NewCombinedClusterPoolIdentifier returns a new combinedClusterPoolIdentifier.
-func NewCombinedClusterPoolIdentifier(poolIdentifiers []ClusterNodePoolIdentifier, mode CombinedClusterPoolIdentifierMode) ClusterNodePoolIdentifier {
-	return &combinedClusterPoolIdentifier{
-		poolIdentifiers: poolIdentifiers,
-		mode:            mode,
-	}
-}
-
-// IsPoolMember satisfies the IsPoolMember function on the
-// ClusterNodePoolIdentifier interface.
-func (c *combinedClusterPoolIdentifier) IsPoolMember(n *api.NodeListStub) bool {
-	// If mode is 'and' we assume the node is a member unless told otherwise.
-	isMember := c.mode == CombinedClusterPoolIdentifierAnd
-
-	for _, identifier := range c.poolIdentifiers {
-		switch c.mode {
-		case CombinedClusterPoolIdentifierAnd:
-			isMember = isMember && identifier.IsPoolMember(n)
-		case CombinedClusterPoolIdentifierOr:
-			isMember = isMember || identifier.IsPoolMember(n)
+// IsPoolMember returns true if the node matches all identifiers in the list.
+func (l ClusterNodePoolIdentifierList) IsPoolMember(n *api.NodeListStub) bool {
+	for _, id := range l {
+		if !id.IsPoolMember(n) {
+			return false
 		}
 	}
-	return isMember
-}
-
-// Key satisfies the Key function on the ClusterNodePoolIdentifier interface.
-func (c *combinedClusterPoolIdentifier) Key() string {
-	return "combined_identifier"
-}
-
-// Value satisfies the Value function on the ClusterNodePoolIdentifier
-// interface.
-func (c *combinedClusterPoolIdentifier) Value() string {
-	values := make([]string, 0, len(c.poolIdentifiers))
-	for _, identifier := range c.poolIdentifiers {
-		values = append(values, fmt.Sprintf("%s:%s", identifier.Key(), identifier.Value()))
-	}
-	return strings.Join(values, fmt.Sprintf(" %s ", c.mode))
+	return true
 }

--- a/sdk/helper/scaleutils/nodepool/combined.go
+++ b/sdk/helper/scaleutils/nodepool/combined.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nodepool

--- a/sdk/helper/scaleutils/nodepool/combined_deprecated.go
+++ b/sdk/helper/scaleutils/nodepool/combined_deprecated.go
@@ -1,0 +1,78 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+// This file contains a deprecated implementation of a combined ClusterNodePoolIdentifier 
+// It is retained for backward compatibility with existing code that uses this implementation
+// TODO: Remove this file and all references in next Release.
+
+package nodepool
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+// CombinedClusterPoolIdentifierMode defines how different
+// ClusterNodePoolIdentifiers are combined.
+//
+// Deprecated: Use ClusterNodePoolIdentifierList for AND filtering.
+type CombinedClusterPoolIdentifierMode string
+
+const (
+	// CombinedClusterPoolIdentifierAnd requires all identifiers to return true.
+	CombinedClusterPoolIdentifierAnd CombinedClusterPoolIdentifierMode = "and"
+
+	// CombinedClusterPoolIdentifierOr requires at least one identifier to
+	// return true.
+	CombinedClusterPoolIdentifierOr CombinedClusterPoolIdentifierMode = "or"
+)
+
+// Deprecated: Use ClusterNodePoolIdentifierList for AND filtering.
+// NewCombinedClusterPoolIdentifier returns a new combinedClusterPoolIdentifier.
+func NewCombinedClusterPoolIdentifier(poolIdentifiers []ClusterNodePoolIdentifier, mode CombinedClusterPoolIdentifierMode) ClusterNodePoolIdentifier {
+	return &combinedClusterPoolIdentifier{
+		poolIdentifiers: poolIdentifiers,
+		mode:            mode,
+	}
+}
+
+// combinedClusterPoolIdentifier is an implementation of the
+// ClusterNodePoolIdentifier interface that filters Nomad nodes by combining
+// multiple filters.
+type combinedClusterPoolIdentifier struct {
+	poolIdentifiers []ClusterNodePoolIdentifier
+	mode            CombinedClusterPoolIdentifierMode
+}
+
+// IsPoolMember satisfies the IsPoolMember function on the
+// ClusterNodePoolIdentifier interface.
+func (c *combinedClusterPoolIdentifier) IsPoolMember(n *api.NodeListStub) bool {
+	// If mode is 'and' we assume the node is a member unless told otherwise.
+	isMember := c.mode == CombinedClusterPoolIdentifierAnd
+
+	for _, identifier := range c.poolIdentifiers {
+		switch c.mode {
+		case CombinedClusterPoolIdentifierAnd:
+			isMember = isMember && identifier.IsPoolMember(n)
+		case CombinedClusterPoolIdentifierOr:
+			isMember = isMember || identifier.IsPoolMember(n)
+		}
+	}
+	return isMember
+}
+
+// Key satisfies the Key function on the ClusterNodePoolIdentifier interface.
+func (c *combinedClusterPoolIdentifier) Key() string {
+	return "combined_identifier"
+}
+
+// Value satisfies the Value function on the ClusterNodePoolIdentifier
+// interface.
+func (c *combinedClusterPoolIdentifier) Value() string {
+	values := make([]string, 0, len(c.poolIdentifiers))
+	for _, identifier := range c.poolIdentifiers {
+		values = append(values, fmt.Sprintf("%s:%s", identifier.Key(), identifier.Value()))
+	}
+	return strings.Join(values, fmt.Sprintf(" %s ", c.mode))
+}

--- a/sdk/helper/scaleutils/nodepool/combined_deprecated_test.go
+++ b/sdk/helper/scaleutils/nodepool/combined_deprecated_test.go
@@ -1,0 +1,123 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+// TODO: Remove this file and all references in next Release.
+
+package nodepool
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/shoenig/test/must"
+)
+
+func Test_NewCombinedClusterPoolIdentifier_AND(t *testing.T) {
+	classID := NewNodeClassPoolIdentifier("high-memory")
+	dcID := NewNodeDatacenterPoolIdentifier("dc1")
+
+	combined := NewCombinedClusterPoolIdentifier(
+		[]ClusterNodePoolIdentifier{classID, dcID},
+		CombinedClusterPoolIdentifierAnd,
+	)
+
+	testCases := []struct {
+		name     string
+		node     *api.NodeListStub
+		expected bool
+	}{
+		{
+			name:     "matches both → true",
+			node:     &api.NodeListStub{NodeClass: "high-memory", Datacenter: "dc1"},
+			expected: true,
+		},
+		{
+			name:     "matches class only → false",
+			node:     &api.NodeListStub{NodeClass: "high-memory", Datacenter: "dc2"},
+			expected: false,
+		},
+		{
+			name:     "matches dc only → false",
+			node:     &api.NodeListStub{NodeClass: "low-memory", Datacenter: "dc1"},
+			expected: false,
+		},
+		{
+			name:     "matches neither → false",
+			node:     &api.NodeListStub{NodeClass: "low-memory", Datacenter: "dc2"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expected, combined.IsPoolMember(tc.node))
+		})
+	}
+}
+
+func Test_NewCombinedClusterPoolIdentifier_OR(t *testing.T) {
+	classID := NewNodeClassPoolIdentifier("high-memory")
+	dcID := NewNodeDatacenterPoolIdentifier("dc1")
+
+	combined := NewCombinedClusterPoolIdentifier(
+		[]ClusterNodePoolIdentifier{classID, dcID},
+		CombinedClusterPoolIdentifierOr,
+	)
+
+	testCases := []struct {
+		name     string
+		node     *api.NodeListStub
+		expected bool
+	}{
+		{
+			name:     "matches both → true",
+			node:     &api.NodeListStub{NodeClass: "high-memory", Datacenter: "dc1"},
+			expected: true,
+		},
+		{
+			name:     "matches class only → true",
+			node:     &api.NodeListStub{NodeClass: "high-memory", Datacenter: "dc2"},
+			expected: true,
+		},
+		{
+			name:     "matches dc only → true",
+			node:     &api.NodeListStub{NodeClass: "low-memory", Datacenter: "dc1"},
+			expected: true,
+		},
+		{
+			name:     "matches neither → false",
+			node:     &api.NodeListStub{NodeClass: "low-memory", Datacenter: "dc2"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expected, combined.IsPoolMember(tc.node))
+		})
+	}
+}
+
+func Test_NewCombinedClusterPoolIdentifier_Empty(t *testing.T) {
+	combined := NewCombinedClusterPoolIdentifier(
+		[]ClusterNodePoolIdentifier{},
+		CombinedClusterPoolIdentifierAnd,
+	)
+
+	// Empty AND list: isMember starts true, no iterations, returns true.
+	must.True(t, combined.IsPoolMember(&api.NodeListStub{NodeClass: "x", Datacenter: "dc1"}))
+	must.Eq(t, "combined_identifier", combined.Key())
+	must.Eq(t, "", combined.Value())
+}
+
+func Test_NewCombinedClusterPoolIdentifier_KeyValue(t *testing.T) {
+	classID := NewNodeClassPoolIdentifier("high-memory")
+	dcID := NewNodeDatacenterPoolIdentifier("dc1")
+
+	combined := NewCombinedClusterPoolIdentifier(
+		[]ClusterNodePoolIdentifier{classID, dcID},
+		CombinedClusterPoolIdentifierAnd,
+	)
+
+	must.Eq(t, "combined_identifier", combined.Key())
+	must.Eq(t, "node_class:high-memory and datacenter:dc1", combined.Value())
+}

--- a/sdk/helper/scaleutils/nodepool/combined_test.go
+++ b/sdk/helper/scaleutils/nodepool/combined_test.go
@@ -10,138 +10,69 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type mockClusterPoolIdentifier struct{}
-
-func NewMockPoolIdentifier() ClusterNodePoolIdentifier                     { return &mockClusterPoolIdentifier{} }
-func (m *mockClusterPoolIdentifier) IsPoolMember(n *api.NodeListStub) bool { return true }
-func (m *mockClusterPoolIdentifier) Key() string                           { return "mock_identifier" }
-func (c *mockClusterPoolIdentifier) Value() string                         { return "mock_value" }
-
-func TestNewCombinedPoolIdentifier(t *testing.T) {
+func TestClusterNodePoolIdentifierList_IsPoolMember(t *testing.T) {
 	testCases := []struct {
-		name          string
-		identifier    ClusterNodePoolIdentifier
-		expectedValue string
+		name     string
+		ids      ClusterNodePoolIdentifierList
+		nodes    []*api.NodeListStub
+		expected []bool
 	}{
 		{
-			name: "single identifier",
-			identifier: NewCombinedClusterPoolIdentifier(
-				[]ClusterNodePoolIdentifier{
-					NewNodeClassPoolIdentifier("test-class"),
-				},
-				CombinedClusterPoolIdentifierAnd,
-			),
-			expectedValue: "node_class:test-class",
-		},
-		{
-			name: "multiple identifiers with and",
-			identifier: NewCombinedClusterPoolIdentifier(
-				[]ClusterNodePoolIdentifier{
-					NewNodeClassPoolIdentifier("test-class"),
-					NewNodeDatacenterPoolIdentifier("test-dc"),
-					NewMockPoolIdentifier(),
-				},
-				CombinedClusterPoolIdentifierAnd,
-			),
-			expectedValue: "node_class:test-class and datacenter:test-dc and mock_identifier:mock_value",
-		},
-		{
-			name: "multiple identifiers with or",
-			identifier: NewCombinedClusterPoolIdentifier(
-				[]ClusterNodePoolIdentifier{
-					NewNodeClassPoolIdentifier("test-class"),
-					NewNodeDatacenterPoolIdentifier("test-dc"),
-					NewMockPoolIdentifier(),
-				},
-				CombinedClusterPoolIdentifierOr,
-			),
-			expectedValue: "node_class:test-class or datacenter:test-dc or mock_identifier:mock_value",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, "combined_identifier", tc.identifier.Key())
-			assert.Equal(t, tc.expectedValue, tc.identifier.Value())
-		})
-	}
-}
-
-func TestNewCombinedPoolIdentifier_NodeIsPoolMember(t *testing.T) {
-	testCases := []struct {
-		name       string
-		identifier ClusterNodePoolIdentifier
-		nodes      []*api.NodeListStub
-		expected   []bool
-	}{
-		{
-			name: "find node by class and datacenter",
-			identifier: NewCombinedClusterPoolIdentifier(
-				[]ClusterNodePoolIdentifier{
-					NewNodeClassPoolIdentifier("test-class"),
-					NewNodeDatacenterPoolIdentifier("test-dc"),
-				},
-				CombinedClusterPoolIdentifierAnd,
-			),
-			nodes: []*api.NodeListStub{
-				{
-					NodeClass:  "test-class",
-					Datacenter: "test-dc",
-				},
-				{
-					NodeClass: "test-class",
-				},
-				{
-					Datacenter: "test-dc",
-				},
-				{
-					NodeClass:  "test-wrong-class",
-					Datacenter: "test-dc",
-				},
-				{
-					NodeClass:  "test-wrong-class",
-					Datacenter: "test-wrong-dc",
-				},
+			name: "single class identifier",
+			ids: ClusterNodePoolIdentifierList{
+				NewNodeClassPoolIdentifier("test-class"),
 			},
-			expected: []bool{true, false, false, false, false},
+			nodes: []*api.NodeListStub{
+				{NodeClass: "test-class", Datacenter: "dc1"},
+				{NodeClass: "other-class", Datacenter: "dc1"},
+			},
+			expected: []bool{true, false},
 		},
 		{
-			name: "find node by class or datacenter",
-			identifier: NewCombinedClusterPoolIdentifier(
-				[]ClusterNodePoolIdentifier{
-					NewNodeClassPoolIdentifier("test-class"),
-					NewNodeDatacenterPoolIdentifier("test-dc"),
-				},
-				CombinedClusterPoolIdentifierOr,
-			),
-			nodes: []*api.NodeListStub{
-				{
-					NodeClass:  "test-class",
-					Datacenter: "test-dc",
-				},
-				{
-					NodeClass: "test-class",
-				},
-				{
-					Datacenter: "test-dc",
-				},
-				{
-					NodeClass:  "test-wrong-class",
-					Datacenter: "test-dc",
-				},
-				{
-					NodeClass:  "test-wrong-class",
-					Datacenter: "test-wrong-dc",
-				},
+			name: "single datacenter identifier",
+			ids: ClusterNodePoolIdentifierList{
+				NewNodeDatacenterPoolIdentifier("dc1"),
 			},
-			expected: []bool{true, true, true, true, false},
+			nodes: []*api.NodeListStub{
+				{NodeClass: "test-class", Datacenter: "dc1"},
+				{NodeClass: "test-class", Datacenter: "dc2"},
+			},
+			expected: []bool{true, false},
+		},
+		{
+			name: "combined class and datacenter (AND logic)",
+			ids: ClusterNodePoolIdentifierList{
+				NewNodeClassPoolIdentifier("test-class"),
+				NewNodeDatacenterPoolIdentifier("dc1"),
+			},
+			nodes: []*api.NodeListStub{
+				{NodeClass: "test-class", Datacenter: "dc1"},
+				{NodeClass: "test-class", Datacenter: "dc2"},
+				{NodeClass: "other-class", Datacenter: "dc1"},
+				{NodeClass: "other-class", Datacenter: "dc2"},
+			},
+			expected: []bool{true, false, false, false},
+		},
+		{
+			name: "combined class, datacenter, and node_pool (AND logic)",
+			ids: ClusterNodePoolIdentifierList{
+				NewNodeClassPoolIdentifier("test-class"),
+				NewNodeDatacenterPoolIdentifier("dc1"),
+				NewNodePoolClusterPoolIdentifier("gpu"),
+			},
+			nodes: []*api.NodeListStub{
+				{NodeClass: "test-class", Datacenter: "dc1", NodePool: "gpu"},
+				{NodeClass: "test-class", Datacenter: "dc1", NodePool: "default"},
+				{NodeClass: "test-class", Datacenter: "dc2", NodePool: "gpu"},
+			},
+			expected: []bool{true, false, false},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for i, node := range tc.nodes {
-				got := tc.identifier.IsPoolMember(node)
+				got := tc.ids.IsPoolMember(node)
 				assert.Equal(t, tc.expected[i], got)
 			}
 		})

--- a/sdk/helper/scaleutils/nodepool/combined_test.go
+++ b/sdk/helper/scaleutils/nodepool/combined_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nodepool

--- a/sdk/helper/scaleutils/nodepool/nodepool.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool.go
@@ -27,15 +27,16 @@ type ClusterNodePoolIdentifier interface {
 	Value() string
 }
 
-// NewClusterNodePoolIdentifier generates a new ClusterNodePoolIdentifier based
-// on the provided configuration. If a valid option is not found, an error will
-// be returned.
-func NewClusterNodePoolIdentifier(cfg map[string]string) (ClusterNodePoolIdentifier, error) {
+// NewClusterNodePoolIdentifierList generates a ClusterNodePoolIdentifierList
+// from the provided configuration. It extracts all recognized pool-identifying
+// keys (node_class, datacenter, node_pool) and returns a list that filters
+// nodes using AND logic. An error is returned if no valid keys are found.
+func NewClusterNodePoolIdentifierList(cfg map[string]string) (ClusterNodePoolIdentifierList, error) {
 	class, hasClass := cfg[sdk.TargetConfigKeyClass]
 	dc, hasDC := cfg[sdk.TargetConfigKeyDatacenter]
 	pool, hasPool := cfg[sdk.TargetConfigKeyNodePool]
 
-	ids := make([]ClusterNodePoolIdentifier, 0, 1)
+	ids := make(ClusterNodePoolIdentifierList, 0, 1)
 	if hasClass {
 		ids = append(ids, NewNodeClassPoolIdentifier(class))
 	}
@@ -46,12 +47,8 @@ func NewClusterNodePoolIdentifier(cfg map[string]string) (ClusterNodePoolIdentif
 		ids = append(ids, NewNodePoolClusterPoolIdentifier(pool))
 	}
 
-	switch len(ids) {
-	case 0:
+	if len(ids) == 0 {
 		return nil, fmt.Errorf("node pool identification method required")
-	case 1:
-		return ids[0], nil
-	default:
-		return NewCombinedClusterPoolIdentifier(ids, CombinedClusterPoolIdentifierAnd), nil
 	}
+	return ids, nil
 }

--- a/sdk/helper/scaleutils/nodepool/nodepool.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool.go
@@ -54,14 +54,32 @@ func NewClusterNodePoolIdentifierList(cfg map[string]string) (ClusterNodePoolIde
 }
 
 // Deprecated: Use NewClusterNodePoolIdentifierList for multi-key AND filtering.
-// NewClusterNodePoolIdentifier returns a single ClusterNodePoolIdentifier from
-// the provided configuration. For backward compatibility, if multiple keys are
-// present only the first recognized identifier is returned.
+// NewClusterNodePoolIdentifier generates a new ClusterNodePoolIdentifier based
+// on the provided configuration. If a valid option is not found, an error will
+// be returned.
 // TODO: Remove this function in next Release.
 func NewClusterNodePoolIdentifier(cfg map[string]string) (ClusterNodePoolIdentifier, error) {
-	ids, err := NewClusterNodePoolIdentifierList(cfg)
-	if err != nil {
-		return nil, err
+	class, hasClass := cfg[sdk.TargetConfigKeyClass]
+	dc, hasDC := cfg[sdk.TargetConfigKeyDatacenter]
+	pool, hasPool := cfg[sdk.TargetConfigKeyNodePool]
+
+	ids := make([]ClusterNodePoolIdentifier, 0, 1)
+	if hasClass {
+		ids = append(ids, NewNodeClassPoolIdentifier(class))
 	}
-	return ids[0], nil
+	if hasDC {
+		ids = append(ids, NewNodeDatacenterPoolIdentifier(dc))
+	}
+	if hasPool {
+		ids = append(ids, NewNodePoolClusterPoolIdentifier(pool))
+	}
+
+	switch len(ids) {
+	case 0:
+		return nil, fmt.Errorf("node pool identification method required")
+	case 1:
+		return ids[0], nil
+	default:
+		return NewCombinedClusterPoolIdentifier(ids, CombinedClusterPoolIdentifierAnd), nil
+	}
 }

--- a/sdk/helper/scaleutils/nodepool/nodepool.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nodepool

--- a/sdk/helper/scaleutils/nodepool/nodepool.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool.go
@@ -52,3 +52,15 @@ func NewClusterNodePoolIdentifierList(cfg map[string]string) (ClusterNodePoolIde
 	}
 	return ids, nil
 }
+
+// Deprecated: Use NewClusterNodePoolIdentifierList for multi-key AND filtering.
+// NewClusterNodePoolIdentifier returns a single ClusterNodePoolIdentifier from
+// the provided configuration. For backward compatibility, if multiple keys are
+// present only the first recognized identifier is returned.
+func NewClusterNodePoolIdentifier(cfg map[string]string) (ClusterNodePoolIdentifier, error) {
+	ids, err := NewClusterNodePoolIdentifierList(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return ids[0], nil
+}

--- a/sdk/helper/scaleutils/nodepool/nodepool.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool.go
@@ -57,6 +57,7 @@ func NewClusterNodePoolIdentifierList(cfg map[string]string) (ClusterNodePoolIde
 // NewClusterNodePoolIdentifier returns a single ClusterNodePoolIdentifier from
 // the provided configuration. For backward compatibility, if multiple keys are
 // present only the first recognized identifier is returned.
+// TODO: Remove this function in next Release.
 func NewClusterNodePoolIdentifier(cfg map[string]string) (ClusterNodePoolIdentifier, error) {
 	ids, err := NewClusterNodePoolIdentifierList(cfg)
 	if err != nil {

--- a/sdk/helper/scaleutils/nodepool/nodepool_test.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -80,6 +81,66 @@ func Test_NewClusterNodePoolIdentifierList(t *testing.T) {
 			} else {
 				assert.NoError(t, err, tc.name)
 				assert.Len(t, ids, tc.expectedOutputLen, tc.name)
+			}
+		})
+	}
+}
+
+func Test_NewClusterNodePoolIdentifier(t *testing.T) {
+	testCases := []struct {
+		inputCfg       map[string]string
+		expectedKey    string
+		expectedValue  string
+		expectedErrMsg string
+		name           string
+	}{
+		{
+			inputCfg:       map[string]string{},
+			expectedErrMsg: "node pool identification method required",
+			name:           "empty config returns error",
+		},
+		{
+			inputCfg:      map[string]string{"node_class": "high-memory"},
+			expectedKey:   "node_class",
+			expectedValue: "high-memory",
+			name:          "single node_class returns class identifier",
+		},
+		{
+			inputCfg:      map[string]string{"datacenter": "dc1"},
+			expectedKey:   "datacenter",
+			expectedValue: "dc1",
+			name:          "single datacenter returns dc identifier",
+		},
+		{
+			inputCfg:      map[string]string{"node_pool": "gpu"},
+			expectedKey:   "node_pool",
+			expectedValue: "gpu",
+			name:          "single node_pool returns pool identifier",
+		},
+		{
+			inputCfg:      map[string]string{"node_class": "high-memory", "datacenter": "dc1"},
+			expectedKey:   "node_class",
+			expectedValue: "high-memory",
+			name:          "multiple keys returns first (node_class takes priority)",
+		},
+		{
+			inputCfg:      map[string]string{"datacenter": "dc1", "node_pool": "gpu"},
+			expectedKey:   "datacenter",
+			expectedValue: "dc1",
+			name:          "datacenter and node_pool returns datacenter (priority order)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := NewClusterNodePoolIdentifier(tc.inputCfg)
+			if tc.expectedErrMsg != "" {
+				must.EqError(t, err, tc.expectedErrMsg)
+				must.Nil(t, id)
+			} else {
+				must.NoError(t, err)
+				must.Eq(t, tc.expectedKey, id.Key())
+				must.Eq(t, tc.expectedValue, id.Value())
 			}
 		})
 	}

--- a/sdk/helper/scaleutils/nodepool/nodepool_test.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool_test.go
@@ -76,11 +76,11 @@ func Test_NewClusterNodePoolIdentifierList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ids, err := NewClusterNodePoolIdentifierList(tc.inputCfg)
 			if tc.expectedOutputErr != nil {
-				assert.Equal(t, tc.expectedOutputErr, err, tc.name)
-				assert.Nil(t, ids, tc.name)
+				must.EqError(t, err, tc.expectedOutputErr.Error())
+				must.Nil(t, ids)
 			} else {
-				assert.NoError(t, err, tc.name)
-				assert.Len(t, ids, tc.expectedOutputLen, tc.name)
+				must.NoError(t, err)
+				must.Len(t, tc.expectedOutputLen, ids)
 			}
 		})
 	}
@@ -88,59 +88,83 @@ func Test_NewClusterNodePoolIdentifierList(t *testing.T) {
 
 func Test_NewClusterNodePoolIdentifier(t *testing.T) {
 	testCases := []struct {
-		inputCfg       map[string]string
-		expectedKey    string
-		expectedValue  string
-		expectedErrMsg string
-		name           string
+		inputCfg            map[string]string
+		expectedOutputKey   string
+		expectedOutputValue string
+		expectedOutputErr   error
+		name                string
 	}{
 		{
-			inputCfg:       map[string]string{},
-			expectedErrMsg: "node pool identification method required",
-			name:           "empty config returns error",
+			inputCfg:            map[string]string{},
+			expectedOutputKey:   "",
+			expectedOutputValue: "",
+			expectedOutputErr:   errors.New("node pool identification method required"),
+			name:                "empty input config",
 		},
 		{
-			inputCfg:      map[string]string{"node_class": "high-memory"},
-			expectedKey:   "node_class",
-			expectedValue: "high-memory",
-			name:          "single node_class returns class identifier",
+			inputCfg:            map[string]string{"datacentre": "dc1"},
+			expectedOutputKey:   "",
+			expectedOutputValue: "",
+			expectedOutputErr:   errors.New("node pool identification method required"),
+			name:                "input config with incorrect key",
 		},
 		{
-			inputCfg:      map[string]string{"datacenter": "dc1"},
-			expectedKey:   "datacenter",
-			expectedValue: "dc1",
-			name:          "single datacenter returns dc identifier",
+			inputCfg:            map[string]string{"datacenter": "dc1"},
+			expectedOutputKey:   "datacenter",
+			expectedOutputValue: "dc1",
+			expectedOutputErr:   nil,
+			name:                "datacenter configured in config",
 		},
 		{
-			inputCfg:      map[string]string{"node_pool": "gpu"},
-			expectedKey:   "node_pool",
-			expectedValue: "gpu",
-			name:          "single node_pool returns pool identifier",
+			inputCfg:            map[string]string{"node_class": "high-memory"},
+			expectedOutputKey:   "node_class",
+			expectedOutputValue: "high-memory",
+			expectedOutputErr:   nil,
+			name:                "node_class configured in config",
 		},
 		{
-			inputCfg:      map[string]string{"node_class": "high-memory", "datacenter": "dc1"},
-			expectedKey:   "node_class",
-			expectedValue: "high-memory",
-			name:          "multiple keys returns first (node_class takes priority)",
+			inputCfg:            map[string]string{"node_pool": "gpu"},
+			expectedOutputKey:   "node_pool",
+			expectedOutputValue: "gpu",
+			expectedOutputErr:   nil,
+			name:                "node_pool configured in config",
 		},
 		{
-			inputCfg:      map[string]string{"datacenter": "dc1", "node_pool": "gpu"},
-			expectedKey:   "datacenter",
-			expectedValue: "dc1",
-			name:          "datacenter and node_pool returns datacenter (priority order)",
+			inputCfg:            map[string]string{"node_class": "high-memory", "datacenter": "dc1"},
+			expectedOutputKey:   "combined_identifier",
+			expectedOutputValue: "node_class:high-memory and datacenter:dc1",
+			expectedOutputErr:   nil,
+			name:                "node_class and datacenter are configured in config",
+		},
+		{
+			inputCfg:            map[string]string{"node_pool": "gpu", "datacenter": "dc1"},
+			expectedOutputKey:   "combined_identifier",
+			expectedOutputValue: "datacenter:dc1 and node_pool:gpu",
+			expectedOutputErr:   nil,
+			name:                "node_pool and datacenter are configured in config",
+		},
+		{
+			inputCfg: map[string]string{
+				"node_class": "high-memory",
+				"node_pool":  "gpu",
+				"datacenter": "dc1",
+			},
+			expectedOutputKey:   "combined_identifier",
+			expectedOutputValue: "node_class:high-memory and datacenter:dc1 and node_pool:gpu",
+			expectedOutputErr:   nil,
+			name:                "node_class, node_pool, and datacenter are configured in config",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			id, err := NewClusterNodePoolIdentifier(tc.inputCfg)
-			if tc.expectedErrMsg != "" {
-				must.EqError(t, err, tc.expectedErrMsg)
-				must.Nil(t, id)
+			impl, err := NewClusterNodePoolIdentifier(tc.inputCfg)
+			if tc.expectedOutputErr != nil {
+				assert.Equal(t, tc.expectedOutputErr, err, tc.name)
 			} else {
-				must.NoError(t, err)
-				must.Eq(t, tc.expectedKey, id.Key())
-				must.Eq(t, tc.expectedValue, id.Value())
+				assert.NotNil(t, impl, tc.name)
+				assert.Equal(t, tc.expectedOutputKey, impl.Key(), tc.name)
+				assert.Equal(t, tc.expectedOutputValue, impl.Value(), tc.name)
 			}
 		})
 	}

--- a/sdk/helper/scaleutils/nodepool/nodepool_test.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nodepool

--- a/sdk/helper/scaleutils/nodepool/nodepool_test.go
+++ b/sdk/helper/scaleutils/nodepool/nodepool_test.go
@@ -10,62 +10,54 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_NewClusterNodePoolIdentifier(t *testing.T) {
+func Test_NewClusterNodePoolIdentifierList(t *testing.T) {
 	testCases := []struct {
-		inputCfg            map[string]string
-		expectedOutputKey   string
-		expectedOutputValue string
-		expectedOutputErr   error
-		name                string
+		inputCfg          map[string]string
+		expectedOutputLen int
+		expectedOutputErr error
+		name              string
 	}{
 		{
-			inputCfg:            map[string]string{},
-			expectedOutputKey:   "",
-			expectedOutputValue: "",
-			expectedOutputErr:   errors.New("node pool identification method required"),
-			name:                "empty input config",
+			inputCfg:          map[string]string{},
+			expectedOutputLen: 0,
+			expectedOutputErr: errors.New("node pool identification method required"),
+			name:              "empty input config",
 		},
 		{
-			inputCfg:            map[string]string{"datacentre": "dc1"},
-			expectedOutputKey:   "",
-			expectedOutputValue: "",
-			expectedOutputErr:   errors.New("node pool identification method required"),
-			name:                "input config with incorrect key",
+			inputCfg:          map[string]string{"datacentre": "dc1"},
+			expectedOutputLen: 0,
+			expectedOutputErr: errors.New("node pool identification method required"),
+			name:              "input config with incorrect key",
 		},
 		{
-			inputCfg:            map[string]string{"datacenter": "dc1"},
-			expectedOutputKey:   "datacenter",
-			expectedOutputValue: "dc1",
-			expectedOutputErr:   nil,
-			name:                "datacenter configured in config",
+			inputCfg:          map[string]string{"datacenter": "dc1"},
+			expectedOutputLen: 1,
+			expectedOutputErr: nil,
+			name:              "datacenter configured in config",
 		},
 		{
-			inputCfg:            map[string]string{"node_class": "high-memory"},
-			expectedOutputKey:   "node_class",
-			expectedOutputValue: "high-memory",
-			expectedOutputErr:   nil,
-			name:                "node_class configured in config",
+			inputCfg:          map[string]string{"node_class": "high-memory"},
+			expectedOutputLen: 1,
+			expectedOutputErr: nil,
+			name:              "node_class configured in config",
 		},
 		{
-			inputCfg:            map[string]string{"node_pool": "gpu"},
-			expectedOutputKey:   "node_pool",
-			expectedOutputValue: "gpu",
-			expectedOutputErr:   nil,
-			name:                "node_pool configured in config",
+			inputCfg:          map[string]string{"node_pool": "gpu"},
+			expectedOutputLen: 1,
+			expectedOutputErr: nil,
+			name:              "node_pool configured in config",
 		},
 		{
-			inputCfg:            map[string]string{"node_class": "high-memory", "datacenter": "dc1"},
-			expectedOutputKey:   "combined_identifier",
-			expectedOutputValue: "node_class:high-memory and datacenter:dc1",
-			expectedOutputErr:   nil,
-			name:                "node_class and datacenter are configured in config",
+			inputCfg:          map[string]string{"node_class": "high-memory", "datacenter": "dc1"},
+			expectedOutputLen: 2,
+			expectedOutputErr: nil,
+			name:              "node_class and datacenter are configured in config",
 		},
 		{
-			inputCfg:            map[string]string{"node_pool": "gpu", "datacenter": "dc1"},
-			expectedOutputKey:   "combined_identifier",
-			expectedOutputValue: "datacenter:dc1 and node_pool:gpu",
-			expectedOutputErr:   nil,
-			name:                "node_pool and datacenter are configured in config",
+			inputCfg:          map[string]string{"node_pool": "gpu", "datacenter": "dc1"},
+			expectedOutputLen: 2,
+			expectedOutputErr: nil,
+			name:              "node_pool and datacenter are configured in config",
 		},
 		{
 			inputCfg: map[string]string{
@@ -73,22 +65,21 @@ func Test_NewClusterNodePoolIdentifier(t *testing.T) {
 				"node_pool":  "gpu",
 				"datacenter": "dc1",
 			},
-			expectedOutputKey:   "combined_identifier",
-			expectedOutputValue: "node_class:high-memory and datacenter:dc1 and node_pool:gpu",
-			expectedOutputErr:   nil,
-			name:                "node_class, node_pool, and datacenter are configured in config",
+			expectedOutputLen: 3,
+			expectedOutputErr: nil,
+			name:              "node_class, node_pool, and datacenter are configured in config",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			impl, err := NewClusterNodePoolIdentifier(tc.inputCfg)
+			ids, err := NewClusterNodePoolIdentifierList(tc.inputCfg)
 			if tc.expectedOutputErr != nil {
 				assert.Equal(t, tc.expectedOutputErr, err, tc.name)
+				assert.Nil(t, ids, tc.name)
 			} else {
-				assert.NotNil(t, impl, tc.name)
-				assert.Equal(t, tc.expectedOutputKey, impl.Key(), tc.name)
-				assert.Equal(t, tc.expectedOutputValue, impl.Value(), tc.name)
+				assert.NoError(t, err, tc.name)
+				assert.Len(t, ids, tc.expectedOutputLen, tc.name)
 			}
 		})
 	}

--- a/sdk/policy.go
+++ b/sdk/policy.go
@@ -251,7 +251,8 @@ func (t *ScalingPolicyTarget) IsNodePoolTarget() bool {
 	}
 	_, classOK := t.Config[TargetConfigKeyClass]
 	_, dcOK := t.Config[TargetConfigKeyDatacenter]
-	return classOK || dcOK
+	_, poolOK := t.Config[TargetConfigKeyNodePool]
+	return classOK || dcOK || poolOK
 }
 
 type FileDecodeScalingPolicies struct {

--- a/sdk/policy_test.go
+++ b/sdk/policy_test.go
@@ -155,6 +155,13 @@ func TestScalingPolicyTarget_IsNodePoolTarget(t *testing.T) {
 			expectedOutput: true,
 			name:           "datacenter input target",
 		},
+		{
+			inputScalingPolicyTarget: &ScalingPolicyTarget{
+				Config: map[string]string{"node_pool": "gpu"},
+			},
+			expectedOutput: true,
+			name:           "node_pool input target",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
[JIRA ISSUE](https://hashicorp.atlassian.net/browse/NMD-1394)

**_Previous PR:_** https://github.com/hashicorp/nomad-autoscaler/pull/1291

**_Problem_**

When writing a cluster scaling policy, operators could only filter nodes by node_class:

```
target "aws-asg" {
  node_class = "hashistack"    
  node_drain_deadline = "5m"
}
```

There was no way to filter by datacenter or node_pool. Setting either was silently ignored — the autoscaler would include all nodes regardless, producing incorrect resource totals and wrong scaling decisions.

**_Solution_**

Operators can now use datacenter and node_pool in the target block, individually or combined:

# Filter by datacenter
```
target "aws-asg" {
  datacenter = "us-east-1"
  node_drain_deadline = "5m"
}
```

# Filter by node_pool
```
target "aws-asg" {
  node_pool = "gpu"
  node_drain_deadline = "5m"
}
```

# Filter by both (AND logic — only nodes matching ALL keys)
```
target "aws-asg" {
  node_class = "hashistack"
  datacenter = "us-east-1"
  node_drain_deadline = "5m"
}
```

# Before (only node_class worked)
Policy target config | Internal query generated | Result
-- | -- | --
node_class = "hashistack" | node_percentage-allocated_memory/hashistack/class | Correct — filters by class
datacenter = "dc1" | Ignored — no query expansion, falls through to unfiltered | Returns ALL nodes
node_class = "hashistack" + datacenter = "dc1" | node_percentage-allocated_memory/hashistack/class | Only filters by class, ignores datacenter
node_pool = "gpu" | Ignored | Returns ALL nodes

# After (all keys supported)
Policy target config | Internal query generated | Result
-- | -- | --
node_class = "hashistack" | node_percentage-allocated_memory/node_class=hashistack | Same behavior
datacenter = "dc1" | node_percentage-allocated_memory/datacenter=dc1 | Now filters by datacenter
node_class = "hashistack" + datacenter = "dc1" | node_percentage-allocated_memory/node_class=hashistack,datacenter=dc1 | AND logic — only nodes matching both
node_pool = "gpu" | node_percentage-allocated_memory/node_pool=gpu | Now filters by node_pool
node_class = "hashistack" + datacenter = "dc1" + node_pool = "gpu" | node_percentage-allocated_memory/node_class=hashistack,datacenter=dc1,node_pool=gpu | AND — all three must match


# Old long-form queries are not supported now

Old format | Output
-- | --
node_percentage-allocated_memory/hashistack/class  | ERROR: invalid pool identifier "hashistack/class": expected key=value

The key change: old format used /value/key, new format uses /key=value (with , for combining multiple keys).

**_Data Flow Summary:_**
```
HCL target config
  → IsNodePoolTarget()          [sdk/policy.go — checks node_class || datacenter || node_pool]
  → CanonicalizeAPMQuery()      [policy/policy.go — builds "node_<op>_<metric>/key=url.QueryEscape(val),key=val"]
  → APM plugin: parseNodePoolQuery()  [node.go — splits on "," then "=", url.QueryUnescape, creates identifiers]
  → getPoolResources()          [node.go — filters nodes via ClusterNodePoolIdentifierList.IsPoolMember (AND logic)]
```

**_Testing:_**
<details>

1) client1 -> cpu_total_compute = 2000, memory_total_mb = 2048 2) client2 -> cpu_total_compute = 4000, memory_total_mb = 4096 3) client3 -> cpu_total_compute = 8000, memory_total_mb = 8192

<img width="768" height="86" alt="Screenshot 2026-05-18 at 10 49 35 AM" src="https://github.com/user-attachments/assets/f81b9565-93f1-46e7-b783-7d9cb3c880c7" />

```
> 2026-05-21T18:50:33.019+0530 [DEBUG] internal_plugin.nomad-apm: collected node pool resource data: query=node_percentage-allocated_cpu/datacenter=dc2 allocated_cpu=0 allocated_memory=0 allocatable_cpu=8000 allocatable_memory=8192
> 2026-05-21T18:50:33.019+0530 [DEBUG] internal_plugin.nomad-apm: collected node pool resource data: query="node_percentage-allocated_memory/node_class=hashistack,datacenter=dc1" allocated_cpu=0 allocated_memory=0 allocatable_cpu=2000 allocatable_memory=2048
> 2026-05-21T18:50:33.020+0530 [DEBUG] internal_plugin.nomad-apm: collected node pool resource data: query=node_percentage-allocated_memory/datacenter=dc1 allocated_cpu=10 allocated_memory=12 allocatable_cpu=6000 allocatable_memory=6144
> 2026-05-21T18:50:33.020+0530 [DEBUG] internal_plugin.nomad-apm: collected node pool resource data: query=node_percentage-allocated_cpu/node_class=hashistack allocated_cpu=0 allocated_memory=0 allocatable_cpu=10000 allocatable_memory=10240
```

<img width="1081" height="444" alt="Screenshot 2026-05-21 at 7 15 40 PM" src="https://github.com/user-attachments/assets/212411b2-1e17-4563-9bb6-7402db15536e" />


-

</details>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.