### PR TITLE
fix: wait for all tasks to finish before terminating node after drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 * policy: Fixed a bug where policy handlers were not recreated for unchanged policies after the policy manager recovered from an unrecoverable source error, causing existing policies to stop being evaluated until they were updated again. [[GH-1336](https://github.com/hashicorp/nomad-autoscaler/pull/1336)]
+* scaleutils: After drain completes, the autoscaler now waits until all tasks on the node are dead before terminating the instance, preventing in-progress lifecycle tasks from being lost. [[GH-1337](https://github.com/hashicorp/nomad-autoscaler/pull/1337)]
 
 ## 0.5.0 (May 18, 2026)
 

--- a/policy/manager.go
+++ b/policy/manager.go
@@ -204,7 +204,7 @@ func (m *Manager) processMessageAndUpdateHandlers(ctx context.Context, message I
 		if err != nil {
 			m.log.Error("encountered an error getting the latest version for policy",
 				"policyID", policyID, "error", err)
-			if IsRetryableError(err) {
+			if isRetryableError(err) {
 				m.schedulePolicyRetry(ctx, message.Source, policyID)
 			}
 			continue
@@ -253,7 +253,7 @@ func (m *Manager) processMessageAndUpdateHandlers(ctx context.Context, message I
 		if err != nil {
 			m.log.Error("encountered an error getting the target for the policy handler",
 				"policyID", policyID, "error", err)
-			if IsRetryableError(err) {
+			if isRetryableError(err) {
 				m.schedulePolicyRetry(ctx, message.Source, policyID)
 			}
 			continue
@@ -273,7 +273,7 @@ func (m *Manager) processMessageAndUpdateHandlers(ctx context.Context, message I
 		if err != nil {
 			m.log.Error("encountered an error starting the policy handler",
 				"policyID", policyID, "error", err)
-			if IsRetryableError(err) {
+			if isRetryableError(err) {
 				m.schedulePolicyRetry(ctx, message.Source, policyID)
 			}
 			continue
@@ -409,9 +409,9 @@ func (m *Manager) periodicMetricsReporter(ctx context.Context, interval time.Dur
 	}
 }
 
-// IsRetryableError identifies transient connectivity failures that callers can
+// isRetryableError identifies transient connectivity failures that callers can
 // handle locally without restarting the whole manager.
-func IsRetryableError(err error) bool {
+func isRetryableError(err error) bool {
 	retryableErrors := []string{"connection refused", "EOF"}
 	for _, e := range retryableErrors {
 		if strings.Contains(err.Error(), e) {

--- a/sdk/helper/scaleutils/cluster_scalein_test.go
+++ b/sdk/helper/scaleutils/cluster_scalein_test.go
@@ -186,6 +186,9 @@ func testNomadScaleInServer(t *testing.T) *httptest.Server {
 			n, ok := nodeInfo[nID]
 			must.True(t, ok, must.Sprintf("unknown node: %q", nID))
 			must.NoError(t, json.NewEncoder(w).Encode(n))
+		case "/v1/node/node-a/allocations", "/v1/node/node-b/allocations":
+			w.Header().Set("X-Nomad-Index", "1")
+			must.NoError(t, json.NewEncoder(w).Encode([]*api.Allocation{}))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/sdk/helper/scaleutils/node_drain.go
+++ b/sdk/helper/scaleutils/node_drain.go
@@ -172,7 +172,6 @@ func (c *ClusterScaleUtils) waitForAllTasksDead(ctx context.Context, nodeID stri
 		}
 
 		if !blocking.IndexHasChanged(meta.LastIndex, q.WaitIndex) {
-			q.WaitIndex = meta.LastIndex
 			continue
 		}
 

--- a/sdk/helper/scaleutils/node_drain.go
+++ b/sdk/helper/scaleutils/node_drain.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package scaleutils
@@ -12,6 +12,7 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/hashicorp/nomad-autoscaler/sdk/helper/blocking"
 	errHelper "github.com/hashicorp/nomad-autoscaler/sdk/helper/error"
 	"github.com/hashicorp/nomad/api"
 )
@@ -146,7 +147,58 @@ func (c *ClusterScaleUtils) drainNode(ctx context.Context, nodeID string, spec *
 	if err := c.monitorNodeDrain(ctx, nodeID, resp.LastIndex, spec.IgnoreSystemJobs); err != nil {
 		return fmt.Errorf("context done while monitoring node drain: %w", err)
 	}
+
+	// Drain completion is based on allocation status and does not guarantee
+	// all tasks have finished. Wait until all tasks are dead before proceeding.
+	if err := c.waitForAllTasksDead(ctx, nodeID); err != nil {
+		return fmt.Errorf("failed waiting for all tasks to be dead on node %s: %w", nodeID, err)
+	}
+
 	return nil
+}
+
+// waitForAllTasksDead blocks until all tasks across all allocations on the
+// node are dead, or the context is cancelled. This ensures that any remaining work
+// on the node has completed before the caller proceeds with node termination
+func (c *ClusterScaleUtils) waitForAllTasksDead(ctx context.Context, nodeID string) error {
+	q := &api.QueryOptions{
+		WaitIndex: 0,
+	}
+
+	for {
+		allocs, meta, err := c.client.Nodes().Allocations(nodeID, q.WithContext(ctx))
+		if err != nil {
+			return fmt.Errorf("failed to list allocations for node: %w", err)
+		}
+
+		if !blocking.IndexHasChanged(meta.LastIndex, q.WaitIndex) {
+			q.WaitIndex = meta.LastIndex
+			continue
+		}
+
+		allDead := true
+	allocCheck:
+		for _, alloc := range allocs {
+			for taskName, taskState := range alloc.TaskStates {
+				if taskState.State != "dead" {
+					c.log.Info("waiting for task to finish before terminating node",
+						"node_id", nodeID,
+						"alloc_id", alloc.ID,
+						"task", taskName,
+						"state", taskState.State,
+					)
+					allDead = false
+					break allocCheck
+				}
+			}
+		}
+
+		if allDead {
+			return nil
+		}
+
+		q.WaitIndex = meta.LastIndex
+	}
 }
 
 // monitorNodeDrain follows the drain of a node, logging the messages we

--- a/sdk/helper/scaleutils/node_drain_test.go
+++ b/sdk/helper/scaleutils/node_drain_test.go
@@ -1,11 +1,15 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package scaleutils
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -126,6 +130,20 @@ func Test_DrainNode(t *testing.T) {
 		Level: hclog.LevelFromString("ERROR"),
 	})
 
+	allocs := []*api.Allocation{
+		{
+			ID: "alloc-1",
+			TaskStates: map[string]*api.TaskState{
+				"main": {State: "dead"},
+			},
+		},
+	}
+
+	ts := newNodeAllocsTestServer(t, allocs)
+	defer ts.Close()
+
+	client := testNomadClient(t, ts.URL)
+
 	md := newMockDrainer()
 
 	md.drainerMockFunc = func(nodeID string, opts *api.DrainOptions, _ *api.WriteOptions) (*api.NodeDrainUpdateResponse, error) {
@@ -149,6 +167,7 @@ func Test_DrainNode(t *testing.T) {
 
 	cu := &ClusterScaleUtils{
 		log:     testLogger,
+		client:  client,
 		drainer: md,
 	}
 
@@ -156,5 +175,129 @@ func Test_DrainNode(t *testing.T) {
 	err := cu.drainNode(ctx, testNodeID, &api.DrainSpec{})
 	must.NoError(t, err)
 	must.True(t, md.monitorFunctionCalled)
+}
 
+func Test_WaitForAllTasksDead(t *testing.T) {
+	testLogger := hclog.New(&hclog.LoggerOptions{
+		Level: hclog.LevelFromString("ERROR"),
+	})
+
+	testCases := []struct {
+		name          string
+		allocsSeq     [][]*api.Allocation
+		ctxTimeout    time.Duration
+		expectedError bool
+	}{
+		{
+			name: "all tasks already dead",
+			allocsSeq: [][]*api.Allocation{
+				{
+					{
+						ID: "alloc-1",
+						TaskStates: map[string]*api.TaskState{
+							"main":    {State: "dead"},
+							"cleanup": {State: "dead"},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "task running then becomes dead",
+			allocsSeq: [][]*api.Allocation{
+				// first poll: cleanup still running
+				{
+					{
+						ID: "alloc-1",
+						TaskStates: map[string]*api.TaskState{
+							"main":    {State: "dead"},
+							"cleanup": {State: "running"},
+						},
+					},
+				},
+				// second poll: same alloc, cleanup now dead
+				{
+					{
+						ID: "alloc-1",
+						TaskStates: map[string]*api.TaskState{
+							"main":    {State: "dead"},
+							"cleanup": {State: "dead"},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "context cancelled while task still running",
+			allocsSeq: [][]*api.Allocation{
+				{
+					{
+						ID: "alloc-1",
+						TaskStates: map[string]*api.TaskState{
+							"cleanup": {State: "running"},
+						},
+					},
+				},
+			},
+			ctxTimeout:    100 * time.Millisecond,
+			expectedError: true,
+		},
+		{
+			name:          "no allocations on node",
+			allocsSeq:     [][]*api.Allocation{{}},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			callCount := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				idx := callCount
+				if idx >= len(tc.allocsSeq) {
+					idx = len(tc.allocsSeq) - 1
+				}
+				allocs := tc.allocsSeq[idx]
+				callCount++
+
+				w.Header().Set("X-Nomad-Index", fmt.Sprintf("%d", callCount+1))
+				must.NoError(t, json.NewEncoder(w).Encode(allocs))
+			}))
+			defer ts.Close()
+
+			client := testNomadClient(t, ts.URL)
+			cu := &ClusterScaleUtils{
+				log:    testLogger,
+				client: client,
+			}
+
+			ctx := context.Background()
+			if tc.ctxTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tc.ctxTimeout)
+				defer cancel()
+			}
+
+			err := cu.waitForAllTasksDead(ctx, "node-1")
+			if tc.expectedError {
+				must.Error(t, err)
+			} else {
+				must.NoError(t, err)
+			}
+		})
+	}
+}
+
+func newNodeAllocsTestServer(t *testing.T, allocs []*api.Allocation) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Nomad-Index", "1")
+		must.NoError(t, json.NewEncoder(w).Encode(allocs))
+	}))
 }

--- a/sdk/helper/scaleutils/node_drain_test.go
+++ b/sdk/helper/scaleutils/node_drain_test.go
@@ -186,7 +186,7 @@ func Test_WaitForAllTasksDead(t *testing.T) {
 		name          string
 		allocsSeq     [][]*api.Allocation
 		ctxTimeout    time.Duration
-		expectedError bool
+		expectedError error
 	}{
 		{
 			name: "all tasks already dead",
@@ -201,7 +201,7 @@ func Test_WaitForAllTasksDead(t *testing.T) {
 					},
 				},
 			},
-			expectedError: false,
+			expectedError: nil,
 		},
 		{
 			name: "task running then becomes dead",
@@ -227,7 +227,7 @@ func Test_WaitForAllTasksDead(t *testing.T) {
 					},
 				},
 			},
-			expectedError: false,
+			expectedError: nil,
 		},
 		{
 			name: "context cancelled while task still running",
@@ -242,12 +242,12 @@ func Test_WaitForAllTasksDead(t *testing.T) {
 				},
 			},
 			ctxTimeout:    100 * time.Millisecond,
-			expectedError: true,
+			expectedError: context.DeadlineExceeded,
 		},
 		{
 			name:          "no allocations on node",
 			allocsSeq:     [][]*api.Allocation{{}},
-			expectedError: false,
+			expectedError: nil,
 		},
 	}
 
@@ -257,10 +257,8 @@ func Test_WaitForAllTasksDead(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 
-				idx := callCount
-				if idx >= len(tc.allocsSeq) {
-					idx = len(tc.allocsSeq) - 1
-				}
+				// clamp index between 0 and the last slice entry
+				idx := min(callCount, len(tc.allocsSeq)-1)
 				allocs := tc.allocsSeq[idx]
 				callCount++
 
@@ -283,8 +281,8 @@ func Test_WaitForAllTasksDead(t *testing.T) {
 			}
 
 			err := cu.waitForAllTasksDead(ctx, "node-1")
-			if tc.expectedError {
-				must.Error(t, err)
+			if tc.expectedError != nil {
+				must.ErrorIs(t, err, tc.expectedError)
 			} else {
 				must.NoError(t, err)
 			}


### PR DESCRIPTION
#### Background
When Nomad Autoscaler performs a cluster scale-in, it drains the selected node and terminates the backing instance once drain is reported complete. When an allocation is already in a terminal client status (e.g. `failed`) before drain is initiated, the drainer does not consider it for migration since it does not need to be migrated. The alloc is skipped, drain completes immediately, and Autoscaler proceeds to terminate the instance, even if a `poststop` lifecycle task from that terminal alloc is still actively running on the node. The result is that the `poststop` task is permanently lost.

#### Fix
After drain completes, before proceeding with instance termination, poll the node's allocations using Nomad blocking queries until all tasks across all allocations have reached a `dead` state. This ensures any remaining work on the node, including `poststop` lifecycle tasks on already-terminal allocations has fully completed before the node is removed.

Jira Link: https://hashicorp.atlassian.net/browse/NMD-1675

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

