### PR TITLE
enable jsonencode in file policy decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 
 IMPROVEMENTS:
 * plugin/apm/nomad: Add support for grouping nodes by `datacenter`, `node_pool`, or a combination of multiple pool identifiers in node pool APM queries. Previously only `node_class` was supported. [[GH-1300](https://github.com/hashicorp/nomad-autoscaler/pull/1300)]
+* policy/file: File-based scaling policies now support `jsonencode(...)` (for example in `check.query`). This makes complex JSON queries easier to write and maintain, since you can use native HCL objects instead of escaped JSON strings. [GH-1320](https://github.com/hashicorp/nomad-autoscaler/pull/1300)]
 
 ## 0.5.0 (May 18, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES:
 
 IMPROVEMENTS:
 * plugin/apm/nomad: Add support for grouping nodes by `datacenter`, `node_pool`, or a combination of multiple pool identifiers in node pool APM queries. Previously only `node_class` was supported. [[GH-1300](https://github.com/hashicorp/nomad-autoscaler/pull/1300)]
-* policy/file: File-based scaling policies now support `jsonencode(...)` (for example in `check.query`). This makes complex JSON queries easier to write and maintain, since you can use native HCL objects instead of escaped JSON strings. [GH-1320](https://github.com/hashicorp/nomad-autoscaler/pull/1300)]
+* policy/file: File-based scaling policies now support `jsonencode(...)` (for example in `check.query`). This makes complex JSON queries easier to write and maintain, since you can use native HCL objects instead of escaped JSON strings. [GH-1320](https://github.com/hashicorp/nomad-autoscaler/pull/1320)]
 
 ## 0.5.0 (May 18, 2026)
 

--- a/policy/file/parse.go
+++ b/policy/file/parse.go
@@ -7,15 +7,24 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsimple"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
 )
+
+var filePolicyEvalContext = &hcl.EvalContext{
+	Functions: map[string]function.Function{
+		"jsonencode": stdlib.JSONEncodeFunc,
+	},
+}
 
 func decodeFile(file string) (map[string]*sdk.ScalingPolicy, error) {
 	policies := make(map[string]*sdk.ScalingPolicy)
 
 	filePolicies := sdk.FileDecodeScalingPolicies{}
-	if err := hclsimple.DecodeFile(file, nil, &filePolicies); err != nil {
+	if err := hclsimple.DecodeFile(file, filePolicyEvalContext, &filePolicies); err != nil {
 		return nil, err
 	}
 

--- a/policy/file/parse_test.go
+++ b/policy/file/parse_test.go
@@ -4,11 +4,15 @@
 package file
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -191,4 +195,80 @@ func Test_decodePolicyDoc_QueryWindowInvalid(t *testing.T) {
 	err := decodePolicyDoc(decodePolicy)
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "not-a-duration"))
+}
+
+func Test_decodeFile_JSONEncodeQuery(t *testing.T) {
+	policyContent := `
+scaling "jsonencode-policy" {
+  enabled = true
+  max     = 10
+
+  policy {
+    check "instana_check" {
+      source = "instana"
+      query = jsonencode({
+        plugin  = "host"
+        metrics = ["cpu.used"]
+      })
+
+      strategy "target-value" {
+        target = "80"
+      }
+    }
+
+    target "nomad" {
+      Job   = "example"
+      Group = "cache"
+    }
+  }
+}
+`
+
+	policyPath := filepath.Join(t.TempDir(), "policy.hcl")
+	must.NoError(t, os.WriteFile(policyPath, []byte(policyContent), 0o600))
+
+	policies, err := decodeFile(policyPath)
+	must.NoError(t, err)
+
+	check := policies["jsonencode-policy"].Checks[0]
+	var query struct {
+		Plugin  string   `json:"plugin"`
+		Metrics []string `json:"metrics"`
+	}
+	must.NoError(t, json.Unmarshal([]byte(check.Query), &query))
+	must.Eq(t, "host", query.Plugin)
+	must.Eq(t, []string{"cpu.used"}, query.Metrics)
+}
+
+func Test_decodeFile_UnsupportedFunctionRejected(t *testing.T) {
+	policyContent := `
+scaling "unsupported-function-policy" {
+  enabled = true
+  max     = 10
+
+  policy {
+    check "instana_check" {
+      source = "instana"
+      query  = file("query.json")
+
+      strategy "target-value" {
+        target = "80"
+      }
+    }
+
+    target "nomad" {
+      Job   = "example"
+      Group = "cache"
+    }
+  }
+}
+`
+
+	policyPath := filepath.Join(t.TempDir(), "policy.hcl")
+	must.NoError(t, os.WriteFile(policyPath, []byte(policyContent), 0o600))
+
+	_, err := decodeFile(policyPath)
+	must.Error(t, err)
+	must.StrContains(t, strings.ToLower(err.Error()), "function")
+	must.StrContains(t, strings.ToLower(err.Error()), "file")
 }


### PR DESCRIPTION
**Description:**

Added `jsonencode(...)` support for **file-based autoscaler policies** so users can write structured HCL objects (for example in `check.query`) instead of manually escaping JSON strings.

**Example usage:**
-  The Instana APM plugin expects `check.query` as a JSON string.   This change improves file-policy authoring by allowing `jsonencode({...})`, so users can write readable HCL objects and let autoscaler produce valid JSON, instead of manually maintaining escaped JSON strings/heredocs.

**Note:**
- `jsonencode(...)` already works in Nomad job-sourced policy flows because Nomad evaluates job HCL before autoscaler reads the policy. This PR brings equivalent ergonomics to autoscaler **file-sourced** policies, where that evaluation previously did not happen.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

