### PR TITLE
chore(deps): group dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
+# Copyright IBM Corp. 2020, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 version: 2
 updates:
-  - package-ecosystem: gomod
+  - package-ecosystem: "gomod"
     directories:
       - "/"
       - "/plugins/test/noop-apm"
@@ -12,6 +15,10 @@ updates:
       time: "09:00"
     labels:
       - "theme/dependencies"
+    groups:
+      go:
+        patterns:
+          - "*"
     ignore:
       # All modules for The AWS SDK must be updated together, including
       # indirect dependencies. Refer to #826 for more details.
@@ -19,3 +26,17 @@ updates:
       # Ignoring on dependabot for now until we can validate and properly
       # automate the upgrade path.
       - dependency-name: "github.com/aws/aws-sdk-go-v2*"
+
+  - package-ecosystem: "github-actions"
+    directory: /
+    labels:
+      - "theme/dependencies"
+      - "theme/ci"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

Consolidates dependabot PRs into a single one.
JIRA Link: https://hashicorp.atlassian.net/browse/NMD-1586
- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

